### PR TITLE
improve configuration

### DIFF
--- a/get_env_data.py
+++ b/get_env_data.py
@@ -1,8 +1,11 @@
 from plexapi.myplex import MyPlexAccount
 import utils
+from os import path
 import trakt
 import trakt.core
 
+trakt.core.CONFIG_PATH = path.dirname(path.abspath(__file__)) + "/.pytrakt.json"
+env_file = path.join(path.dirname(path.abspath(__file__)), ".env")
 
 plex_needed = utils.input_yesno("Are you logged into this server with a Plex account?")
 if plex_needed:
@@ -11,13 +14,19 @@ if plex_needed:
     servername = input("Now enter the server name: ")
     account = MyPlexAccount(username, password)
     plex = account.resource(servername).connect()  # returns a PlexServer instance
-    print("Copy this Plex token to the .env file:", plex._token)
+    with open(env_file, 'w') as txt:
+        txt.write("PLEX_TOKEN=" + plex._token + "\n")
+    print("Your Plex token has been added in .env file: PLEX_TOKEN=" + plex._token)
 else:
-    print("Add this as the PLEX_TOKEN in the .env file: PLEX_TOKEN=-")
+    with open(env_file, "w") as txt:
+        txt.write("PLEX_TOKEN=-\n")
 
 trakt.APPLICATION_ID = '65370'
 trakt.core.AUTH_METHOD=trakt.core.OAUTH_AUTH
 trakt_user = input("Please input your Trakt username: ")
 trakt.init(trakt_user, store=True)
-print("You are now logged into Trakt. Add your username in .env: TRAKT_USER=" + trakt_user)
-print("Once the PLEX_TOKEN and TRAKT_USER are in your .env file, you can run 'python3 main.py' and enjoy!")
+with open(env_file, "a") as txt:
+    txt.write("TRAKT_USERNAME=" + trakt_user + "\n")
+print("You are now logged into Trakt. Your Trakt credentials have been added in .env and .pytrakt.json files.")
+print("You can enjoy sync! \nCheck config.json to adjust settings.")
+print("If you want to change Plex or Trakt account, just edit or remove .env and .pytrakt.json files.")

--- a/get_env_data.py
+++ b/get_env_data.py
@@ -4,7 +4,7 @@ from os import path
 import trakt
 import trakt.core
 
-trakt.core.CONFIG_PATH = path.dirname(path.abspath(__file__)) + "/.pytrakt.json"
+trakt.core.CONFIG_PATH = path.join(path.dirname(path.abspath(__file__)), ".pytrakt.json")
 env_file = path.join(path.dirname(path.abspath(__file__)), ".env")
 
 plex_needed = utils.input_yesno("Are you logged into this server with a Plex account?")

--- a/main.py
+++ b/main.py
@@ -1,13 +1,14 @@
 
 import plexapi.server
+from os import getenv, path
 import trakt
+trakt.core.CONFIG_PATH = path.join(path.dirname(path.abspath(__file__)), ".pytrakt.json")
 import trakt.movies
 import trakt.tv
 import trakt.sync
 import trakt.users
 import trakt.core
 from dotenv import load_dotenv
-from os import getenv
 import logging
 from time import time
 from json.decoder import JSONDecodeError
@@ -242,6 +243,10 @@ def main():
 
     start_time = time()
     load_dotenv()
+    if not getenv("PLEX_TOKEN") or not getenv("TRAKT_USERNAME"):
+        print("First run, please follow those configuration instructions.")
+        import get_env_data
+        load_dotenv()
     logLevel = logging.DEBUG if CONFIG['log_debug_messages'] else logging.INFO
     logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s',
                         handlers=[logging.FileHandler('last_update.log', 'w', 'utf-8')],


### PR DESCRIPTION
Setup could be more user-friendly, here is what I did :

- .pytrakt.json is moved from home folder to project folder (with .env and config.json) so that all config files are together. Easier for maintenance or migration.
- if main.py runs for the first time, get_env_data.py is called.
- get_env_data.py writes PLEX_TOKEN and TRAKT_USERNAME in .env file, no need to manually copy/paste.

Also, why do you have `trakt.APPLICATION_ID = '65370'` line ?
It is only needed for pin auth method but you choose oauth method.
By the way, PIN authentication would be easier for such a basic script. Note that it is default pytrakt method.