### PR TITLE
Switch to device auth

### DIFF
--- a/get_env_data.py
+++ b/get_env_data.py
@@ -21,10 +21,9 @@ else:
     with open(env_file, "w") as txt:
         txt.write("PLEX_TOKEN=-\n")
 
-trakt.APPLICATION_ID = '65370'
-trakt.core.AUTH_METHOD=trakt.core.OAUTH_AUTH
+trakt.core.AUTH_METHOD=trakt.core.DEVICE_AUTH
 trakt_user = input("Please input your Trakt username: ")
-trakt.init(trakt_user, store=True)
+trakt.init(store=True)
 with open(env_file, "a") as txt:
     txt.write("TRAKT_USERNAME=" + trakt_user + "\n")
 print("You are now logged into Trakt. Your Trakt credentials have been added in .env and .pytrakt.json files.")

--- a/get_env_data.py
+++ b/get_env_data.py
@@ -23,7 +23,8 @@ else:
 
 trakt.core.AUTH_METHOD=trakt.core.DEVICE_AUTH
 trakt_user = input("Please input your Trakt username: ")
-trakt.init(store=True)
+client_id, client_secret = trakt.core._get_client_info()
+trakt.init(client_id=client_id, client_secret=client_secret, store=True)
 with open(env_file, "a") as txt:
     txt.write("TRAKT_USERNAME=" + trakt_user + "\n")
 print("You are now logged into Trakt. Your Trakt credentials have been added in .env and .pytrakt.json files.")


### PR DESCRIPTION
[Device authentication](https://trakt.docs.apiary.io/#reference/authentication-devices) is easier to setup for users with command line scripts.
Users don't have to copy/paste a long url but only a code.
Moreover, the pytrakt function of device_auth stores the `oauth_refresh` token which can be used to automatically refresh the `oauth_token` every 3 months.