### PR TITLE
full path for file opening

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 import json
+from os import path
 
-with open('config.json', 'r') as fp:
+config_file = path.join(path.dirname(path.abspath(__file__)), "config.json")
+with open(config_file, 'r') as fp:
     CONFIG = json.load(fp)


### PR DESCRIPTION
If user runs script from outside its folder, full path is needed to open file.

closes #16 

Maybe needed for last_update.log too #17 