### PR TITLE
Add excluded libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ the documentation and comments are lacking at best.
 
 ## Features
 
- - All media in PMS are added to Trakt collection
+ - Media in Plex are added to Trakt collection
  - Ratings are synced (if ratings differ, Trakt takes precedence)
- - Watched status is synced (only if watched or not, not the dates)
- - Liked lists in Trakt are downloaded and all movies in PMS belonging to that
+ - Watched status are synced (dates are not reported from Trakt to Plex)
+ - Liked lists in Trakt are downloaded and all movies in Plex belonging to that
    list are added
+ - You can edit the [config file](https://github.com/Taxel/PlexTraktSync/blob/master/config.json) to choose what to sync
  - None of the above requires a Plex Pass or Trakt VIP membership.
    Downside: Needs to be executed manually or via cronjob,
    can not use live data via webhooks.

--- a/config.json
+++ b/config.json
@@ -12,8 +12,8 @@
         "movies": "imdb",
         "shows": "tvdb"
     },
-    "excluded-libraries": {
+    "excluded-libraries": [
         "Private",
         "Family Holidays"
-    }
+    ]
 }

--- a/config.json
+++ b/config.json
@@ -11,5 +11,9 @@
     "xbmc-providers": {
         "movies": "imdb",
         "shows": "tvdb"
+    },
+    "excluded-libraries": {
+        "Private",
+        "Family Holidays"
     }
 }

--- a/main.py
+++ b/main.py
@@ -302,6 +302,8 @@ def main():
     with requests_cache.disabled():
         sections = plex.library.sections()
     for section in sections:
+        if section.title in CONFIG['excluded-libraries']:
+            continue
         # process movie sections
         section_start_time = time()
         if type(section) is plexapi.library.MovieSection:


### PR DESCRIPTION
User can customize the "excluded-libraries" list in `config.json` to set Plex section names that will not be sync.

closes #22 