### PR TITLE
Store Plex base url automatically in the .env file on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Plex-Trakt-Sync
 
 This project adds a two-way-sync between trakt.tv and Plex Media Server. It
-requires a trakt.tv account but no Plex premium and Trakt VIP subscriptions,
+requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions,
 unlike the Plex app provided by Trakt.
 
 I am not actively maintaining this, so use at own risk, there may be bugs and
@@ -41,8 +41,6 @@ To connect to Trakt you need to create a new API app: Visit
 `https://trakt.tv/oauth/applications/new`, give it a meaningful name and enter
 `urn:ietf:wg:oauth:2.0:oob`as the redirect url. You can leave Javascript
 origins and the checkboxes blank.
-
-If your Plex server is not on localhost, edit base_url in `config.json` file.
 
 Then, run `python3 main.py`.
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-    "base_url": "http://localhost:32400",
     "log_debug_messages": false,
     "sync": {
         "liked_lists": true,

--- a/get_env_data.py
+++ b/get_env_data.py
@@ -44,7 +44,10 @@ if plex_needed:
     with open(env_file, 'w') as txt:
         txt.write("PLEX_USERNAME=" + username + "\n")
         txt.write("PLEX_TOKEN=" + token + "\n")
-    print("Plex token for {} has been added in .env file: PLEX_TOKEN={}".format(username, token))
+        txt.write("PLEX_BASEURL=" + plex._baseurl + "\n")
+    print("Plex token for {} has been added in .env file:".format(username))
+    print("PLEX_TOKEN={}".format(token))
+    print("PLEX_BASEURL={}".format(plex._baseurl))
 else:
     with open(env_file, "w") as txt:
         txt.write("PLEX_USERNAME=-\n")

--- a/main.py
+++ b/main.py
@@ -298,11 +298,12 @@ def main():
     logging.debug("Movie ratings from trakt: {}".format(ratings))
     logging.info('Loaded Trakt lists.')
     plex_token = getenv("PLEX_TOKEN")
+    plex_baseurl = getenv("PLEX_BASEURL")
     if plex_token == '-':
         plex_token = ""
     with requests_cache.disabled():
         plex = plexapi.server.PlexServer(
-            token=plex_token, baseurl=CONFIG['base_url'])
+            token=plex_token, baseurl=plex_baseurl)
         logging.info("Server version {} updated at: {}".format(
             plex.version, plex.updatedAt))
         logging.info("Recently added: {}".format(


### PR DESCRIPTION
Plex base url is now found at first run and automatically stored in `.env` file.
The user doesn't need to edit it in config file anymore.
It also allows the use of a Plex shared librarie (remote Plex librarie shared by a friend).

closes #27 