### PR TITLE
keep trakt rank when sync playlists to plex

### DIFF
--- a/main.py
+++ b/main.py
@@ -284,7 +284,7 @@ def main():
         #logging.debug("Movie collection from trakt:", trakt_movie_collection)
         trakt_watched_shows = pytrakt_extensions.allwatched()
         if CONFIG['sync']['watchlist']:
-            listutil.addList(None, "Trakt Watchlist", list_set=set(
+            listutil.addList(None, "Trakt Watchlist", list_set=list(
                 map(lambda m: m.slug, trakt_user.watchlist_movies)))
         #logging.debug("Movie watchlist from trakt:", trakt_movie_watchlist)
         user_ratings = trakt_user.get_ratings(media_type='movies')

--- a/main.py
+++ b/main.py
@@ -284,7 +284,7 @@ def main():
         #logging.debug("Movie collection from trakt:", trakt_movie_collection)
         trakt_watched_shows = pytrakt_extensions.allwatched()
         if CONFIG['sync']['watchlist']:
-            listutil.addList(None, "Trakt Watchlist", list_set=list(
+            listutil.addList(None, "Trakt Watchlist", slug_list=list(
                 map(lambda m: m.slug, trakt_user.watchlist_movies)))
         #logging.debug("Movie watchlist from trakt:", trakt_movie_watchlist)
         user_ratings = trakt_user.get_ratings(media_type='movies')

--- a/trakt_list_util.py
+++ b/trakt_list_util.py
@@ -9,8 +9,9 @@ class TraktList():
     def __init__(self, username, listname):
         self.name = listname
         self.plex_movies = []
+        self.list_order = []
         if username != None:
-            self.slugs = set(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]))
+            self.slugs = list(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]))
     
     @staticmethod
     def from_set(listname, list_set):
@@ -21,6 +22,7 @@ class TraktList():
     def addPlexMovie(self, slug, plex_movie):
         if slug in self.slugs:
             self.plex_movies.append(plex_movie)
+            self.list_order.append(self.slugs.index(slug))
             logging.info('Movie [{} ({})]: added to list {}'.format(plex_movie.title, plex_movie.year, self.name))
 
     def updatePlexList(self, plex):
@@ -31,7 +33,8 @@ class TraktList():
                 logging.error("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
                 pass
             if len(self.plex_movies) > 0:
-                plex.createPlaylist(self.name, items=self.plex_movies)
+                _, plex_movies_sorted = zip(*sorted(zip(self.list_order, self.plex_movies)))
+                plex.createPlaylist(self.name, items=plex_movies_sorted)
 
 
 class TraktListUtil():

--- a/trakt_list_util.py
+++ b/trakt_list_util.py
@@ -14,9 +14,9 @@ class TraktList():
             self.slugs = list(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]))
     
     @staticmethod
-    def from_set(listname, list_set):
+    def from_slug_list(listname, slug_list):
         l = TraktList(None, listname)
-        l.slugs = list_set
+        l.slugs = slug_list
         return l
 
     def addPlexMovie(self, slug, plex_movie):
@@ -41,9 +41,9 @@ class TraktListUtil():
     def __init__(self):
         self.lists = []
 
-    def addList(self, username, listname, list_set = None):
-        if list_set is not None:
-            self.lists.append(TraktList.from_set(listname, list_set))
+    def addList(self, username, listname, slug_list = None):
+        if slug_list is not None:
+            self.lists.append(TraktList.from_slug_list(listname, slug_list))
             logging.info("Downloaded List {}".format(listname))
             return
         try:

--- a/trakt_list_util.py
+++ b/trakt_list_util.py
@@ -11,18 +11,21 @@ class TraktList():
         self.plex_movies = []
         self.list_order = []
         if username != None:
-            self.slugs = list(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]))
+            slug_dict = dict(enumerate(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie])))
+            self.slugs = dict(zip(slug_dict.values(), slug_dict.keys()))
     
     @staticmethod
     def from_slug_list(listname, slug_list):
         l = TraktList(None, listname)
-        l.slugs = slug_list
+        slug_dict = dict(enumerate(slug_list))
+        l.slugs = dict(zip(slug_dict.values(), slug_dict.keys()))
         return l
 
     def addPlexMovie(self, slug, plex_movie):
-        if slug in self.slugs:
+        rank = self.slugs.get(slug)
+        if rank is not None:
             self.plex_movies.append(plex_movie)
-            self.list_order.append(self.slugs.index(slug))
+            self.list_order.append(rank)
             logging.info('Movie [{} ({})]: added to list {}'.format(plex_movie.title, plex_movie.year, self.name))
 
     def updatePlexList(self, plex):

--- a/trakt_list_util.py
+++ b/trakt_list_util.py
@@ -10,7 +10,6 @@ class TraktList():
     def __init__(self, username, listname):
         self.name = listname
         self.plex_movies = []
-        self.list_order = []
         if username != None:
             self.slugs = dict(zip(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]),count()))
     
@@ -23,8 +22,7 @@ class TraktList():
     def addPlexMovie(self, slug, plex_movie):
         rank = self.slugs.get(slug)
         if rank is not None:
-            self.plex_movies.append(plex_movie)
-            self.list_order.append(rank)
+            self.plex_movies.append((rank, plex_movie))
             logging.info('Movie [{} ({})]: added to list {}'.format(plex_movie.title, plex_movie.year, self.name))
 
     def updatePlexList(self, plex):
@@ -35,7 +33,7 @@ class TraktList():
                 logging.error("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
                 pass
             if len(self.plex_movies) > 0:
-                _, plex_movies_sorted = zip(*sorted(zip(self.list_order, self.plex_movies)))
+                _, plex_movies_sorted = zip(*sorted(self.plex_movies))
                 plex.createPlaylist(self.name, items=plex_movies_sorted)
 
 

--- a/trakt_list_util.py
+++ b/trakt_list_util.py
@@ -4,6 +4,7 @@ from trakt.movies import Movie
 import requests_cache
 import logging
 from plexapi.exceptions import BadRequest, NotFound
+from itertools import count
 
 class TraktList():
     def __init__(self, username, listname):
@@ -11,14 +12,12 @@ class TraktList():
         self.plex_movies = []
         self.list_order = []
         if username != None:
-            slug_dict = dict(enumerate(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie])))
-            self.slugs = dict(zip(slug_dict.values(), slug_dict.keys()))
+            self.slugs = dict(zip(map(lambda m: m.slug, [elem for elem in UserList._get(listname, username).get_items() if type(elem) == Movie]),count()))
     
     @staticmethod
     def from_slug_list(listname, slug_list):
         l = TraktList(None, listname)
-        slug_dict = dict(enumerate(slug_list))
-        l.slugs = dict(zip(slug_dict.values(), slug_dict.keys()))
+        l.slugs = dict(zip(slug_list, count()))
         return l
 
     def addPlexMovie(self, slug, plex_movie):


### PR DESCRIPTION
This makes the script respect the Trakt playlists order (items rank is preserved) when syncing them to Plex.

fixes #54 