### PR TITLE
Update run script to rotate logs

### DIFF
--- a/plex_trakt_sync.sh
+++ b/plex_trakt_sync.sh
@@ -1,3 +1,13 @@
 #!/bin/sh
 PATH=/usr/local/bin:/usr/local/sbin:~/bin:/usr/bin:/bin:/usr/sbin:/sbin
-python3 ./main.py
+set -eu
+
+file=$(readlink -f "$0")
+dir=$(dirname "$file")
+date=$(date --rfc-3339=ns | tr ' ' '_')
+
+if python3 "$dir/main.py" "$@"; then
+	mv last_update.log "update-$date.log"
+else
+	mv last_update.log "error-$date.log"
+fi


### PR DESCRIPTION
This modifies `plex_trakt_sync.sh` script to keep sepatate log for each run:

- "update-$date.log" - for success
- "error-$date.log" - for errors