### PR TITLE
Allow custom envfile path to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ by adding the line:
 
 to the cronjobs after typing `crontab -e` in the terminal.
 
+You can supply a custom env file by using the CUSTOM_ENV envoirment variable. 
+
+```
+CUSTOM_ENV=.env.my.plex.host ./plex_trakt_sync
+```
+
 ## Sync settings
 
 To disable parts of the functionality of this software, look no further than

--- a/main.py
+++ b/main.py
@@ -254,7 +254,15 @@ def process_show_section(s, watched_set):
 def main():
 
     start_time = time()
-    load_dotenv()
+    # try to load the custom envfile set in CUSTOM_ENV envoirment variable
+    envFile = getenv('CUSTOM_ENV')
+    if envFile == None:
+        envFile = path.join(path.dirname(path.abspath(__file__)), '.env')
+    else:
+        if not path.isabs(envFile):
+           envFile = path.join(path.dirname(path.abspath(__file__)), envFile) 
+        print("Using custom env file: %s" % envFile)  
+    load_dotenv(dotenv_path=envFile)
     if not getenv("PLEX_TOKEN") or not getenv("TRAKT_USERNAME"):
         print("First run, please follow those configuration instructions.")
         import get_env_data


### PR DESCRIPTION
This will allow to supply a custom envfile to the script. Im using PlexTraktSync to keep three servers in sync and it works perfectly. This change makes it very easy to reuse the script to sync multiple servers. There is no verification or checks in place the custom envfile really exists. Its not needed for my purposes. If you want this added feel free to ping me and i implement it :+1: 