### PR TITLE
Add new keyword 'title' for TV show seasons

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ def process_show_section(s, watched_set):
                 logging.error("Show [{} ({})]: Did not find on Trakt. Aborting. GUID: {}".format(show.title, show.year, guid))
                 continue
             with requests_cache.disabled():
-                trakt_collected = pytrakt_extensions.collected(trakt_show.slug)
+                trakt_collected = pytrakt_extensions.collected(trakt_show.trakt)
             start_time = time()
             # this lookup-table is accessible via lookup[season][episode]
             with requests_cache.disabled():

--- a/pytrakt_extensions.py
+++ b/pytrakt_extensions.py
@@ -75,7 +75,7 @@ class EpisodeProgress():
         return self.completed
 
 class SeasonProgress():
-    def __init__(self, number=0, aired=0, completed=False, episodes=None):
+    def __init__(self, number=0, title=None, aired=0, completed=False, episodes=None):
         self.number = number
         self.aired = aired
         self.episodes = {}

--- a/pytrakt_extensions.py
+++ b/pytrakt_extensions.py
@@ -16,7 +16,7 @@ def get_liked_lists():
 @get
 def lookup_table(show):
     # returns all seasons and episodes with one single call
-    data = yield 'shows/{}/seasons?extended=episodes'.format(show.slug)
+    data = yield 'shows/{}/seasons?extended=episodes'.format(show.trakt)
     retVal = {}
     for season in data:
         eps = {}
@@ -54,9 +54,9 @@ def watched(show_id):
     yield ShowProgress(**data)
 
 @get
-def collected(show_slug):
+def collected(show_id):
     # returns a ShowProgress object containing the watched states of the passed show
-    data = yield 'shows/{}/progress/collection'.format(show_slug)
+    data = yield 'shows/{}/progress/collection?specials=true'.format(show_id)
     #print(data)
     yield ShowProgress(**data)
 


### PR DESCRIPTION
Some Trakt API response have changed recently :
There is a new keyword `title` for TV show seasons. Trakt now returns the title for each season.
This PR adds keyword `title` to `SeasonProgress()` and therefore fixes the `bad response from trakt` error for entire TV Library that showed up recently.

And use of trakt id instead of slug just like in PR #31

closes #71 