### PR TITLE
Plexmovieagent fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 trakt_cache.sqlite
 last_update.log
+.pytrakt.json

--- a/Pipfile
+++ b/Pipfile
@@ -1,9 +1,7 @@
 [[source]]
-name = "pypi"
-url = "https://pypi.org/simple"
+url = "https://pypi.python.org/simple"
 verify_ssl = true
-
-[dev-packages]
+name = "pypi"
 
 [packages]
 astroid = "==2.3.2"
@@ -24,9 +22,13 @@ tqdm = "==4.36.1"
 trakt = "==2.14.1"
 typed-ast = "==1.4.0"
 urllib3 = "==1.25.6"
-wrapt = "==1.11.2"
-PlexAPI = "==3.2.0"
 websocket_client = "==0.56.0"
+wrapt = "==1.11.2"
+
+[dev-packages]
 
 [requires]
-python_version = "3"
+python_version = "3.8"
+
+[packages.d367f6a]
+file = "https://codeload.github.com/andyloree/python-plexapi/legacy.tar.gz/8635727cd6d90099da9fbe9a540ae0c54cac19f7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,16 +1,16 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a72c2190a3f2336980afd554841372315b94d79481274b0dd4917a676b6e273b"
+            "sha256": "a41bb34262954a355d26eb0b990dea7763482d262eee5e472cf1dc897ff61af0"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3"
+            "python_version": "3.8"
         },
         "sources": [
             {
                 "name": "pypi",
-                "url": "https://pypi.org/simple",
+                "url": "https://pypi.python.org/simple",
                 "verify_ssl": true
             }
         ]
@@ -39,6 +39,9 @@
             ],
             "index": "pypi",
             "version": "==3.0.4"
+        },
+        "d367f6a": {
+            "file": "https://codeload.github.com/andyloree/python-plexapi/legacy.tar.gz/8635727cd6d90099da9fbe9a540ae0c54cac19f7"
         },
         "idna": {
             "hashes": [
@@ -95,13 +98,6 @@
             ],
             "index": "pypi",
             "version": "==3.1.0"
-        },
-        "plexapi": {
-            "hashes": [
-                "sha256:d3007194594d4d347d67b4aa9337e211cab9c1f123d889f067a28e7266260be1"
-            ],
-            "index": "pypi",
-            "version": "==3.2.0"
         },
         "pylint": {
             "hashes": [

--- a/main.py
+++ b/main.py
@@ -36,6 +36,10 @@ def process_movie_section(s, watched_set, ratings_dict, listutil, collection):
     for movie in allMovies:
         # find id to search movie
         guid = movie.guid
+        if guid.startswith('plex://movie/'):
+            if len(movie.guids) > 0:
+                logging.debug("trying first alternative guid: " + str(movie.guids[0].id))
+                guid = movie.guids[0].id
         x = provider = None
         if guid.startswith('local') or 'agents.none' in guid:
             # ignore this guid, it's not matched
@@ -46,7 +50,7 @@ def process_movie_section(s, watched_set, ratings_dict, listutil, collection):
             x = guid.split('//')[1]
             x = x.split('?')[0]
             provider = 'imdb'
-        elif 'themoviedb' in guid:
+        elif 'themoviedb' in guid or 'tmdb' in guid:
             x = guid.split('//')[1]
             x = x.split('?')[0]
             provider = 'tmdb'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ isort==4.3.21
 lazy-object-proxy==1.4.2
 mccabe==0.6.1
 oauthlib==3.1.0
-PlexAPI==3.2.0
 pylint==2.4.3
 python-dotenv==0.10.3
 requests==2.22.0
@@ -19,3 +18,4 @@ typed-ast==1.4.0
 urllib3==1.25.6
 websocket-client==0.56.0
 wrapt==1.11.2
+https://codeload.github.com/andyloree/python-plexapi/legacy.tar.gz/8635727cd6d90099da9fbe9a540ae0c54cac19f7


### PR DESCRIPTION
Hey guys,

after finally getting to installing this script in my home, I was immediately annoyed by the fact that the new plex movie agent does not work so far.
So I went ahead and included the tar.gz of the [pull request in python-plexapi that fixes the issue](https://github.com/pkkid/python-plexapi/pull/562) and some minor modifications that use the new `movie.guids` property if the new Plex movie agent is used.

It works fine on my machine, if someone who still has a library with the old movie agent can confirm I didn't break anything there, we can merge this.

This fixes #56 and makes #83 unnecessary because it turns out the newer plexapi actually gives back the imdb and/or tvdb links in the new property, no more "search by name and year and hope it's the right match" necessary.

Once the pull request on the `python-plexapi` package is merged, we should be able to go to the latest version there without problems.

Also, I just deleted and recreated the Pipfile and Pipfile.lock, which apparently pinned Python 3.8 as the version. Since I have no experience with this: Is there a better way to do this?

## Installation
Simply reinstalling your dependencies, either with `pip3 install -r requirements.txt` or `pipenv install` should be all that's needed.

Greez
Taxel
