### PR TITLE
Update to use guids from python-plexapi to fix Plexmovieagent breakage

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,10 @@ def process_movie_section(s, watched_set, ratings_dict, listutil, collection):
     for movie in allMovies:
         # find id to search movie
         guid = movie.guid
+        if guid.startswith('plex://movie/'):
+            if len(movie.guids) > 0:
+                logging.debug("trying first alternative guid: " + str(movie.guids[0].id))
+                guid = movie.guids[0].id
         x = provider = None
         if guid.startswith('local') or 'agents.none' in guid:
             # ignore this guid, it's not matched
@@ -46,7 +50,7 @@ def process_movie_section(s, watched_set, ratings_dict, listutil, collection):
             x = guid.split('//')[1]
             x = x.split('?')[0]
             provider = 'imdb'
-        elif 'themoviedb' in guid:
+        elif 'themoviedb' in guid or 'tmdb' in guid:
             x = guid.split('//')[1]
             x = x.split('?')[0]
             provider = 'tmdb'


### PR DESCRIPTION
Hey guys,

after finally getting to installing this script in my home, I was immediately annoyed by the fact that the new plex movie agent does not work so far.
So I went ahead and included the tar.gz of the [pull request in python-plexapi that fixes the issue](https://github.com/pkkid/python-plexapi/pull/562) and some minor modifications that use the new `movie.guids` property if the new Plex movie agent is used.

It works fine on my machine, if someone who still has a library with the old movie agent can confirm I didn't break anything there, we can merge this.

This fixes #56 and makes #83 unnecessary because it turns out the newer plexapi actually gives back the imdb and/or tvdb links in the new property, no more "search by name and year and hope it's the right match" necessary.

Once the pull request on the `python-plexapi` package is merged, we should be able to go to the latest version there without problems.

Also, I just deleted and recreated the Pipfile and Pipfile.lock, which apparently pinned Python 3.8 as the version. Since I have no experience with this: Is there a better way to do this?

## Installation
Simply reinstalling your dependencies, either with `pip3 install -r requirements.txt` or `pipenv install` should be all that's needed.

Greez
Taxel

----

Replaces https://github.com/Taxel/PlexTraktSync/pull/86 which was unintentionally closed.

Fixes https://github.com/Taxel/PlexTraktSync/pull/83 (replaces)

----

@glensc I followed all your suggestions, splitting up the commit, using Python 3 instead of Python 3.8 in Pipenv, and accidentally pushing to master in the process. The master can now no longer be pushed to (even by me) to avoid this in the future.

This apparently closed the other PR, so here's a new one.