### PR TITLE
Ignore .pytrakt.json to avoid accidentially commiting credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 trakt_cache.sqlite
 last_update.log
+.pytrakt.json


### PR DESCRIPTION
Extracted out of https://github.com/Taxel/PlexTraktSync/pull/87 so the change could be merged sooner.

cc @Taxel 