### PR TITLE
Improve connection to Plex server

### DIFF
--- a/get_env_data.py
+++ b/get_env_data.py
@@ -46,6 +46,7 @@ if plex_needed:
         txt.write("PLEX_USERNAME=" + username + "\n")
         txt.write("PLEX_TOKEN=" + token + "\n")
         txt.write("PLEX_BASEURL=" + plex._baseurl + "\n")
+        txt.write("PLEX_FALLBACKURL=http://localhost:32400\n")
     print("Plex token and baseurl for {} have been added in .env file:".format(username))
     print("PLEX_TOKEN={}".format(token))
     print("PLEX_BASEURL={}".format(plex._baseurl))


### PR DESCRIPTION
This PR makes connection attempts to Plex more resilient.

It makes the script try different url for connections attempts to Plex until success :
1. if SSL certificate mismatch, it tries the expected url and if success it updates the url in .env file (*)
2. if SSL error, it tries the unsecured way (without SSL)
3. if connection still fails, it tries to basically connect to localhost (url added in .env as "fallbackurl" and customisable)

(*) : Plex server sometime updates its ID. Therefore the connection url change too (the `server_id_hash` part here) :
`https://dashed_ip_address.server_id_hash.plex.direct:port`
The SSL certificate provided by Plex server is for *.server_id_hash.plex.direct and must match the connection url. 

If someone finds a better way to implement the 3 try/except I wrote, no problem. 😄 

fixes #18
fixes #79