### PR TITLE
Set trakt config_path before import trakt.users

### DIFF
--- a/clear_trakt_collections.py
+++ b/clear_trakt_collections.py
@@ -1,10 +1,11 @@
 # deletes everything in trakt's collection
 # dangerous!
-import trakt.users
+import trakt
 import sys
 from os import path
-
 trakt.core.CONFIG_PATH = path.join(path.dirname(path.abspath(__file__)), ".pytrakt.json")
+import trakt.users
+
 
 def main():
     trakt_user = trakt.users.User('me')


### PR DESCRIPTION
The config_path to .pytrakt.json for trakt credentials needs to be set before the `import trakt.users` command.

closes #103 