### PR TITLE
Update PlexAPI from 3.2.0 to 4.3.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ trakt = "==2.14.1"
 typed-ast = "==1.4.0"
 urllib3 = "==1.25.6"
 wrapt = "==1.11.2"
-PlexAPI = "==3.2.0"
+PlexAPI = "==4.3.1"
 websocket_client = "==0.56.0"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a72c2190a3f2336980afd554841372315b94d79481274b0dd4917a676b6e273b"
+            "sha256": "f34cff601f7cc4c4036eff620ba804d739a400008c1eb36284f871e3db1a7ee5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -98,10 +98,11 @@
         },
         "plexapi": {
             "hashes": [
-                "sha256:d3007194594d4d347d67b4aa9337e211cab9c1f123d889f067a28e7266260be1"
+                "sha256:1fc14397908a68b39e26d93dc1a8257fa90d91a203e9127e19462a1fd5dc7cfc",
+                "sha256:c17026e035d311626bc84607fe18a341ce44f2f112ece7c66dc4a6cb800f6d98"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==4.3.1"
         },
         "pylint": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ isort==4.3.21
 lazy-object-proxy==1.4.2
 mccabe==0.6.1
 oauthlib==3.1.0
-PlexAPI==3.2.0
+PlexAPI==4.3.1
 pylint==2.4.3
 python-dotenv==0.10.3
 requests==2.22.0


### PR DESCRIPTION
The project has no changelog for migration:
- https://github.com/pkkid/python-plexapi/issues/521

So it would be trial and error to resolve what's broken.

Whole diff:
- https://github.com/pkkid/python-plexapi/compare/3.2.0...4.3.1

Release notes by versions in the range:
- https://github.com/pkkid/python-plexapi/releases/tag/3.4.0 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/3.5.0 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/3.5.1 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/3.6.0 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/4.0.0 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/4.1.0 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/4.1.1 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/4.1.2 (no notes)
- https://github.com/pkkid/python-plexapi/releases/tag/4.2.0
- https://github.com/pkkid/python-plexapi/releases/tag/4.3.0
- https://github.com/pkkid/python-plexapi/releases/tag/4.3.1

refs:
- https://github.com/Taxel/PlexTraktSync/pull/87#issuecomment-766613322