### PR TITLE
Add watch subcommand to print play events from PMS

### DIFF
--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -1,6 +1,7 @@
 import click
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.sync import sync
+from plex_trakt_sync.commands.watch import watch
 
 
 @click.group(invoke_without_command=True)
@@ -15,3 +16,4 @@ def cli(ctx):
 
 cli.add_command(sync)
 cli.add_command(clear_collections)
+cli.add_command(watch)

--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -1,4 +1,42 @@
 import click
+from plexapi.server import PlexServer
+from plex_trakt_sync.listener import WebSocketListener, PLAYING
+from plex_trakt_sync.config import CONFIG
+
+
+class WatchStateUpdater:
+    def __init__(self, plex):
+        self.plex = plex
+
+    def __call__(self, message):
+        """
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 0, 'playQueueItemID': 17679, 'state': 'playing'}
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 10000, 'playQueueItemID': 17679, 'state': 'playing', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 20000, 'playQueueItemID': 17679, 'state': 'playing', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 30000, 'playQueueItemID': 17679, 'state': 'playing', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 30000, 'playQueueItemID': 17679, 'state': 'paused', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
+            {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 30000, 'playQueueItemID': 17679, 'state': 'paused', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
+        """
+        if message["size"] != 1:
+            raise ValueError("Unexpected size: %r" % message)
+
+        for item in message["PlaySessionStateNotification"]:
+            print(item)
+            state = item["state"]
+            # "playing", 'buffering', 'stopped'
+            if state == 'buffering':
+                continue
+
+            viewOffset = item["viewOffset"]
+            ratingKey = item["ratingKey"]
+            print("Find movie for %s @ %s" % (ratingKey, viewOffset))
+            movie = self.plex.library.fetchItem("/library/metadata/%s" % ratingKey)
+            print("Found movie: %r" % movie)
+            percent = viewOffset/movie.duration * 100
+
+            print("%r: %.6F%% Duration: %s, Watched: %s, LastViewed: %s" % (
+                movie, percent, movie.duration, movie.isWatched, movie.lastViewedAt
+            ))
 
 
 @click.command()
@@ -7,4 +45,11 @@ def watch():
     Listen to events from Plex
     """
 
-    print("Listening for events")
+    url = CONFIG["PLEX_BASEURL"]
+    token = CONFIG["PLEX_TOKEN"]
+    server = PlexServer(url, token)
+
+    ws = WebSocketListener(server)
+    ws.on(PLAYING, WatchStateUpdater(server))
+    print("Listening for events!")
+    ws.listen()

--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -1,0 +1,10 @@
+import click
+
+
+@click.command()
+def watch():
+    """
+    Listen to events from Plex
+    """
+
+    print("Listening for events")

--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -1,0 +1,30 @@
+from time import sleep
+from plexapi.server import PlexServer
+
+PLAYING = "playing"
+
+
+class WebSocketListener:
+    def __init__(self, plex: PlexServer, interval=1):
+        self.plex = plex
+        self.interval = interval
+        self.event_handlers = {}
+
+    def on(self, event_name, handler):
+        if event_name not in self.event_handlers:
+            self.event_handlers[event_name] = []
+
+        self.event_handlers[event_name].append(handler)
+
+    def listen(self):
+        def handler(data):
+            event_type = data['type']
+            if event_type not in self.event_handlers:
+                return
+
+            for handler in self.event_handlers[event_type]:
+                handler(data)
+
+        notifier = self.plex.startAlertListener(callback=handler)
+        while notifier.is_alive():
+            sleep(self.interval)


### PR DESCRIPTION
This adds `watch` subcommand to print play events from PMS:

```
➔ ./plex_trakt_sync.sh watch
Listening for events!
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
{'type': 'playing', 'size': 1, 'PlaySessionStateNotification': [{'sessionKey': '19', 'guid': '', 'ratingKey': '9723', 'url': '', 'key': '/library/metadata/9723', 'viewOffset': 39000, 'playQueueItemID': 17659, 'state': 'playing', 'transcodeSession': '9dd9jn2ci6cx3fynei05gs6p'}]}
{'type': 'playing', 'size': 1, 'PlaySessionStateNotification': [{'sessionKey': '19', 'guid': '', 'ratingKey': '9723', 'url': '', 'key': '/library/metadata/9723', 'viewOffset': 41000, 'playQueueItemID': 17659, 'state': 'stopped', 'transcodeSession': '9dd9jn2ci6cx3fynei05gs6p'}]}
```

nothing intermediately useful, other than info now.