### PR TITLE
Add clear_trakt_collections as subcommand

### DIFF
--- a/clear_trakt_collections.py
+++ b/clear_trakt_collections.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from plex_trakt_sync.clear_trakt_collections import clear_trakt_collections
-
-if __name__ == "__main__":
-    clear_trakt_collections()

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -1,11 +1,37 @@
 import click
 from plex_trakt_sync.main import main
+from plex_trakt_sync.clear_trakt_collections import clear_trakt_collections
 
 
-@click.command()
+@click.group()
 def cli():
     """
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
+    pass
+
+
+@click.command()
+def sync():
+    """
+    Perform sync between Plex and Trakt
+    """
 
     main()
+
+
+@click.command()
+@click.option('--confirm', is_flag=True, help='Confirm the dangerous action')
+def clear_collections(confirm):
+    """
+    Clear Movies and Shows collections in Trakt
+    """
+
+    if not confirm:
+        click.echo('You need to pass --confirm option to proceed')
+        return
+    clear_trakt_collections()
+
+
+cli.add_command(sync)
+cli.add_command(clear_collections)

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -3,12 +3,14 @@ from plex_trakt_sync.main import main
 from plex_trakt_sync.clear_trakt_collections import clear_trakt_collections
 
 
-@click.group()
-def cli():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
     """
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
-    pass
+    if not ctx.invoked_subcommand:
+        main()
 
 
 @click.command()


### PR DESCRIPTION
To run the clear collections, you now have to pass `--confirm` option:

```
➔ ./main.py clear-collections
You need to pass --confirm option to proceed
```