### PR TITLE
Add measure_time helper to log block timing

### DIFF
--- a/plex_trakt_sync/decorators.py
+++ b/plex_trakt_sync/decorators.py
@@ -1,2 +1,15 @@
+import logging
+from contextlib import contextmanager
 from plex_trakt_sync.memoize import Memoize as memoize
 from plex_trakt_sync.nocache import CacheDisabledDecorator as nocache
+from time import time
+
+
+@contextmanager
+def measure_time(message, level=logging.INFO):
+    start = time()
+    yield
+    timedelta = time() - start
+
+    m, s = divmod(timedelta, 60)
+    logging.log(level, message + " in " + (m > 0) * "{:.0f} min ".format(m) + (s > 0) * "{:.1f} seconds".format(s))


### PR DESCRIPTION
Inspired from https://stackoverflow.com/a/62956469/2314626

```py
    with measure_time("Completed full sync"):
        sync()
```