### PR TITLE
Correct connect error message on plex connection

### DIFF
--- a/plex_trakt_sync/main.py
+++ b/plex_trakt_sync/main.py
@@ -346,7 +346,7 @@ def get_plex_server():
         server = plexapi.server.PlexServer(
             token=plex_token, baseurl=plex_baseurl)
     except plexapi.server.requests.exceptions.SSLError as e:
-        m = "Plex connection error: {}, fallback url {} didn't respond either.".format(str(e), plex_fallbackurl)
+        m = "Plex connection error: {}, tried url {}".format(str(e), plex_baseurl)
         excep_msg = str(e.__context__)
         if "doesn't match '*." in excep_msg:
             hash_pos = excep_msg.find("*.") + 2


### PR DESCRIPTION
At the time this exception is thrown, the main url as tried, not fallback.

Found this when reading the code, no actual error encountered.

refs:
- #94 

cc @twolaw 