### PR TITLE
Add rate_limit decorator

### DIFF
--- a/plex_trakt_sync/decorators/__init__.py
+++ b/plex_trakt_sync/decorators/__init__.py
@@ -1,3 +1,4 @@
 from .measure_time import measure_time
 from .memoize import memoize
 from .nocache import CacheDisabledDecorator as nocache
+from .rate_limit import rate_limit

--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -18,9 +18,11 @@ def rate_limit(retries=5):
                         raise e
 
                     delay = int(e.response.headers.get("Retry-After", 1))
-                    logging.warning('RateLimitException, retrying after {} seconds'.format(delay))
-                    sleep(delay)
                     retry += 1
+                    logging.warning(
+                        f'RateLimitException for {fn}, retrying after {delay} seconds (try: {retry}/{retries})'
+                    )
+                    sleep(delay)
 
         return wrapper
 

--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -1,0 +1,27 @@
+from functools import wraps
+from time import sleep
+from trakt.errors import RateLimitException
+
+from plex_trakt_sync.logging import logging
+
+
+def rate_limit(retries=5):
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            retry = 0
+            while True:
+                try:
+                    return fn(*args, **kwargs)
+                except RateLimitException as e:
+                    if retry == retries:
+                        raise e
+
+                    delay = int(e.response.headers.get("Retry-After", 1))
+                    logging.warning('RateLimitException, retrying after {} seconds'.format(delay))
+                    sleep(delay)
+                    retry += 1
+
+        return wrapper
+
+    return decorator

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -8,7 +8,7 @@ import trakt.users
 from trakt.errors import OAuthException, ForbiddenException
 
 from plex_trakt_sync.logging import logging
-from plex_trakt_sync.decorators import memoize, nocache
+from plex_trakt_sync.decorators import memoize, nocache, rate_limit
 from plex_trakt_sync.config import CONFIG
 
 
@@ -20,6 +20,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def me(self):
         try:
             return trakt.users.User('me')
@@ -30,6 +31,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def liked_lists(self):
         if not CONFIG['sync']['liked_lists']:
             return []
@@ -38,6 +40,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def watched_movies(self):
         return set(
             map(lambda m: m.trakt, self.me.watched_movies)
@@ -46,6 +49,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def movie_collection(self):
         return set(
             map(lambda m: m.trakt, self.me.movie_collection)
@@ -54,12 +58,14 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def watched_shows(self):
         return pytrakt_extensions.allwatched()
 
     @property
     @memoize
     @nocache
+    @rate_limit()
     def watchlist_movies(self):
         if not CONFIG['sync']['watchlist']:
             return []
@@ -71,6 +77,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
+    @rate_limit()
     def movie_ratings(self):
         return self.me.get_ratings(media_type='movies')
 


### PR DESCRIPTION
Methods with such decorators are retried if `RateLimitException` exception is thrown.

```python
    @rate_limit()
    def watched_shows(self):
        return pytrakt_extensions.allwatched()
```

The whole method is retried, so don't put there anything you don't want to be retried.

there's also side effect, if method calls another method getting the exception. like:

```python
    @rate_limit()
    def movie_ratings(self):
        return self.me.get_ratings(media_type='movies')
```

the decorator will retry `me` 5 times, and then for each `movie_ratings` 5 retries another 5 times of `me`.

```
/usr/local/bin/python3 /Users/glen/scm/plex/Plugins/PlexTraktSync/test_pytest_trakt_search.py
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.movie_ratings at 0x10b0e9a60>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.movie_ratings at 0x10b0e9a60>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.movie_ratings at 0x10b0e9a60>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.movie_ratings at 0x10b0e9a60>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.movie_ratings at 0x10b0e9a60>, retrying after 1 seconds (try: 5/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 1/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 2/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 3/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 4/5)
WARNING: RateLimitException for <function TraktApi.me at 0x10b0dfe50>, retrying after 1 seconds (try: 5/5)
Traceback (most recent call last):
...

trakt.errors.RateLimitException: Rate Limit Exceeded

Process finished with exit code 1

```

this is an unlikely scenario that all retries fail, to recover any better, so leaving this as is.


refs:
- https://github.com/Taxel/PlexTraktSync/pull/119