### PR TITLE
Add rate limit delay support

### DIFF
--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -3,7 +3,7 @@ from time import sleep, time
 from trakt.errors import RateLimitException
 from plex_trakt_sync.logging import logging
 
-last_time = time()
+last_time = None
 
 
 # https://trakt.docs.apiary.io/#introduction/rate-limiting
@@ -18,6 +18,12 @@ def rate_limit(retries=5, delay=None):
     def respect_trakt_rate():
         if delay is None:
             return
+
+        global last_time
+        if last_time is None:
+            last_time = time()
+            return
+
         diff_time = time() - last_time
         if diff_time < delay:
             wait = delay - diff_time

--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -1,17 +1,38 @@
 from functools import wraps
-from time import sleep
+from time import sleep, time
 from trakt.errors import RateLimitException
-
 from plex_trakt_sync.logging import logging
 
+last_time = time()
 
-def rate_limit(retries=5):
+
+# https://trakt.docs.apiary.io/#introduction/rate-limiting
+def rate_limit(retries=5, delay=None):
+    """
+
+    :param retries: number of retries
+    :param delay: delay in sec between trakt requests to respect rate limit
+    :return:
+    """
+
+    def respect_trakt_rate():
+        if delay is None:
+            return
+        diff_time = time() - last_time
+        if diff_time < delay:
+            wait = delay - diff_time
+            logging.warning(
+                f'Sleeping for {wait:.3f} seconds'
+            )
+            sleep(wait)
+
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             retry = 0
             while True:
                 try:
+                    respect_trakt_rate()
                     return fn(*args, **kwargs)
                 except RateLimitException as e:
                     if retry == retries:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -22,7 +22,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
-    @rate_limit()
+    @rate_limit(delay=1.2)
     def me(self):
         try:
             return trakt.users.User('me')

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -13,6 +13,8 @@ from plex_trakt_sync.logging import logging
 from plex_trakt_sync.decorators import memoize, nocache, rate_limit
 from plex_trakt_sync.config import CONFIG
 
+TRAKT_POST_DELAY = 1.1
+
 
 class TraktApi:
     """
@@ -22,7 +24,7 @@ class TraktApi:
     @property
     @memoize
     @nocache
-    @rate_limit(delay=1.2)
+    @rate_limit(delay=TRAKT_POST_DELAY)
     def me(self):
         try:
             return trakt.users.User('me')


### PR DESCRIPTION
To rate limit requests without hitting rate limit error, decorate the method like:

```python
    @rate_limit(delay=1.2)
    def me(self):
        try:
            return trakt.users.User('me')
```

All methods share the same pool for rate limits.

Currently, all methods in TraktApi all `GET` method based, so for test only `.me` method is rate limited

refs:
- https://trakt.docs.apiary.io/#introduction/rate-limiting
- https://github.com/Taxel/PlexTraktSync/pull/119