### PR TITLE
Rewrite nocache as function to support decorators on class method arguments

### DIFF
--- a/plex_trakt_sync/decorators/__init__.py
+++ b/plex_trakt_sync/decorators/__init__.py
@@ -1,4 +1,4 @@
 from .measure_time import measure_time
 from .memoize import memoize
-from .nocache import CacheDisabledDecorator as nocache
+from .nocache import nocache
 from .rate_limit import rate_limit

--- a/plex_trakt_sync/decorators/nocache.py
+++ b/plex_trakt_sync/decorators/nocache.py
@@ -1,10 +1,12 @@
+from functools import wraps
+
 import requests_cache
 
 
-class CacheDisabledDecorator:
-    def __init__(self, fn):
-        self.fn = fn
-
-    def __call__(self, *args):
+def nocache(method):
+    @wraps(method)
+    def inner(self, *args, **kwargs):
         with requests_cache.disabled():
-            return self.fn(*args)
+            return method(self, *args, **kwargs)
+
+    return inner


### PR DESCRIPTION
Extracted from https://github.com/Taxel/PlexTraktSync/pull/180

otherwise methods being decorated with `@nocache` got their arguments shifted around.

```python
    @nocache
    def rate(self, m, rating):
        m.rate(rating)
```

this was called with two arguments only: `m, rating`.