### PR TITLE
Add scrobbling support to watch command

### DIFF
--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -1,10 +1,9 @@
 import click
 from plexapi.server import PlexServer
 
-from plex_trakt_sync.decorators import memoize
 from plex_trakt_sync.listener import WebSocketListener, PLAYING
 from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.plex_api import PlexApi, PlexLibraryItem
+from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.trakt_api import TraktApi
 
 
@@ -14,6 +13,30 @@ class WatchStateUpdater:
         self.trakt = trakt
 
     def __call__(self, message):
+        for pm, tm, item in self.filter_media(message):
+            movie = pm.item
+            percent = pm.watch_progress(item["viewOffset"])
+
+            print("%r: %.6F%% Watched: %s, LastViewed: %s" % (
+                movie, percent, movie.isWatched, movie.lastViewedAt
+            ))
+
+            self.trakt.scrobble(tm, percent)
+
+    def filter_media(self, message):
+        for item in self.filter_playing(message):
+            pm = self.plex.fetch_item(item["ratingKey"])
+            print(f"Found {pm}")
+            if not pm:
+                continue
+
+            tm = self.trakt.find_movie(pm)
+            if not tm:
+                continue
+
+            yield pm, tm, item
+
+    def filter_playing(self, message):
         """
             {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 0, 'playQueueItemID': 17679, 'state': 'playing'}
             {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 10000, 'playQueueItemID': 17679, 'state': 'playing', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
@@ -22,33 +45,18 @@ class WatchStateUpdater:
             {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 30000, 'playQueueItemID': 17679, 'state': 'paused', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
             {'sessionKey': '23', 'guid': '', 'ratingKey': '9725', 'url': '', 'key': '/library/metadata/9725', 'viewOffset': 30000, 'playQueueItemID': 17679, 'state': 'paused', 'transcodeSession': '18nyclub53k1ey37jjbg8ok3'}
         """
+
         if message["size"] != 1:
             raise ValueError("Unexpected size: %r" % message)
 
         for item in message["PlaySessionStateNotification"]:
-            print(item)
             state = item["state"]
+            print(f"State: {state}")
             # "playing", 'buffering', 'stopped'
             if state == 'buffering':
                 continue
 
-            pm = self.plex.fetch_item(item["ratingKey"])
-            print(f"Found {pm} for {item['ratingKey']}")
-            if not pm:
-                continue
-
-            movie = pm.item
-            percent = pm.watch_progress(item["viewOffset"])
-
-            print("%r: %.6F%% Duration: %s, Watched: %s, LastViewed: %s" % (
-                movie, percent, movie.duration, movie.isWatched, movie.lastViewedAt
-            ))
-
-            tm = self.trakt.find_movie(pm)
-            if not tm:
-                continue
-
-            self.trakt.scrobble(tm, percent)
+            yield item
 
 
 @click.command()

--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -53,7 +53,7 @@ class WatchStateUpdater:
             state = item["state"]
             print(f"State: {state}")
             # "playing", 'buffering', 'stopped'
-            if state == 'buffering':
+            if state not in ["playing", "stopped"]:
                 continue
 
             yield item

--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -1,6 +1,8 @@
 from time import sleep
 from plexapi.server import PlexServer
 
+from plex_trakt_sync.logging import logging
+
 PLAYING = "playing"
 
 
@@ -9,6 +11,7 @@ class WebSocketListener:
         self.plex = plex
         self.interval = interval
         self.event_handlers = {}
+        self.logger = logging.getLogger("PlexTraktSync.WebSocketListener")
 
     def on(self, event_name, handler):
         if event_name not in self.event_handlers:
@@ -18,6 +21,7 @@ class WebSocketListener:
 
     def listen(self):
         def handler(data):
+            self.logger.debug(data)
             event_type = data['type']
             if event_type not in self.event_handlers:
                 return

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -66,6 +66,10 @@ class PlexLibraryItem:
         except ValueError:  # for py<3.6
             return date
 
+    def watch_progress(self, view_offset):
+        percent = view_offset / self.item.duration * 100
+        return percent
+
     @property
     @memoize
     def guid_is_imdb_legacy(self):

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -135,6 +135,10 @@ class PlexApi:
 
         return result
 
+    @memoize
+    def fetch_item(self, key: str):
+        return self.plex.library.fetchItem(f"/library/metadata/{key}")
+
     @property
     @memoize
     @nocache

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -137,7 +137,8 @@ class PlexApi:
 
     @memoize
     def fetch_item(self, key: str):
-        return self.plex.library.fetchItem(f"/library/metadata/{key}")
+        media = self.plex.library.fetchItem(f"/library/metadata/{key}")
+        return PlexLibraryItem(media)
 
     @property
     @memoize

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -128,6 +128,13 @@ class TraktApi:
         m.rate(rating)
 
     @nocache
+    @rate_limit()
+    def scrobble(self, media: Union[Movie, TVEpisode], percent: float):
+        progress = int(percent)
+        scrobbler = media.scrobble(progress, None, None)
+        return scrobbler
+
+    @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)
     def mark_watched(self, m, time):
         m.mark_as_seen(time)

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -137,9 +137,19 @@ class TraktApi:
 
     @nocache
     @rate_limit()
+    def scrobbler_pause(self, scrobbler: Scrobbler):
+        scrobbler.pause()
+
+    @nocache
+    @rate_limit()
     def scrobbler_update(self, scrobbler: Scrobbler, percent: float):
         progress = int(percent)
         scrobbler.update(progress)
+
+    @nocache
+    @rate_limit()
+    def scrobbler_stop(self, scrobbler: Scrobbler):
+        scrobbler.stop()
 
     @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -11,6 +11,7 @@ import trakt.movies
 from trakt.movies import Movie
 from trakt.tv import TVShow, TVSeason, TVEpisode
 from trakt.errors import OAuthException, ForbiddenException
+from trakt.sync import Scrobbler
 
 from plex_trakt_sync.logging import logging
 from plex_trakt_sync.decorators import memoize, nocache, rate_limit
@@ -133,6 +134,12 @@ class TraktApi:
         progress = int(percent)
         scrobbler = media.scrobble(progress, None, None)
         return scrobbler
+
+    @nocache
+    @rate_limit()
+    def scrobbler_update(self, scrobbler: Scrobbler, percent: float):
+        progress = int(percent)
+        scrobbler.update(progress)
 
     @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)


### PR DESCRIPTION
Builds on top of https://github.com/Taxel/PlexTraktSync/pull/148

This is mostly proof of concept (but it works!), therefore no readme update.

There's plenty of to optimize:
- skip events, in case laptop suspend/resume there's tons of messages from websocket that should be skipped
- code refactoring, isolate logic to own classes/methods/functions
- optimize on cpu, needs investigating what first
- the code is synchronous, maybe need to rewrite asynchronous
- the sleep(1) maybe is putting too much pressure on cpu
- scrobblng probably needs to emitted only on start/pause/stop, as trakt can itself continue counting play time
- optimize for reducing requests to trakt
- ... that's already a bunch!

NOTE: The Trakt app may need `scrobble` permission:
- https://trakt.docs.apiary.io/#reference/scrobble