### PR TITLE
Include logger name to log messages

### DIFF
--- a/plex_trakt_sync/commands/clear_collections.py
+++ b/plex_trakt_sync/commands/clear_collections.py
@@ -1,5 +1,5 @@
 import click
-from plex_trakt_sync.logging import logging
+from plex_trakt_sync.logging import logger
 from plex_trakt_sync.trakt_api import TraktApi
 
 
@@ -18,11 +18,11 @@ def clear_collections(confirm, dry_run):
     trakt = TraktApi()
 
     for movie in trakt.movie_collection:
-        logging.info(f"Deleting: {movie}")
+        logger.info(f"Deleting: {movie}")
         if not dry_run:
             trakt.remove_from_library(movie)
 
     for show in trakt.show_collection:
-        logging.info(f"Deleting: {show}")
+        logger.info(f"Deleting: {show}")
         if not dry_run:
             trakt.remove_from_library(show)

--- a/plex_trakt_sync/decorators/measure_time.py
+++ b/plex_trakt_sync/decorators/measure_time.py
@@ -1,4 +1,4 @@
-import logging
+from plex_trakt_sync.logging import logging, logger
 from contextlib import contextmanager
 from time import time
 
@@ -10,4 +10,4 @@ def measure_time(message, level=logging.INFO):
     timedelta = time() - start
 
     m, s = divmod(timedelta, 60)
-    logging.log(level, message + " in " + (m > 0) * "{:.0f} min ".format(m) + (s > 0) * "{:.1f} seconds".format(s))
+    logger.log(level, message + " in " + (m > 0) * "{:.0f} min ".format(m) + (s > 0) * "{:.1f} seconds".format(s))

--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from time import sleep, time
 from trakt.errors import RateLimitException
-from plex_trakt_sync.logging import logging
+from plex_trakt_sync.logging import logger
 
 last_time = None
 
@@ -27,7 +27,7 @@ def rate_limit(retries=5, delay=None):
         diff_time = time() - last_time
         if diff_time < delay:
             wait = delay - diff_time
-            logging.warning(
+            logger.warning(
                 f'Sleeping for {wait:.3f} seconds'
             )
             sleep(wait)
@@ -46,7 +46,7 @@ def rate_limit(retries=5, delay=None):
 
                     seconds = int(e.response.headers.get("Retry-After", 1))
                     retry += 1
-                    logging.warning(
+                    logger.warning(
                         f'RateLimitException for {fn}, retrying after {seconds} seconds (try: {retry}/{retries})'
                     )
                     sleep(seconds)

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -16,6 +16,7 @@ def initialize():
 
     # file handler can log down to debug messages
     file_handler = logging.FileHandler(log_file, 'w', 'utf-8')
+    file_handler.setFormatter(logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s"))
     file_handler.setLevel(logging.DEBUG)
 
     handlers = [

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -27,3 +27,5 @@ def initialize():
 
 
 initialize()
+
+logger = logging.getLogger('PlexTraktSync')

--- a/plex_trakt_sync/main.py
+++ b/plex_trakt_sync/main.py
@@ -16,7 +16,7 @@ from json.decoder import JSONDecodeError
 
 from plex_trakt_sync import pytrakt_extensions
 from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.logging import logging
+from plex_trakt_sync.logging import logger as logging
 from plex_trakt_sync.requests_cache import requests_cache
 
 trakt_post_wait = 1.2  # delay in sec between trakt post requests to respect rate limit

--- a/plex_trakt_sync/plex_server.py
+++ b/plex_trakt_sync/plex_server.py
@@ -1,6 +1,6 @@
 import plexapi.server
 from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.logging import logging
+from plex_trakt_sync.logging import logger
 
 
 def get_plex_server():
@@ -37,7 +37,7 @@ def get_plex_server():
                 CONFIG["PLEX_BASEURL"] = new_plex_baseurl
                 CONFIG["PLEX_FALLBACKURL"] = plex_fallbackurl
                 CONFIG.save()
-                logging.info("Plex server url changed to {}".format(new_plex_baseurl))
+                logger.info("Plex server url changed to {}".format(new_plex_baseurl))
             except Exception:
                 pass
         if server is None and plex_baseurl[:5] == "https":
@@ -45,7 +45,7 @@ def get_plex_server():
             try:  # 2
                 server = plexapi.server.PlexServer(
                     token=plex_token, baseurl=new_plex_baseurl)
-                logging.warning("Switched to Plex unsecure connection because of SSLError.")
+                logger.warning("Switched to Plex unsecure connection because of SSLError.")
             except Exception:
                 pass
     except Exception as e:
@@ -55,9 +55,9 @@ def get_plex_server():
         try:  # 3
             server = plexapi.server.PlexServer(
                 token=plex_token, baseurl=plex_fallbackurl)
-            logging.warning("No response from {}, fallback to {}".format(plex_baseurl, plex_fallbackurl))
+            logger.warning("No response from {}, fallback to {}".format(plex_baseurl, plex_fallbackurl))
         except Exception:
-            logging.error(m)
+            logger.error(m)
             print(m)
             exit(1)
     return server

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -13,7 +13,7 @@ from trakt.tv import TVShow, TVSeason, TVEpisode
 from trakt.errors import OAuthException, ForbiddenException
 from trakt.sync import Scrobbler
 
-from plex_trakt_sync.logging import logging
+from plex_trakt_sync.logging import logger
 from plex_trakt_sync.decorators import memoize, nocache, rate_limit
 from plex_trakt_sync.config import CONFIG
 
@@ -33,7 +33,7 @@ class TraktApi:
         try:
             return trakt.users.User('me')
         except (OAuthException, ForbiddenException) as e:
-            logging.fatal("Trakt authentication error: {}".format(str(e)))
+            logger.fatal("Trakt authentication error: {}".format(str(e)))
             raise e
 
     @property

--- a/plex_trakt_sync/trakt_list_util.py
+++ b/plex_trakt_sync/trakt_list_util.py
@@ -3,7 +3,7 @@ from trakt.errors import NotFoundException, OAuthException
 from trakt.movies import Movie
 from trakt.tv import TVEpisode
 from plexapi.video import Episode
-import requests_cache
+from plex_trakt_sync.requests_cache import requests_cache
 from plex_trakt_sync.logging import logger
 from plexapi.exceptions import BadRequest, NotFound
 from itertools import count

--- a/plex_trakt_sync/trakt_list_util.py
+++ b/plex_trakt_sync/trakt_list_util.py
@@ -4,7 +4,7 @@ from trakt.movies import Movie
 from trakt.tv import TVEpisode
 from plexapi.video import Episode
 import requests_cache
-import logging
+from plex_trakt_sync.logging import logger
 from plexapi.exceptions import BadRequest, NotFound
 from itertools import count
 
@@ -27,16 +27,16 @@ class TraktList():
         if rank is not None:
             self.plex_items.append((rank, plex_item))
             if isinstance(plex_item, Episode):
-                logging.info('Show [{} ({})]: {} added to list {}'.format(plex_item.show().title, plex_item.show().year, plex_item.seasonEpisode, self.name))
+                logger.info('Show [{} ({})]: {} added to list {}'.format(plex_item.show().title, plex_item.show().year, plex_item.seasonEpisode, self.name))
             else:
-                logging.info('Movie [{} ({})]: added to list {}'.format(plex_item.title, plex_item.year, self.name))
+                logger.info('Movie [{} ({})]: added to list {}'.format(plex_item.title, plex_item.year, self.name))
 
     def updatePlexList(self, plex):
         with requests_cache.disabled():
             try:
                 plex.playlist(self.name).delete()
             except (NotFound, BadRequest):
-                logging.error("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
+                logger.error("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
                 pass
             if len(self.plex_items) > 0:
                 _, plex_items_sorted = zip(*sorted(dict(reversed(self.plex_items)).items()))
@@ -50,13 +50,13 @@ class TraktListUtil():
     def addList(self, username, listname, traktid_list=None):
         if traktid_list is not None:
             self.lists.append(TraktList.from_traktid_list(listname, traktid_list))
-            logging.info("Downloaded List {}".format(listname))
+            logger.info("Downloaded List {}".format(listname))
             return
         try:
             self.lists.append(TraktList(username, listname))
-            logging.info("Downloaded List {}".format(listname))
+            logger.info("Downloaded List {}".format(listname))
         except (NotFoundException, OAuthException):
-            logging.warning("Failed to get list {} by user {}".format(listname, username))
+            logger.warning("Failed to get list {} by user {}".format(listname, username))
 
     def addPlexItemToLists(self, traktid, plex_item):
         for l in self.lists:


### PR DESCRIPTION
```
2021-04-06 20:27:10,368 DEBUG[trakt.core]:method, url :: get, https://api-v2launch.trakt.tv/shows/1/seasons?extended=episodes
2021-04-06 20:27:10,371 DEBUG[urllib3.connectionpool]:Starting new HTTPS connection (1): api-v2launch.trakt.tv:443
2021-04-06 20:27:10,497 DEBUG[urllib3.connectionpool]:https://api-v2launch.trakt.tv:443 "GET /shows/1/seasons?extended=episodes HTTP/1.1" 200 None
2021-04-06 20:27:10,506 DEBUG[trakt.core]:RESPONSE [get] (https://api-v2launch.trakt.tv/shows/1/seasons?extended=episodes): <Response [200]>
2021-04-06 20:27:11,392 INFO[PlexTraktSync]:Completed full sync in 53.3 seconds
```

This affects only file logger, stdout logger is not affected