### PR TITLE
Fix py 3.7 compatibility

### DIFF
--- a/plex_trakt_sync/decorators/memoize.py
+++ b/plex_trakt_sync/decorators/memoize.py
@@ -3,4 +3,8 @@ try:
 except ImportError:
     # For py<3.9
     # https://docs.python.org/3.9/library/functools.html
-    from functools import lru_cache as memoize
+    from functools import lru_cache
+
+
+    def memoize(user_function):
+        return lru_cache(maxsize=None)(user_function)


### PR DESCRIPTION
Revert "Use lru_cache directly for py<3.8"

This reverts commit 86d3923e81b029b7380ed2ac5307ba75f56a466d.