### PR TITLE
Update last_time when rate limiting POST requests

### DIFF
--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -31,6 +31,7 @@ def rate_limit(retries=5, delay=None):
                 f'Sleeping for {wait:.3f} seconds'
             )
             sleep(wait)
+        last_time = time()
 
     def decorator(fn):
         @wraps(fn)


### PR DESCRIPTION
The `last_time` was not updated, therefore the evasive `sleep()` calls to avoid the rate limit being hit, did not work.