### PR TITLE
Fill collected_at for from Plex library

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -18,7 +18,7 @@ def sync_collection(pm, tm, trakt: TraktApi, trakt_movie_collection):
         return
 
     logger.info(f"Add to Trakt Collection: {pm}")
-    trakt.add_to_collection(tm)
+    trakt.add_to_collection(tm, pm)
 
 
 def sync_show_collection(pm, tm, pe, te, trakt: TraktApi):
@@ -31,7 +31,7 @@ def sync_show_collection(pm, tm, pe, te, trakt: TraktApi):
         return
 
     logger.info(f"Add to Trakt Collection: {pm} S{pe.seasonNumber:02}E{pe.index:02}")
-    trakt.add_to_collection(te.instance)
+    trakt.add_to_collection(te.instance, pe)
 
 
 def sync_ratings(pm, tm, plex: PlexApi, trakt: TraktApi):

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -66,16 +66,7 @@ class PlexLibraryItem:
     @property
     @memoize
     def seen_date(self):
-        media = self.item
-        if not media.lastViewedAt:
-            raise ValueError('lastViewedAt is not set')
-
-        date = media.lastViewedAt
-
-        try:
-            return date.astimezone(datetime.timezone.utc)
-        except ValueError:  # for py<3.6
-            return date
+        return self.date_value(self.item.lastViewedAt)
 
     def watch_progress(self, view_offset):
         percent = view_offset / self.item.duration * 100
@@ -88,6 +79,15 @@ class PlexLibraryItem:
 
         # old item, like imdb 'tt0112253'
         return guid[0:2] == "tt" and guid[2:].isnumeric()
+
+    def date_value(self, date):
+        if not date:
+            raise ValueError("Value can't be None")
+
+        try:
+            return date.astimezone(datetime.timezone.utc)
+        except ValueError:  # for py<3.6
+            return date
 
     def __repr__(self):
         return "<%s:%s:%s>" % (self.provider, self.id, self.item)

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -97,6 +97,10 @@ class PlexLibraryItem:
     def __repr__(self):
         return "<%s:%s:%s>" % (self.provider, self.id, self.item)
 
+    def to_json(self):
+        return {
+            "collected_at": self.collected_at,
+        }
 
 class PlexLibrarySection:
     def __init__(self, section: LibrarySection):

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -68,6 +68,11 @@ class PlexLibraryItem:
     def seen_date(self):
         return self.date_value(self.item.lastViewedAt)
 
+    @property
+    @memoize
+    def collected_at(self):
+        return self.date_value(self.item.addedAt)
+
     def watch_progress(self, view_offset):
         percent = view_offset / self.item.duration * 100
         return percent

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -5,6 +5,7 @@ from plexapi.library import MovieSection, ShowSection, LibrarySection
 from plexapi.video import Movie, Show
 from plex_trakt_sync.decorators import memoize, nocache
 from plex_trakt_sync.config import CONFIG
+from trakt.utils import timestamp
 
 
 class PlexLibraryItem:
@@ -99,8 +100,9 @@ class PlexLibraryItem:
 
     def to_json(self):
         return {
-            "collected_at": self.collected_at,
+            "collected_at": timestamp(self.collected_at),
         }
+
 
 class PlexLibrarySection:
     def __init__(self, section: LibrarySection):

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -170,14 +170,14 @@ class TraktApi:
         # https://github.com/moogar0880/PyTrakt/issues/143
         if m.media_type == "movies":
             json = {
-                m.media_type: dict(
+                m.media_type: [dict(
                     **m.ids,
                     **pm.to_json(),
-                ),
+                )],
             }
-            trakt.sync.add_to_collection(json)
+            return trakt.sync.add_to_collection(json)
         else:
-            m.add_to_library()
+            return m.add_to_library()
 
     @memoize
     @nocache

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -165,8 +165,12 @@ class TraktApi:
 
     @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)
-    def add_to_collection(self, m):
-        m.add_to_library()
+    def add_to_collection(self, m, pm: PlexLibraryItem):
+        # support is missing, compose custom json ourselves
+        # https://github.com/moogar0880/PyTrakt/issues/143
+        json = m.to_json()
+        json.update(pm.to_json())
+        trakt.sync.add_to_collection(json)
 
     @memoize
     @nocache

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -168,9 +168,16 @@ class TraktApi:
     def add_to_collection(self, m, pm: PlexLibraryItem):
         # support is missing, compose custom json ourselves
         # https://github.com/moogar0880/PyTrakt/issues/143
-        json = m.to_json()
-        json.update(pm.to_json())
-        trakt.sync.add_to_collection(json)
+        if m.media_type == "movies":
+            json = {
+                m.media_type: dict(
+                    **m.ids,
+                    **pm.to_json(),
+                ),
+            }
+            trakt.sync.add_to_collection(json)
+        else:
+            m.add_to_library()
 
     @memoize
     @nocache

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -171,6 +171,8 @@ class TraktApi:
         if m.media_type == "movies":
             json = {
                 m.media_type: [dict(
+                    title=m.title,
+                    year=m.year,
                     **m.ids,
                     **pm.to_json(),
                 )],


### PR DESCRIPTION
When started to look at https://github.com/Taxel/PlexTraktSync/issues/117, I noticed the `collected_at` was not filled at all. This uses `addedAt` value from Plex when adding items to "Collection" in Trakt.

This adds `collected_at` to movies only (not tv episodes)

refs:
- https://trakt.docs.apiary.io/#reference/sync/add-to-collection/add-items-to-collection