### PR TITLE
Restart websocket if connection was closed

### DIFF
--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -29,6 +29,10 @@ class WebSocketListener:
             for handler in self.event_handlers[event_type]:
                 handler(data)
 
-        notifier = self.plex.startAlertListener(callback=handler)
-        while notifier.is_alive():
+        while True:
+            notifier = self.plex.startAlertListener(callback=handler)
+            while notifier.is_alive():
+                sleep(self.interval)
+
+            self.logger.debug(f"Listener finished. Restarting in {self.interval}")
             sleep(self.interval)


### PR DESCRIPTION
```
$ ./plex_trakt_sync.sh watch
Listening for events!
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: [Errno 61] Connection refused
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
ERROR: AlertListener Error: Connection is already closed.
INFO: Starting AlertListener: ws://localhost:32400/:/websockets/notifications?X-Plex-Token=<hidden>
```