### PR TITLE
Add media_type to collection metadata when adding media to collections

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -193,6 +193,7 @@ class PlexLibraryItem:
     def to_json(self):
         return {
             "collected_at": timestamp(self.collected_at),
+            "media_type": "digital",
         }
 
 


### PR DESCRIPTION
Requires:
- https://github.com/Taxel/PlexTraktSync/pull/211

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/117