### PR TITLE
Use property type to check media type

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -23,18 +23,12 @@ class PlexLibraryItem:
     @property
     @memoize
     def type(self):
-        if type(self.item) is Movie:
-            return "movies"
-        if type(self.item) is Show:
-            return "shows"
+        return f"{self.media_type}s"
 
     @property
     @memoize
     def media_type(self):
-        if type(self.item) is Movie:
-            return "movie"
-        if type(self.item) is Show:
-            return "show"
+        return self.item.type
 
     @property
     @memoize


### PR DESCRIPTION
This allows better mocking of the item not relying on specific class

_Extracted from https://github.com/Taxel/PlexTraktSync/pull/215_