### PR TITLE
Upgrade requests-cache to 0.6.x

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "==7.1.2"
 plexapi = "==4.5.0"
 python-dotenv = "==0.15.0"
 python-git-info = "==0.6.1"
-requests-cache = "==0.5.2"
+requests-cache = "==0.6.0"
 trakt = "==3.1.0"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ click = "==7.1.2"
 plexapi = "==4.5.0"
 python-dotenv = "==0.15.0"
 python-git-info = "==0.6.1"
-requests-cache = "==0.6.0"
+requests-cache = "==0.6.3"
 trakt = "==3.1.0"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e15535215392894422f8613d1e96901b69d119d6d84c5eed61642ffc11f3df57"
+            "sha256": "a7198f235d31d57dd1775bc1c2f1017ac8ea09b5b415901c6230ac97867562de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -96,11 +96,11 @@
         },
         "requests-cache": {
             "hashes": [
-                "sha256:5d3c3cfe86b37d99ecbf0e338396044e92d7efed257d3925ca4bca2bb312dff4",
-                "sha256:ba9b8b7893b15464d2bd35c40098c6f7561d77416068f15932ea9d223e1559ed"
+                "sha256:0b9b5555b3b2ecda74a9aa5abd98174bc7332de2e1d32f9f8f056583b01d6e99",
+                "sha256:6e28e461873415036ea383c2414691cf1164cb01391ad4c45b84b3ebf0fb9287"
             ],
             "index": "pypi",
-            "version": "==0.6.0"
+            "version": "==0.6.3"
         },
         "requests-oauthlib": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b782af96bccb52b0fa8e8384d91d93bef4f2dee0df97b960fa8c4c9cd8b98e4d"
+            "sha256": "e15535215392894422f8613d1e96901b69d119d6d84c5eed61642ffc11f3df57"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,6 +47,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.0"
+        },
         "oauthlib": {
             "hashes": [
                 "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
@@ -88,11 +96,11 @@
         },
         "requests-cache": {
             "hashes": [
-                "sha256:813023269686045f8e01e2289cc1e7e9ae5ab22ddd1e2849a9093ab3ab7270eb",
-                "sha256:81e13559baee64677a7d73b85498a5a8f0639e204517b5d05ff378e44a57831a"
+                "sha256:5d3c3cfe86b37d99ecbf0e338396044e92d7efed257d3925ca4bca2bb312dff4",
+                "sha256:ba9b8b7893b15464d2bd35c40098c6f7561d77416068f15932ea9d223e1559ed"
             ],
             "index": "pypi",
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         },
         "requests-oauthlib": {
             "hashes": [
@@ -102,6 +110,14 @@
             ],
             "version": "==1.3.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
         "trakt": {
             "hashes": [
                 "sha256:6387bb3488afef523dd52056c502d9375120561da55f3a37d843daeb6a2f5f4a",
@@ -109,6 +125,14 @@
             ],
             "index": "pypi",
             "version": "==3.1.0"
+        },
+        "url-normalize": {
+            "hashes": [
+                "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2",
+                "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.4.3"
         },
         "urllib3": {
             "hashes": [

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from plex_trakt_sync.commands.cache import cache
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
 from plex_trakt_sync.commands.plex_login import plex_login
@@ -18,6 +19,7 @@ def cli(ctx):
         sync()
 
 
+cli.add_command(cache)
 cli.add_command(clear_collections)
 cli.add_command(inspect)
 cli.add_command(plex_login)

--- a/plex_trakt_sync/commands/cache.py
+++ b/plex_trakt_sync/commands/cache.py
@@ -1,0 +1,8 @@
+import click
+
+@click.command()
+def cache():
+    """
+    Manage and analyze Requests Cache.
+    """
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click==7.1.2
 plexapi==4.5.0
 python-dotenv==0.15.0
 python-git-info==0.6.1
-requests-cache==0.6.0
+requests-cache==0.6.3
 trakt==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click==7.1.2
 plexapi==4.5.0
 python-dotenv==0.15.0
 python-git-info==0.6.1
-requests-cache==0.5.2
+requests-cache==0.6.0
 trakt==3.1.0


### PR DESCRIPTION
- [ ] previous cache will all expire on upgrade
- [x] currently (requests-cache 0.6.0) crashes loading old cache (fixed)
- [x] currently (requests-cache 0.6.0) it logs too much, needs to patch log level (fixed)

refs:
- https://github.com/reclosedev/requests-cache/issues/224
- https://github.com/reclosedev/requests-cache/issues/223