### PR TITLE
Fix tv episodes matching for new tv agent

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -36,6 +36,7 @@ class PlexLibraryItem:
             return "imdb"
         x = self.guid.split("://")[0]
         x = x.replace("com.plexapp.agents.", "")
+        x = x.replace("tv.plex.agents.", "")
         x = x.replace("themoviedb", "tmdb")
         x = x.replace("thetvdb", "tvdb")
         if x == "xbmcnfo":

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -22,18 +22,12 @@ class PlexLibraryItem:
     @property
     @memoize
     def type(self):
-        if type(self.item) is Movie:
-            return "movies"
-        if type(self.item) is Show:
-            return "shows"
+        return f"{self.media_type}s"
 
     @property
     @memoize
     def media_type(self):
-        if type(self.item) is Movie:
-            return "movie"
-        if type(self.item) is Show:
-            return "show"
+        return self.item.type
 
     @property
     @memoize

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -14,7 +14,7 @@ class PlexLibraryItem:
     @property
     @memoize
     def guid(self):
-        if self.item.guid.startswith('plex://movie/'):
+        if self.item.guid.startswith('plex://'):
             if len(self.item.guids) > 0:
                 return self.item.guids[0].id
         return self.item.guid

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -192,7 +192,7 @@ class TraktApi:
             raise ValueError(f"Unable parse search result for {media.provider}/{media.id}: {e.doc!r}") from e
         except ValueError as e:
             # Search_type must be one of ('trakt', ..., 'imdb', 'tmdb', 'tvdb')
-            raise ValueError(f"Invalid id_type: {media.provider}") from e
+            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}'") from e
         # look for the first wanted type in the results
         for m in search:
             if m.media_type == media.type:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -192,7 +192,7 @@ class TraktApi:
             raise ValueError(f"Unable parse search result for {media.provider}/{media.id}: {e.doc!r}") from e
         except ValueError as e:
             # Search_type must be one of ('trakt', ..., 'imdb', 'tmdb', 'tvdb')
-            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}'") from e
+            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}': {e}") from e
         # look for the first wanted type in the results
         for m in search:
             if m.media_type == media.type:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -192,7 +192,7 @@ class TraktApi:
             raise ValueError(f"Unable parse search result for {media.provider}/{media.id}: {e.doc!r}") from e
         except ValueError as e:
             # Search_type must be one of ('trakt', ..., 'imdb', 'tmdb', 'tvdb')
-            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}': {e}") from e
+            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}', guids: '{media.item.guids}': {e}") from e
         # look for the first wanted type in the results
         for m in search:
             if m.media_type == media.type:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import sys
+from os.path import dirname, abspath
+
+# Add our module to system path
+sys.path.insert(0, dirname(dirname(abspath(__file__))))

--- a/tests/test_new_agent.py
+++ b/tests/test_new_agent.py
@@ -27,3 +27,17 @@ def test_tv_lookup():
     assert m.provider == 'imdb'
     assert m.id == 'tt2661044'
     assert m.media_type == 'show'
+
+
+def test_tv_lookup_none():
+    m = PlexLibraryItem(make(
+        cls='plexapi.video.Show',
+        guid='tv.plex.agents.none://68178',
+        guids=[
+        ],
+        type='show',
+    ))
+
+    assert m.provider == 'none'
+    assert m.id == '68178'
+    assert m.media_type == 'show'

--- a/tests/test_new_agent.py
+++ b/tests/test_new_agent.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3 -m pytest
+from plex_trakt_sync.plex_api import PlexLibraryItem
+from plex_trakt_sync.trakt_api import TraktApi
+
+
+def make(cls=None, **kwargs):
+    cls = cls if cls is not None else "object"
+    # https://stackoverflow.com/a/2827726/2314626
+    return type(cls, (object,), kwargs)
+
+
+trakt = TraktApi()
+
+
+def test_tv_lookup():
+    m = PlexLibraryItem(make(
+        cls='plexapi.video.Show',
+        guid='plex://show/5d9c085ae98e47001eb0d74f',
+        guids=[
+            make(id='imdb://tt2661044'),
+            make(id='tmdb://48866'),
+            make(id='tvdb://268592'),
+        ],
+        type='show',
+    ))
+
+    assert m.provider == 'imdb'
+    assert m.id == 'tt2661044'
+    assert m.media_type == 'show'


### PR DESCRIPTION
Fixes error reported here:
- https://github.com/Taxel/PlexTraktSync/issues/220#issuecomment-817190974

```
  File "/Users/bink/scripts/PlexTraktSyncTV/plex_trakt_sync/decorators/rate_limit.py", line 43, in wrapper
    return fn(*args, **kwargs)
  File "/Users/bink/scripts/PlexTraktSyncTV/plex_trakt_sync/trakt_api.py", line 195, in find_movie
    raise ValueError(f"Invalid id_type: {media.provider}") from e
ValueError: Invalid id_type: plex
```