### PR TITLE
Add error catching of NotFound plex items

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -95,13 +95,9 @@ def for_each_pair(sections, trakt: TraktApi):
     for section in sections:
         with measure_time(f"Processing section {section.title}"):
             for pm in section.items():
-                if not pm.provider:
-                    logger.error(f'[{pm}]: Unrecognized GUID {pm.guid}')
-                    continue
-
                 tm = trakt.find_movie(pm)
                 if tm is None:
-                    logger.warning(f"[{pm})]: Not found from Trakt. Skipping")
+                    logger.warning(f"[{pm})]: Not found on Trakt. Skipping")
                     continue
 
                 yield pm, tm

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -1,8 +1,11 @@
 import datetime
 from typing import Union
 
+from plexapi.exceptions import NotFound
 from plexapi.library import MovieSection, ShowSection, LibrarySection
 from plexapi.video import Movie, Show
+
+from plex_trakt_sync.logging import logger
 from plex_trakt_sync.decorators import memoize, nocache
 from plex_trakt_sync.config import CONFIG
 
@@ -108,7 +111,13 @@ class PlexLibrarySection:
     def items(self):
         result = []
         for item in (PlexLibraryItem(x) for x in self.all()):
-            if item.provider in ["local", "none", "agents.none"]:
+            try:
+                provider = item.provider
+            except NotFound as e:
+                logger.error(f"{e}, skipping {item}")
+                continue
+
+            if provider in ["local", "none", "agents.none"]:
                 continue
             result.append(item)
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -24,6 +24,11 @@ class PlexLibraryItem:
 
     @property
     @memoize
+    def guids(self):
+        return self.item.guids
+
+    @property
+    @memoize
     def type(self):
         return f"{self.media_type}s"
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -124,6 +124,11 @@ class PlexLibrarySection:
 
             if provider in ["local", "none", "agents.none"]:
                 continue
+
+            if provider not in ["imdb", "tmdb", "tvdb"]:
+                logger.error(f"{item}: Unable to parse a valid provider from guid:'{item.guid}', guids:{item.guids}")
+                continue
+
             result.append(item)
 
         return result


### PR DESCRIPTION
Catch an error from `NotFound` item from Plex:
- https://github.com/Taxel/PlexTraktSync/issues/220#issue-855138799