### PR TITLE
Add command to log in to Plex

### DIFF
--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -2,6 +2,7 @@ import click
 
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
+from plex_trakt_sync.commands.plex_login import plex_login
 from plex_trakt_sync.commands.sync import sync
 from plex_trakt_sync.commands.watch import watch
 
@@ -18,5 +19,6 @@ def cli(ctx):
 
 cli.add_command(clear_collections)
 cli.add_command(inspect)
+cli.add_command(plex_login)
 cli.add_command(sync)
 cli.add_command(watch)

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -1,15 +1,76 @@
 import click
-from plexapi.server import PlexServer
+from click import Choice
+from plexapi.exceptions import Unauthorized
+from plexapi.myplex import MyPlexAccount
 from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.plex_api import PlexApi
+
+PROMPT_PLEX_PASSWORD = click.style("Please enter your Plex password", fg="yellow")
+PROMPT_PLEX_USERNAME = click.style("Please enter your Plex username", fg="yellow")
+PROMPT_PLEX_RELOGIN = click.style("You already logged in to Plex, do you want to log in again?", fg="yellow")
+PROMPT_MANAGED_USER = click.style("Do you want to use managed user instead of main account?", fg="yellow")
+
+
+def myplex_login(username, password):
+    while True:
+        username = click.prompt(PROMPT_PLEX_USERNAME, type=str, default=username)
+        password = click.prompt(PROMPT_PLEX_PASSWORD, type=str, default=password, hide_input=True, show_default=False)
+        try:
+            return MyPlexAccount(username, password)
+        except Unauthorized as e:
+            click.secho(f"Logging failed: {e} Try again.", fg="red")
+
+
+def choose_managed_user(account: MyPlexAccount):
+    users = [u.title for u in account.users() if u.friend]
+    if not users:
+        return None
+
+    click.secho("Managed user(s) found:", fg="green")
+    users = sorted(users)
+    for user in users:
+        click.echo(f"- {user}")
+
+    if not click.confirm(PROMPT_MANAGED_USER):
+        return None
+
+    # choice = prompt_choice(users)
+    user = click.prompt(
+        click.style("Please select:", fg="yellow"),
+        type=Choice(users),
+        show_default=True,
+    )
+
+    # Sanity check, even the user can't input invalid user
+    user_account = account.user(user)
+    if user_account:
+        return user
+
+    return None
 
 
 @click.command()
-def plex_login():
+@click.option("--username", help="Plex login", default=CONFIG["PLEX_USERNAME"])
+@click.option("--password", help="Plex password")
+def plex_login(username, password):
     """
     Log in to Plex Account
     """
 
     if CONFIG["PLEX_TOKEN"]:
-        if not click.confirm("You already logged in to Plex, do you want to log in again?"):
+        if not click.confirm(PROMPT_PLEX_RELOGIN, default=True):
             return
+
+    account = myplex_login(username, password)
+    click.secho("Login success!", fg="green")
+
+    managed_user = choose_managed_user(account)
+    if managed_user:
+        user = managed_user
+        token = account.user(managed_user).get_token(account.machineIdentifier)
+    else:
+        user = username
+        token = account.machineIdentifier
+
+    baseurl = account._baseurl
+
+    print(f"User={user}, token={token}, {baseurl}")

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -126,14 +126,15 @@ def plex_login(username, password):
     account = myplex_login(username, password)
     click.secho("Login to MyPlex success!", fg="green")
 
-    managed_user = choose_managed_user(account)
-    if managed_user:
-        user = managed_user
-        token = account.user(managed_user).get_token(account.authenticationToken)
-    else:
-        user = username
-
     [server, plex] = choose_server(account)
-    click.secho(f"Connection to {plex.machineIdentifier} success!", fg="green")
+    click.secho(f"Connection to {plex.friendlyName} established successfully!", fg="green")
 
-    print(f"User={user}, token={server.accessToken}, {plex._baseurl}")
+    token = server.accessToken
+    user = username
+    if server.owned:
+        managed_user = choose_managed_user(account)
+        if managed_user:
+            user = managed_user
+            token = account.user(managed_user).get_token(plex.machineIdentifier)
+
+    print(f"User={user}, token={token}, {plex._baseurl}")

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -1,12 +1,10 @@
-from http.client import RemoteDisconnected
 from typing import List
 
 import click
 from click import Choice
-from plexapi.exceptions import Unauthorized
+from plexapi.exceptions import Unauthorized, NotFound
 from plexapi.myplex import MyPlexAccount, MyPlexResource
 from plexapi.server import PlexServer
-from urllib3.exceptions import ConnectTimeoutError
 
 from plex_trakt_sync.config import CONFIG
 from plex_trakt_sync.style import prompt, error, success, title, comment
@@ -110,7 +108,7 @@ def choose_server(account: MyPlexAccount):
             # Validate connection again, the way we connect
             plex = PlexServer(token=server.accessToken, baseurl=plex._baseurl)
             return [server, plex]
-        except (ConnectTimeoutError, RemoteDisconnected, Exception) as e:
+        except NotFound as e:
             click.secho(f"{e}, Try another server, {type(e)}")
 
 

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -117,7 +117,7 @@ def choose_server(account: MyPlexAccount):
 @click.option("--password", help="Plex password")
 def plex_login(username, password):
     """
-    Log in to Plex Account
+    Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.
     """
 
     if CONFIG["PLEX_TOKEN"]:

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -103,6 +103,7 @@ def choose_server(account: MyPlexAccount):
         try:
             server = pick_server(account)
             # Connect to obtain baseUrl
+            click.secho(f"Attempting to connect to {server.name}. This may take time and emit some errors.", fg="yellow")
             plex = server.connect()
             # Validate connection again, the way we connect
             plex = PlexServer(token=server.accessToken, baseurl=plex._baseurl)

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -9,3 +9,7 @@ def plex_login():
     """
     Log in to Plex Account
     """
+
+    if CONFIG["PLEX_TOKEN"]:
+        if not click.confirm("You already logged in to Plex, do you want to log in again?"):
+            return

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -124,16 +124,16 @@ def plex_login(username, password):
             return
 
     account = myplex_login(username, password)
-    click.secho("Login success!", fg="green")
+    click.secho("Login to MyPlex success!", fg="green")
 
     managed_user = choose_managed_user(account)
     if managed_user:
         user = managed_user
-        token = account.user(managed_user).get_token(account.machineIdentifier)
+        token = account.user(managed_user).get_token(account.authenticationToken)
     else:
         user = username
-        token = account.machineIdentifier
 
-    baseurl = account._baseurl
+    [server, plex] = choose_server(account)
+    click.secho(f"Connection to {plex.machineIdentifier} success!", fg="green")
 
-    print(f"User={user}, token={token}, {baseurl}")
+    print(f"User={user}, token={server.accessToken}, {plex._baseurl}")

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -1,0 +1,11 @@
+import click
+from plexapi.server import PlexServer
+from plex_trakt_sync.config import CONFIG
+from plex_trakt_sync.plex_api import PlexApi
+
+
+@click.command()
+def plex_login():
+    """
+    Log in to Plex Account
+    """

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -13,6 +13,7 @@ PROMPT_PLEX_PASSWORD = prompt("Please enter your Plex password")
 PROMPT_PLEX_USERNAME = prompt("Please enter your Plex username")
 PROMPT_PLEX_RELOGIN = prompt("You already have Plex Access Token, do you want to log in again?")
 PROMPT_MANAGED_USER = prompt("Do you want to use managed user instead of main account?")
+SUCCESS_MESSAGE = success("Plex Media Server Authentication Token and base URL have been added to .env file")
 
 
 def myplex_login(username, password):
@@ -138,4 +139,10 @@ def plex_login(username, password):
             user = managed_user
             token = account.user(managed_user).get_token(plex.machineIdentifier)
 
-    print(f"User={user}, token={token}, {plex._baseurl}")
+    CONFIG["PLEX_USERNAME"] = user
+    CONFIG["PLEX_TOKEN"] = token
+    CONFIG["PLEX_BASEURL"] = plex._baseurl
+    CONFIG["PLEX_FALLBACKURL"] = "http://localhost:32400"
+    CONFIG.save()
+
+    click.echo(SUCCESS_MESSAGE)

--- a/plex_trakt_sync/style.py
+++ b/plex_trakt_sync/style.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+import click
+
+title = partial(click.style, fg="yellow")
+prompt = partial(click.style, fg="yellow")
+success = partial(click.style, fg="green")
+error = partial(click.style, fg="red")
+comment = partial(click.style, fg="cyan")


### PR DESCRIPTION
```
➔ ./plex_trakt_sync.sh plex-login --help
Usage: main.py plex-login [OPTIONS]

  Log in to Plex Account

Options:
  --username TEXT  Plex login
  --password TEXT  Plex password
  --help           Show this message and exit.
```

the command line options are optional, they are asked interactively.

Similarly to https://github.com/Taxel/PlexTraktSync/pull/243