### PR TITLE
Group API calls to add items to Trakt collection

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -178,6 +178,8 @@ def sync_all(movies=True, tv=True):
     with measure_time("Updated plex watchlist"):
         listutil.updatePlexLists(server)
 
+    trakt.flush()
+
 
 @click.command()
 @click.option(

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -218,3 +218,26 @@ class TraktApi:
                 return m
 
         return None
+
+
+class TraktBatch:
+    def __init__(self, trakt: TraktApi):
+        self.trakt = trakt
+        self.collection = {}
+
+    @nocache
+    @rate_limit(delay=TRAKT_POST_DELAY)
+    def submit_collection(self):
+        try:
+            return trakt.sync.add_to_collection(self.collection)
+        finally:
+            self.collection.clear()
+
+    def add_to_collection(self, media_type: str, item):
+        """
+        Add item of media_type to collection
+        """
+        if media_type not in self.collection:
+            self.collection[media_type] = []
+
+        self.collection[media_type].append(item)

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -231,6 +231,9 @@ class TraktBatch:
     @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)
     def submit_collection(self):
+        if not len(self.collection):
+            return None
+
         try:
             return trakt.sync.add_to_collection(self.collection)
         finally:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -235,7 +235,9 @@ class TraktBatch:
             return None
 
         try:
-            return trakt.sync.add_to_collection(self.collection)
+            result = trakt.sync.add_to_collection(self.collection)
+            if result:
+                logger.info(f"Updated Trakt collection: {result}")
         finally:
             self.collection.clear()
 


### PR DESCRIPTION
This reduces API calls made to Trakt API to add items to collection to 1 (or 0).

This also reports summary of changes made:
```
INFO: Updated Trakt collection: {'added': {'episodes': 15}}
INFO: Completed full sync in 45.0 seconds
```

this saved 14 POST calls to Trakt, possibly reducing run time of 13 seconds.