### PR TITLE
Add semantic styles helpers

### DIFF
--- a/plex_trakt_sync/style.py
+++ b/plex_trakt_sync/style.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+import click
+
+title = partial(click.style, fg="yellow")
+prompt = partial(click.style, fg="yellow")
+success = partial(click.style, fg="green")
+error = partial(click.style, fg="red")
+comment = partial(click.style, fg="cyan")


### PR DESCRIPTION
This allows to use styles like "error", "success" so they be colored identically, and in the future can change style by changing style, not code:

```py
import plex_trakt_sync.style

PROMPT_TRAKT_CLIENT_SECRET = style.prompt("Please enter your client secret")
TRAKT_LOGIN_SUCCESS = style.success(
    "You are now logged into Trakt. "
    "Your Trakt credentials have been added in .env and .pytrakt.json files."
)
```