### PR TITLE
Update find_by_media to support legacy episode format

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -61,6 +61,30 @@ class PlexLibraryItem:
 
     @property
     @memoize
+    def is_episode(self):
+        """
+        Return true of the id is in form of <show>/<season>/<episode>
+        """
+        parts = self.id.split("/")
+        if len(parts) == 3 and all(x.isnumeric() for x in parts):
+            return True
+
+        return False
+
+    @property
+    @memoize
+    def show_id(self):
+        if not self.is_episode:
+            raise ValueError("show_id is not valid for non-episodes")
+
+        show = self.id.split("/", 1)[0]
+        if not show.isnumeric():
+            raise ValueError(f"show_id is not numeric: {show}")
+
+        return int(show)
+
+    @property
+    @memoize
     def rating(self):
         return int(self.item.userRating) if self.item.userRating is not None else None
 

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -200,6 +200,10 @@ class TraktApi:
 
     @memoize
     def find_by_media(self, pm: PlexLibraryItem):
+        if pm.type == "episode" and pm.is_episode:
+            ts = self.search_by_id(pm.show_id, id_type=pm.provider, media_type="show")
+            return self.find_episode(ts, pm)
+
         return self.search_by_id(pm.id, id_type=pm.provider, media_type=pm.type)
 
     @rate_limit()

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -199,19 +199,8 @@ class TraktApi:
         return pytrakt_extensions.lookup_table(tm)
 
     @memoize
-    @rate_limit()
-    def find_by_media(self, media: PlexLibraryItem):
-        try:
-            search = trakt.sync.search_by_id(media.id, id_type=media.provider, media_type=media.type)
-        except ValueError as e:
-            # Search_type must be one of ('trakt', ..., 'imdb', 'tmdb', 'tvdb')
-            raise ValueError(f"Invalid id_type: '{media.provider}', guid: '{media.guid}', guids: '{media.item.guids}': {e}") from e
-        # look for the first wanted type in the results
-        for m in search:
-            if m.media_type == media.media_type:
-                return m
-
-        return None
+    def find_by_media(self, pm: PlexLibraryItem):
+        return self.search_by_id(pm.id, id_type=pm.provider, media_type=pm.type)
 
     @rate_limit()
     def search_by_id(self, media_id: str, id_type: str, media_type: str):

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -213,6 +213,16 @@ class TraktApi:
 
         return None
 
+    @rate_limit()
+    def search_by_id(self, media_id: str, id_type: str, media_type: str):
+        search = trakt.sync.search_by_id(media_id, id_type=id_type, media_type=media_type)
+        # look for the first wanted type in the results
+        for m in search:
+            if m.media_type == f"{media_type}s":
+                return m
+
+        return None
+
     def find_episode(self, tm: TVShow, pe: PlexLibraryItem):
         """
         Find Trakt Episode from Plex Episode

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3 -m pytest
-import pytest
-from trakt.errors import MethodNotAllowedException
 
 from plex_trakt_sync.plex_api import PlexLibraryItem
 from plex_trakt_sync.trakt_api import TraktApi
@@ -33,5 +31,6 @@ def test_tv_lookup_by_episode_id():
         index=1,
     ))
 
-    with pytest.raises(MethodNotAllowedException):
-        trakt.find_by_media(pe)
+    te = trakt.find_by_media(pe)
+    assert te.imdb == "tt0505457"
+    assert te.tmdb == 511997


### PR DESCRIPTION
This allows watch command to scrobble tv episodes by legacy agent, i.e `com.plexapp.agents.thetvdb://77137/1/1?lang=en` guid.

