### PR TITLE
Fallback to single episode search for found form Trakt errors

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -136,6 +136,7 @@ def find_show_episodes(show, plex: PlexApi, trakt: TraktApi):
 
 
 def for_each_show_episode(pm, tm, trakt: TraktApi):
+    lookup = trakt.lookup(tm)
     for pe in pm.episodes():
         try:
             provider = pe.provider
@@ -147,7 +148,7 @@ def for_each_show_episode(pm, tm, trakt: TraktApi):
             logger.error(f"Skipping {pe}: Provider {provider} not supported")
             continue
 
-        te = trakt.find_episode(tm, pe)
+        te = trakt.find_episode(tm, pe, lookup)
         if te is None:
             logger.warning(f"Skipping {pe}: Not found on Trakt")
             continue

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -216,11 +216,11 @@ class TraktApi:
 
         return None
 
-    def find_episode(self, tm: TVShow, pe: PlexLibraryItem):
+    def find_episode(self, tm: TVShow, pe: PlexLibraryItem, lookup=None):
         """
         Find Trakt Episode from Plex Episode
         """
-        lookup = self.lookup(tm)
+        lookup = lookup if lookup else self.lookup(tm)
         try:
             return lookup[pe.season_number][pe.episode_number].instance
         except KeyError:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -224,6 +224,9 @@ class TraktApi:
         try:
             return lookup[pe.season_number][pe.episode_number].instance
         except KeyError:
+            # Retry using search for specific Plex Episode
+            if not pe.is_episode:
+                return self.find_by_media(pe)
             return None
 
     def flush(self):

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -225,6 +225,7 @@ class TraktApi:
             return lookup[pe.season_number][pe.episode_number].instance
         except KeyError:
             # Retry using search for specific Plex Episode
+            logger.warning("Retry using search for specific Plex Episode")
             if not pe.is_episode:
                 return self.find_by_media(pe)
             return None

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3 -m pytest
+from typing import Union
+
+from trakt.tv import TVShow
 
 from plex_trakt_sync.plex_api import PlexLibraryItem
 from plex_trakt_sync.trakt_api import TraktApi
 
 
-def make(cls=None, **kwargs):
+def make(cls=None, **kwargs) -> Union[TVShow]:
     cls = cls if cls is not None else "object"
     # https://stackoverflow.com/a/2827726/2314626
     return type(cls, (object,), kwargs)

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -34,3 +34,24 @@ def test_tv_lookup_by_episode_id():
     te = trakt.find_by_media(pe)
     assert te.imdb == "tt0505457"
     assert te.tmdb == 511997
+
+
+def test_find_episode():
+    tm = make(
+        cls='TVShow',
+        # trakt=4965066,
+        trakt=176447,
+    )
+
+    pe = PlexLibraryItem(make(
+        cls='Episode',
+        guid='imdb://tt11909222',
+        type='episode',
+        seasonNumber=1,
+        index=1,
+    ))
+
+    te = trakt.find_episode(tm, pe)
+    assert te.season == 1
+    assert te.episode == 1
+    assert te.imdb == "tt11909222"


### PR DESCRIPTION
Replaces https://github.com/Taxel/PlexTraktSync/pull/240, which proven to be too slow to fetch from trakt for each episode.

So this PR uses fetch for episode only if previous bulk fetch failed.

- [x] Solve `WARNING: Skipping <imdb:tt11909222:<Episode:198150:Frank-of-Ireland-s01e01>>: Not found on Trakt`
- [ ] Solve repeated `INFO: Add to Trakt Collection: <imdb:tt11909222:<Episode:198150:Frank-of-Ireland-s01e01>>`

Problem solution to the discussions at:
- https://github.com/Taxel/PlexTraktSync/discussions/208
- https://github.com/Taxel/PlexTraktSync/pull/240