### PR TITLE
Add support to disable log truncation on each run

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,8 @@
 {
     "log_debug_messages": false,
+    "logging": {
+        "append": false
+    },
     "sync": {
         "liked_lists": true,
         "watchlist": true,

--- a/plex_trakt_sync/config.py
+++ b/plex_trakt_sync/config.py
@@ -19,26 +19,6 @@ class Config(dict):
         "TRAKT_USERNAME",
     ]
 
-    defaults = {
-        "log_debug_messages": False,
-        "logging": {
-            "append": False,
-        },
-        "sync": {
-            "liked_lists": True,
-            "watchlist": True,
-            "watched_status": True,
-            "collection": True,
-            "ratings": True,
-        },
-        "xbmc-providers": {
-            "movies": "imdb",
-            "shows": "tvdb",
-        },
-        "excluded-libraries": [
-        ],
-    }
-
     initialized = False
 
     def __getitem__(self, item):
@@ -47,11 +27,11 @@ class Config(dict):
         return dict.__getitem__(self, item)
 
     def initialize(self):
-        self.update(self.defaults)
+        with open(default_config_file, "r") as fp:
+            defaults = json.load(fp)
+            self.update(defaults)
 
         if not exists(config_file):
-            with open(default_config_file, "r") as fp:
-                defaults = json.load(fp)
             with open(config_file, "w") as fp:
                 fp.write(json.dumps(defaults, indent=4))
 

--- a/plex_trakt_sync/config.py
+++ b/plex_trakt_sync/config.py
@@ -19,6 +19,26 @@ class Config(dict):
         "TRAKT_USERNAME",
     ]
 
+    defaults = {
+        "log_debug_messages": False,
+        "logging": {
+            "append": False,
+        },
+        "sync": {
+            "liked_lists": True,
+            "watchlist": True,
+            "watched_status": True,
+            "collection": True,
+            "ratings": True,
+        },
+        "xbmc-providers": {
+            "movies": "imdb",
+            "shows": "tvdb",
+        },
+        "excluded-libraries": [
+        ],
+    }
+
     initialized = False
 
     def __getitem__(self, item):
@@ -27,6 +47,8 @@ class Config(dict):
         return dict.__getitem__(self, item)
 
     def initialize(self):
+        self.update(self.defaults)
+
         if not exists(config_file):
             with open(default_config_file, "r") as fp:
                 defaults = json.load(fp)

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -15,7 +15,8 @@ def initialize():
     console_handler.setLevel(logging.INFO)
 
     # file handler can log down to debug messages
-    file_handler = logging.FileHandler(log_file, 'w', 'utf-8')
+    mode = "a" if CONFIG['logging']['append'] else "w"
+    file_handler = logging.FileHandler(log_file, mode, 'utf-8')
     file_handler.setFormatter(logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s"))
     file_handler.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
This solves a problem that different runs overwrite logs that user is having.

```json
    "logging": {
        "append": true
    },
```

Fixes https://github.com/Taxel/PlexTraktSync/issues/231