### PR TITLE
Catch TraktException in rate limit to retry after 1s

### DIFF
--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -2,7 +2,7 @@ from functools import wraps
 from time import sleep, time
 
 from requests.exceptions import ConnectionError
-from trakt.errors import RateLimitException
+from trakt.errors import RateLimitException, TraktInternalException
 from plex_trakt_sync.logging import logger
 
 last_time = None
@@ -41,7 +41,7 @@ def rate_limit(retries=5, delay=None):
                 try:
                     respect_trakt_rate()
                     return fn(*args, **kwargs)
-                except (RateLimitException, ConnectionError) as e:
+                except (RateLimitException, ConnectionError, TraktInternalException) as e:
                     if retry == retries:
                         raise e
 


### PR DESCRIPTION
This is quick fix for https://github.com/Taxel/PlexTraktSync/issues/257

Similarly to #248, just add another exception to the catch.

refs:
- https://github.com/Taxel/PlexTraktSync/issues/260