### PR TITLE
Add --batch-size option for TraktBatch

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -219,8 +219,8 @@ def sync_all(movies=True, tv=True, show=None, batch_size=None):
 @click.option(
     "--batch-size", "batch_size",
     type=int,
-    default=None,
-    help="Specify batch size for collection submit queue"
+    default=1, show_default=True,
+    help="Batch size for collection submit queue"
 )
 def sync(sync_option: str, show: str, batch_size: int):
     """

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -154,12 +154,12 @@ def for_each_show_episode(pm, tm, trakt: TraktApi):
         yield tm, pe, te
 
 
-def sync_all(movies=True, tv=True, show=None):
+def sync_all(movies=True, tv=True, show=None, batch_size=None):
     with requests_cache.disabled():
         server = get_plex_server()
     listutil = TraktListUtil()
     plex = PlexApi(server)
-    trakt = TraktApi()
+    trakt = TraktApi(batch_size=batch_size)
 
     with measure_time("Loaded Trakt lists"):
         trakt_watched_movies = trakt.watched_movies
@@ -216,7 +216,13 @@ def sync_all(movies=True, tv=True, show=None):
     default="all",
     show_default=True, help="Specify what to sync"
 )
-def sync(sync_option: str, show: str):
+@click.option(
+    "--batch-size", "batch_size",
+    type=int,
+    default=None,
+    help="Specify batch size for collection submit queue"
+)
+def sync(sync_option: str, show: str, batch_size: int):
     """
     Perform sync between Plex and Trakt
     """
@@ -237,4 +243,4 @@ def sync(sync_option: str, show: str):
         logger.info(f"Syncing TV={tv}, Movies={movies}")
 
     with measure_time("Completed full sync"):
-        sync_all(movies=movies, tv=tv, show=show)
+        sync_all(movies=movies, tv=tv, show=show, batch_size=batch_size)

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -18,7 +18,7 @@ def sync_collection(pm, tm, trakt: TraktApi, trakt_movie_collection):
     if tm.trakt in trakt_movie_collection:
         return
 
-    logger.info(f"Add to Trakt Collection: {pm}")
+    logger.info(f"To be added to collection: {pm}")
     trakt.add_to_collection(tm, pm)
 
 

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -50,8 +50,8 @@ class TraktApi:
     Trakt API class abstracting common data access and dealing with requests cache.
     """
 
-    def __init__(self):
-        self.batch = TraktBatch(self)
+    def __init__(self, batch_size=None):
+        self.batch = TraktBatch(self, batch_size=batch_size)
 
     @property
     @memoize
@@ -234,8 +234,9 @@ class TraktApi:
 
 
 class TraktBatch:
-    def __init__(self, trakt: TraktApi):
+    def __init__(self, trakt: TraktApi, batch_size=None):
         self.trakt = trakt
+        self.batch_size = batch_size
         self.collection = {}
 
     @nocache

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -246,7 +246,7 @@ class TraktBatch:
             return
 
         try:
-            result = trakt.sync.add_to_collection(self.collection)
+            result = self.trakt_sync_collection(self.collection)
             result = self.remove_empty_values(result)
             if result:
                 logger.info(f"Updated Trakt collection: {result}")
@@ -279,6 +279,9 @@ class TraktBatch:
 
         self.collection[media_type].append(item)
         self.flush()
+
+    def trakt_sync_collection(self, media_object):
+        return trakt.sync.add_to_collection(media_object)
 
     def remove_empty_values(self, result):
         """

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -260,6 +260,16 @@ class TraktBatch:
 
         return size
 
+    def flush(self):
+        """
+        Flush the queue if it's bigger than batch_size
+        """
+        if not self.batch_size:
+            return
+
+        if self.queue_size() >= self.batch_size:
+            self.submit_collection()
+
     def add_to_collection(self, media_type: str, item):
         """
         Add item of media_type to collection
@@ -268,6 +278,7 @@ class TraktBatch:
             self.collection[media_type] = []
 
         self.collection[media_type].append(item)
+        self.flush()
 
     def remove_empty_values(self, result):
         """

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -253,6 +253,13 @@ class TraktBatch:
         finally:
             self.collection.clear()
 
+    def queue_size(self):
+        size = 0
+        for media_type in self.collection:
+            size += len(self.collection[media_type])
+
+        return size
+
     def add_to_collection(self, media_type: str, item):
         """
         Add item of media_type to collection

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -242,8 +242,8 @@ class TraktBatch:
     @nocache
     @rate_limit(delay=TRAKT_POST_DELAY)
     def submit_collection(self):
-        if not len(self.collection):
-            return None
+        if self.queue_size() == 0:
+            return
 
         try:
             result = trakt.sync.add_to_collection(self.collection)

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -247,7 +247,7 @@ class TraktBatch:
 
         try:
             result = self.trakt_sync_collection(self.collection)
-            result = self.remove_empty_values(result)
+            result = self.remove_empty_values(result.copy())
             if result:
                 logger.info(f"Updated Trakt collection: {result}")
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import json
+from os.path import dirname, join as join_path
+
+MOCK_DATA_DIR = join_path(dirname(__file__), "mock_data")
+
+
+def load_mock(name: str):
+    filename = join_path(MOCK_DATA_DIR, name)
+    with open(filename, encoding='utf-8') as f:
+        return json.load(f)

--- a/tests/mock_data/trakt_sync_collection_request.json
+++ b/tests/mock_data/trakt_sync_collection_request.json
@@ -1,0 +1,101 @@
+{
+  "movies": [
+    {
+      "collected_at": "2014-09-01T09:10:11.000Z",
+      "title": "Batman Begins",
+      "year": 2005,
+      "ids": {
+        "trakt": 1,
+        "slug": "batman-begins-2005",
+        "imdb": "tt0372784",
+        "tmdb": 272
+      },
+      "media_type": "digital",
+      "resolution": "uhd_4k",
+      "hdr": "dolby_vision",
+      "audio": "dts_ma",
+      "audio_channels": "5.1"
+    },
+    {
+      "ids": {
+        "imdb": "tt0000111"
+      }
+    }
+  ],
+  "shows": [
+    {
+      "title": "Breaking Bad",
+      "year": 2008,
+      "ids": {
+        "trakt": 1,
+        "slug": "breaking-bad",
+        "tvdb": 81189,
+        "imdb": "tt0903747",
+        "tmdb": 1396
+      }
+    },
+    {
+      "title": "The Walking Dead",
+      "year": 2010,
+      "ids": {
+        "trakt": 2,
+        "slug": "the-walking-dead",
+        "tvdb": 153021,
+        "imdb": "tt1520211",
+        "tmdb": 1402
+      },
+      "seasons": [
+        {
+          "number": 3
+        }
+      ]
+    },
+    {
+      "title": "Mad Men",
+      "year": 2007,
+      "ids": {
+        "trakt": 4,
+        "slug": "mad-men",
+        "tvdb": 80337,
+        "imdb": "tt0804503",
+        "tmdb": 1104
+      },
+      "seasons": [
+        {
+          "number": 1,
+          "episodes": [
+            {
+              "number": 1,
+              "media_type": "bluray",
+              "resolution": "hd_1080p",
+              "audio": "dolby_digital_plus",
+              "audio_channels": "5.1"
+            },
+            {
+              "number": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seasons": [
+    {
+      "ids": {
+        "trakt": 140912,
+        "tvdb": 703353,
+        "tmdb": 81266
+      }
+    }
+  ],
+  "episodes": [
+    {
+      "ids": {
+        "trakt": 1061,
+        "tvdb": 1555111,
+        "imdb": "tt007404",
+        "tmdb": 422183
+      }
+    }
+  ]
+}

--- a/tests/mock_data/trakt_sync_collection_response.json
+++ b/tests/mock_data/trakt_sync_collection_response.json
@@ -1,0 +1,20 @@
+{
+  "added": {
+    "movies": 0,
+    "episodes": 0
+  },
+  "updated": {
+    "movies": 0,
+    "episodes": 0
+  },
+  "existing": {
+    "movies": 0,
+    "episodes": 0
+  },
+  "not_found": {
+    "movies": [],
+    "shows": [],
+    "seasons": [],
+    "episodes": []
+  }
+}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3 -m pytest
+from plex_trakt_sync.trakt_api import TraktApi, TraktBatch
+from tests.conftest import load_mock
+from unittest.mock import Mock
+
+trakt = TraktApi()
+
+
+def test_batch():
+    response = load_mock("trakt_sync_collection_response.json")
+    b = TraktBatch(trakt)
+    b.trakt_sync_collection = Mock(return_value=response)
+
+    assert b.queue_size() == 0
+
+    request = load_mock("trakt_sync_collection_request.json")
+    for media_type, items in request.items():
+        for item in items:
+            b.add_to_collection(media_type, item)
+    assert b.queue_size() == 7
+
+    b.submit_collection()
+    assert b.queue_size() == 0
+    assert b.trakt_sync_collection.call_count == 1

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 trakt = TraktApi()
 
 
-def test_batch():
+def test_batch_size_none():
     response = load_mock("trakt_sync_collection_response.json")
     b = TraktBatch(trakt)
     b.trakt_sync_collection = Mock(return_value=response)
@@ -22,3 +22,22 @@ def test_batch():
     b.submit_collection()
     assert b.queue_size() == 0
     assert b.trakt_sync_collection.call_count == 1
+
+
+def test_batch_size_1():
+    response = load_mock("trakt_sync_collection_response.json")
+    b = TraktBatch(trakt, batch_size=1)
+    b.trakt_sync_collection = Mock(return_value=response)
+
+    assert b.queue_size() == 0
+
+    request = load_mock("trakt_sync_collection_request.json")
+    for media_type, items in request.items():
+        for item in items:
+            b.add_to_collection(media_type, item)
+    assert b.queue_size() == 0
+    assert b.trakt_sync_collection.call_count == 7
+
+    b.submit_collection()
+    assert b.queue_size() == 0
+    assert b.trakt_sync_collection.call_count == 7


### PR DESCRIPTION
```
Usage: main.py sync [OPTIONS]

  Perform sync between Plex and Trakt

Options:
  --show TEXT             Sync specific show only
  --sync [all|movies|tv]  Specify what to sync  [default: all]
  --batch-size INTEGER    Batch size for collection submit queue  [default: 1]
  --help                  Show this message and exit.
```

refs:
- https://github.com/Taxel/PlexTraktSync/pull/232#issuecomment-821866092
- https://github.com/Taxel/PlexTraktSync/issues/256#issuecomment-821851004