### PR TITLE
Print git version info if available

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 click = "==7.1.2"
 plexapi = "==4.5.0"
 python-dotenv = "==0.15.0"
+python-git-info = "==0.6.1"
 requests-cache = "==0.5.2"
 trakt = "==3.1.0"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31aa883b7bc5d936b309b6d69fc7d6836c096bcb74e302945255f4f6c69f4e5b"
+            "sha256": "b782af96bccb52b0fa8e8384d91d93bef4f2dee0df97b960fa8c4c9cd8b98e4d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -70,6 +70,13 @@
             ],
             "index": "pypi",
             "version": "==0.15.0"
+        },
+        "python-git-info": {
+            "hashes": [
+                "sha256:75ba1016873b014e17263ba512b9bd0304de2a55f1724858bd48cce932f49702"
+            ],
+            "index": "pypi",
+            "version": "==0.6.1"
         },
         "requests": {
             "hashes": [

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -9,6 +9,7 @@ from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.trakt_api import TraktApi
 from plex_trakt_sync.trakt_list_util import TraktListUtil
 from plex_trakt_sync.logging import logger
+from plex_trakt_sync.version import git_version_info
 
 
 def sync_collection(pm, tm, trakt: TraktApi, trakt_movie_collection):
@@ -221,6 +222,9 @@ def sync(sync_option: str, show: str):
     Perform sync between Plex and Trakt
     """
 
+    git_version = git_version_info()
+    if git_version:
+        logger.info(f"PlexTraktSync [{git_version}]")
     logger.info(f"Syncing with Plex {CONFIG['PLEX_USERNAME']} and Trakt {CONFIG['TRAKT_USERNAME']}")
 
     movies = sync_option in ["all", "movies"]

--- a/plex_trakt_sync/version.py
+++ b/plex_trakt_sync/version.py
@@ -1,0 +1,11 @@
+def git_version_info():
+    try:
+        from gitinfo import get_git_info
+    except ImportError:
+        return
+
+    commit = get_git_info()
+    if not commit:
+        return None
+
+    return f"{commit['commit'][0:8]}: {commit['message']} @{commit['author_date']}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click==7.1.2
 plexapi==4.5.0
 python-dotenv==0.15.0
+python-git-info==0.6.1
 requests-cache==0.5.2
 trakt==3.1.0

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3 -m pytest
+from plex_trakt_sync.version import git_version_info
+
+
+def test_version():
+    v = git_version_info()
+
+    assert type(v) == str


### PR DESCRIPTION
Prints version info from git, if available:

```
INFO: PlexTraktSync [2ad99c15: Add primitive version test @2021-04-18 09:27:16]
```

This adds new module, but it's import error is ignored if user have not updated dependencies.