### PR TITLE
Refactor: Add Timer class, separate rate_limit and time_limit decorators

### DIFF
--- a/plex_trakt_sync/config.py
+++ b/plex_trakt_sync/config.py
@@ -9,6 +9,10 @@ Platform name to identify our application
 """
 PLEX_PLATFORM = "PlexTraktSync"
 
+"""
+Constant in seconds for how much to wait between Trakt POST API calls.
+"""
+TRAKT_POST_DELAY = 1.1
 
 class Config(dict):
     env_keys = [

--- a/plex_trakt_sync/decorators/__init__.py
+++ b/plex_trakt_sync/decorators/__init__.py
@@ -2,3 +2,4 @@ from .measure_time import measure_time
 from .memoize import memoize
 from .nocache import nocache
 from .rate_limit import rate_limit
+from .time_limit import time_limit

--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -1,37 +1,17 @@
 from functools import wraps
-from time import sleep, time
+from time import sleep
 
 from requests.exceptions import ConnectionError
 from trakt.errors import RateLimitException, TraktInternalException
 from plex_trakt_sync.logging import logger
 
-last_time = None
-
 
 # https://trakt.docs.apiary.io/#introduction/rate-limiting
-def rate_limit(retries=5, delay=None):
+def rate_limit(retries=5):
     """
-
     :param retries: number of retries
-    :param delay: delay in sec between trakt requests to respect rate limit
     :return:
     """
-
-    def respect_trakt_rate():
-        if delay is None:
-            return
-
-        global last_time
-        if last_time is None:
-            last_time = time()
-            return
-
-        diff_time = time() - last_time
-        if diff_time < delay:
-            wait = delay - diff_time
-            logger.debug(f"Sleeping for {wait:.3f} seconds")
-            sleep(wait)
-        last_time = time()
 
     def decorator(fn):
         @wraps(fn)
@@ -39,7 +19,6 @@ def rate_limit(retries=5, delay=None):
             retry = 0
             while True:
                 try:
-                    respect_trakt_rate()
                     return fn(*args, **kwargs)
                 except (RateLimitException, ConnectionError, TraktInternalException) as e:
                     if retry == retries:

--- a/plex_trakt_sync/decorators/time_limit.py
+++ b/plex_trakt_sync/decorators/time_limit.py
@@ -1,0 +1,22 @@
+from functools import wraps
+
+from plex_trakt_sync.config import TRAKT_POST_DELAY
+from plex_trakt_sync.timer import Timer
+
+timer = Timer(TRAKT_POST_DELAY)
+
+
+def time_limit():
+    """
+    Throttles calls not to be called more often than TRAKT_POST_DELAY
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            timer.wait_if_needed()
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/plex_trakt_sync/timer.py
+++ b/plex_trakt_sync/timer.py
@@ -1,0 +1,39 @@
+from time import sleep, monotonic
+
+from plex_trakt_sync.logging import logger
+
+
+class Timer:
+    """
+    Class dealing with limiting that something is not called more often than {delay}
+    """
+
+    def __init__(self, delay: float):
+        if delay <= 0:
+            raise ValueError(f"Delay must be a positive number: {delay}")
+        self.delay = delay
+        self.last_time = None
+
+    @property
+    def time_remaining(self):
+        last_time = self.last_time
+        if not last_time:
+            return 0.0
+        diff_time = monotonic() - last_time
+        if diff_time < self.delay:
+            return self.delay - diff_time
+        return 0.0
+
+    def update(self):
+        self.last_time = monotonic()
+
+    def wait_if_needed(self):
+        if not self.last_time:
+            self.update()
+            return
+
+        wait = self.time_remaining
+        if wait:
+            logger.debug(f"Sleeping for {wait:.3f} seconds")
+            sleep(wait)
+        self.update()

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -16,9 +16,7 @@ from trakt.sync import Scrobbler
 
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.decorators import memoize, nocache, rate_limit
-from plex_trakt_sync.config import CONFIG
-
-TRAKT_POST_DELAY = 1.1
+from plex_trakt_sync.config import CONFIG, TRAKT_POST_DELAY
 
 
 class ScrobblerProxy:

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -15,8 +15,8 @@ from trakt.errors import OAuthException, ForbiddenException
 from trakt.sync import Scrobbler
 
 from plex_trakt_sync.logging import logger
-from plex_trakt_sync.decorators import memoize, nocache, rate_limit
-from plex_trakt_sync.config import CONFIG, TRAKT_POST_DELAY
+from plex_trakt_sync.decorators import memoize, nocache, rate_limit, time_limit
+from plex_trakt_sync.config import CONFIG
 
 
 class ScrobblerProxy:
@@ -28,17 +28,20 @@ class ScrobblerProxy:
         self.scrobbler = scrobbler
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def update(self, progress: float):
         self.scrobbler.update(progress)
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def pause(self):
         self.scrobbler.pause()
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def stop(self):
         self.scrobbler.stop()
 
@@ -95,7 +98,8 @@ class TraktApi:
         return self.me.show_collection
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def remove_from_library(self, media: Union[Movie, TVShow, TVSeason, TVEpisode]):
         if not isinstance(media, (Movie, TVShow, TVSeason, TVEpisode)):
             raise ValueError("Must be valid media type")
@@ -150,7 +154,8 @@ class TraktApi:
         return None
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def rate(self, m, rating):
         m.rate(rating)
 
@@ -159,7 +164,8 @@ class TraktApi:
         return ScrobblerProxy(scrobbler)
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def mark_watched(self, m, time):
         m.mark_as_seen(time)
 
@@ -242,7 +248,8 @@ class TraktBatch:
         self.collection = {}
 
     @nocache
-    @rate_limit(delay=TRAKT_POST_DELAY)
+    @rate_limit()
+    @time_limit()
     def submit_collection(self):
         if self.queue_size() == 0:
             return

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -23,3 +23,9 @@ def test_timer():
     with timeit() as t:
         timer.wait_if_needed()
     assert t() > time_limit, "Second call must have waited"
+
+    with timeit() as t:
+        timer.wait_if_needed()
+        timer.wait_if_needed()
+        timer.wait_if_needed()
+    assert t() > 3 * time_limit, "Wait three times"

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3 -m pytest
+from contextlib import contextmanager
+from time import perf_counter
+
+from plex_trakt_sync.timer import Timer
+
+
+@contextmanager
+def timeit():
+    # https://stackoverflow.com/a/62956469/2314626
+    start = perf_counter()
+    yield lambda: perf_counter() - start
+
+
+def test_timer():
+    time_limit = 1.1
+    timer = Timer(time_limit)
+
+    with timeit() as t:
+        timer.wait_if_needed()
+    assert t() < time_limit, "First call is free!"
+
+    with timeit() as t:
+        timer.wait_if_needed()
+    assert t() > time_limit, "Second call must have waited"


### PR DESCRIPTION
NOTE: `time.monotonic` requires Python 3.5 to be available on all Platforms:
- https://docs.python.org/3/library/time.html#time.monotonic