### PR TITLE
Skip git version info on TypeError

### DIFF
--- a/plex_trakt_sync/version.py
+++ b/plex_trakt_sync/version.py
@@ -1,8 +1,8 @@
 def git_version_info():
     try:
         from gitinfo import get_git_info
-    except ImportError:
-        return
+    except (ImportError, TypeError):
+        return None
 
     commit = get_git_info()
     if not commit:


### PR DESCRIPTION
Workaround for library internal errors: https://github.com/spapas/python-git-info/issues/7

refs:
- https://github.com/Taxel/PlexTraktSync/pull/261