### PR TITLE
Add Walker class

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -1,4 +1,5 @@
 import click
+from plexapi.server import PlexServer
 
 from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.requests_cache import requests_cache
@@ -10,6 +11,7 @@ from plex_trakt_sync.trakt_api import TraktApi
 from plex_trakt_sync.trakt_list_util import TraktListUtil
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.version import git_version_info
+from plex_trakt_sync.walker import Walker
 
 
 def sync_collection(m: Media):
@@ -94,12 +96,8 @@ def for_each_show_episode(m: Media, mf: MediaFactory):
         yield me
 
 
-def sync_all(library=None, movies=True, tv=True, show=None, batch_size=None):
-    with requests_cache.disabled():
-        server = get_plex_server()
+def sync_all(walker: Walker, trakt: TraktApi, server: PlexServer):
     listutil = TraktListUtil()
-    plex = PlexApi(server)
-    trakt = TraktApi(batch_size=batch_size)
 
     with measure_time("Loaded Trakt lists"):
         trakt_watched_movies = trakt.watched_movies
@@ -119,28 +117,19 @@ def sync_all(library=None, movies=True, tv=True, show=None, batch_size=None):
         logger.info("Server version {} updated at: {}".format(server.version, server.updatedAt))
         logger.info("Recently added: {}".format(server.library.recentlyAdded()[:5]))
 
-    mf = MediaFactory(plex, trakt)
-    if movies:
-        for m in for_each_pair(plex.movie_sections(library=library), mf):
-            sync_collection(m)
-            sync_ratings(m)
-            sync_watched(m)
+    for movie in walker.find_movies():
+        sync_collection(movie)
+        sync_ratings(movie)
+        sync_watched(movie)
+        # add to plex lists
+        listutil.addPlexItemToLists(movie.trakt_id, movie.plex.item)
 
-            # add to plex lists
-            listutil.addPlexItemToLists(m.trakt_id, m.plex.item)
+    for episode in walker.find_episodes():
+        sync_collection(episode)
+        sync_watched(episode)
 
-    if tv:
-        if show:
-            it = find_show_episodes(show, plex, mf)
-        else:
-            it = for_each_episode(plex.show_sections(library=library), mf)
-
-        for me in it:
-            sync_collection(me)
-            sync_watched(me)
-
-            # add to plex lists
-            listutil.addPlexItemToLists(me.trakt_id, me.plex.item)
+        # add to plex lists
+        listutil.addPlexItemToLists(episode.trakt_id, episode.plex.item)
 
     with measure_time("Updated plex watchlist"):
         listutil.updatePlexLists(server)
@@ -183,9 +172,14 @@ def sync(sync_option: str, library: str, show: str, batch_size: int):
     movies = sync_option in ["all", "movies"]
     tv = sync_option in ["all", "tv"]
 
+    server = get_plex_server()
+    plex = PlexApi(server)
+    trakt = TraktApi(batch_size=batch_size)
+    mf = MediaFactory(plex, trakt)
+    w = Walker(plex, mf, movies=movies, shows=tv)
+
     if show:
-        movies = False
-        tv = True
+        w.add_show(show)
         logger.info(f"Syncing Show: {show}")
     elif not movies and not tv:
         click.echo("Nothing to sync!")
@@ -194,4 +188,4 @@ def sync(sync_option: str, library: str, show: str, batch_size: int):
         logger.info(f"Syncing TV={tv}, Movies={movies}")
 
     with measure_time("Completed full sync"):
-        sync_all(movies=movies, library=library, tv=tv, show=show, batch_size=batch_size)
+        sync_all(walker=w, trakt=trakt, server=server)

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -56,46 +56,6 @@ def sync_watched(m: Media):
         m.mark_watched_plex()
 
 
-def for_each_pair(sections, mf: MediaFactory):
-    for section in sections:
-        label = f"Processing {section.title}"
-        end_label = f"{section.title} processed"
-        with measure_time(end_label):
-            pb = click.progressbar(section.items(), length=len(section), show_pos=True, label=label)
-            with pb as items:
-                for pm in items:
-                    m = mf.resolve(pm)
-                    if not m:
-                        continue
-                    yield m
-
-
-def for_each_episode(sections, mf: MediaFactory):
-    for m in for_each_pair(sections, mf):
-        for me in for_each_show_episode(m, mf):
-            yield me
-
-
-def find_show_episodes(show, plex: PlexApi, mf: MediaFactory):
-    search = plex.search(show, libtype='show')
-    for pm in search:
-        m = mf.resolve(pm)
-        if not m:
-            continue
-        for me in for_each_show_episode(m, mf):
-            yield me
-
-
-def for_each_show_episode(m: Media, mf: MediaFactory):
-    for pe in m.plex.episodes():
-        me = mf.resolve(pe, m.trakt)
-        if not me:
-            continue
-
-        me.show = m
-        yield me
-
-
 def sync_all(walker: Walker, trakt: TraktApi, server: PlexServer):
     listutil = TraktListUtil()
 

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -176,7 +176,7 @@ def sync(sync_option: str, library: str, show: str, batch_size: int):
     plex = PlexApi(server)
     trakt = TraktApi(batch_size=batch_size)
     mf = MediaFactory(plex, trakt)
-    w = Walker(plex, mf, movies=movies, shows=tv)
+    w = Walker(plex, mf, movies=movies, shows=tv, progressbar=click.progressbar)
 
     if library:
         logger.info(f"Filtering Library: {library}")

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -178,6 +178,10 @@ def sync(sync_option: str, library: str, show: str, batch_size: int):
     mf = MediaFactory(plex, trakt)
     w = Walker(plex, mf, movies=movies, shows=tv)
 
+    if library:
+        logger.info(f"Filtering Library: {library}")
+        w.add_library(library)
+
     if show:
         w.add_show(show)
         logger.info(f"Syncing Show: {show}")

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -67,8 +67,8 @@ class Walker:
             sections = [x for x in sections if x.title in titles]
 
         for section in sections:
-            for pm in section.items():
-                yield pm
+            it = self.progressbar(section.items(), length=len(section), label=f"Processing {section.title}")
+            yield from it
 
     def media_from_titles(self, libtype: str, titles: List[str]):
         for title in titles:

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -27,21 +27,35 @@ class Walker:
         """
         Iterate over movie sections unless specific movie is requested
         """
-        for section in self.movie_sections():
-            for pm in section.items():
-                m = self.mf.resolve(pm)
-                if not m:
-                    continue
-                yield m
+        if self.movie:
+            it = self.from_movie_titles(self.movie)
+        else:
+            it = self.from_movie_libraries(self.library)
 
-    def movie_sections(self):
+        for pm in it:
+            m = self.mf.resolve(pm)
+            if not m:
+                continue
+            yield m
+
+    def from_movie_titles(self, titles):
+        for title in titles:
+            search = self.plex.search(title, libtype="movie")
+            yield from search
+
+    def from_movie_libraries(self, titles):
+        for section in self.movie_sections(titles):
+            for pm in section.items():
+                yield pm
+
+    def movie_sections(self, titles):
         """
         Return movie sections, optionally filter only matching section names
         """
         sections = self.plex.movie_sections()
-        if self.library:
+        if titles:
             # Filter by matching section names
-            sections = [x for x in sections if x.title in self.library]
+            sections = [x for x in sections if x.title in titles]
         return sections
 
     def find_episodes(self):

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -87,12 +87,6 @@ class Walker:
             me.show = show
             yield me
 
-    def from_show_titles(self, movie):
-        pass
-
-    def from_show_libraries(self, library):
-        pass
-
     def progressbar(self, iterable, **kwargs):
         if self._progressbar:
             pb = self._progressbar(iterable, show_pos=True, **kwargs)

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -30,24 +30,24 @@ class Walker:
         Iterate over movie sections unless specific movie is requested
         """
         if self.movie:
-            it = self.media_from_titles("movie", self.movie)
+            movies = self.media_from_titles("movie", self.movie)
         else:
-            it = self.media_from_sections(self.plex.movie_sections(), self.library)
+            movies = self.media_from_sections(self.plex.movie_sections(), self.library)
 
-        for pm in it:
-            m = self.mf.resolve(pm)
-            if not m:
+        for plex in movies:
+            movie = self.mf.resolve(plex)
+            if not movie:
                 continue
-            yield m
+            yield movie
 
     def find_episodes(self):
-        if self.movie:
-            it = self.media_from_titles("show", self.show)
+        if self.show:
+            shows = self.media_from_titles("show", self.show)
         else:
-            it = self.media_from_sections(self.plex.show_sections(), self.library)
+            shows = self.media_from_sections(self.plex.show_sections(), self.library)
 
-        for plex_show in it:
-            show = self.mf.resolve(plex_show)
+        for plex in shows:
+            show = self.mf.resolve(plex)
             if not show:
                 continue
             yield show

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -25,9 +25,11 @@ class Walker:
 
     def add_show(self, show):
         self.show.append(show)
+        self.walk_movies = False
 
     def add_movie(self, movie):
         self.movie.append(movie)
+        self.walk_shows = False
 
     def find_movies(self):
         """

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -71,7 +71,8 @@ class Walker:
             yield from it
 
     def media_from_titles(self, libtype: str, titles: List[str]):
-        for title in titles:
+        it = self.progressbar(titles, label=f"Processing {libtype}s")
+        for title in it:
             search = self.plex.search(title, libtype=libtype)
             yield from search
 

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -9,11 +9,12 @@ class Walker:
     Class dealing with finding and walking library, movies/shows, episodes
     """
 
-    def __init__(self, plex: PlexApi, mf: MediaFactory, movies=True, shows=True):
-        self.walk_movies = movies
-        self.walk_shows = shows
+    def __init__(self, plex: PlexApi, mf: MediaFactory, progressbar=None, movies=True, shows=True):
+        self._progressbar = progressbar
         self.plex = plex
         self.mf = mf
+        self.walk_movies = movies
+        self.walk_shows = shows
         self.library = []
         self.show = []
         self.movie = []
@@ -88,3 +89,11 @@ class Walker:
 
     def from_show_libraries(self, library):
         pass
+
+    def progressbar(self, iterable, **kwargs):
+        if self._progressbar:
+            pb = self._progressbar(iterable, show_pos=True, **kwargs)
+            with pb as it:
+                yield from it
+        else:
+            yield from iterable

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from plex_trakt_sync.media import MediaFactory
+from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.plex_api import PlexApi
 
 
@@ -50,7 +50,7 @@ class Walker:
             show = self.mf.resolve(plex)
             if not show:
                 continue
-            yield show
+            yield from self.episode_from_show(show)
 
     def media_from_sections(self, sections, titles: List[str]):
         if titles:
@@ -65,6 +65,15 @@ class Walker:
         for title in titles:
             search = self.plex.search(title, libtype=libtype)
             yield from search
+
+    def episode_from_show(self, show: Media):
+        for pe in show.plex.episodes():
+            me = self.mf.resolve(pe, show.trakt)
+            if not me:
+                continue
+
+            me.show = show
+            yield me
 
     def from_show_titles(self, movie):
         pass

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,9 +1,15 @@
+from plex_trakt_sync.media import MediaFactory
+from plex_trakt_sync.plex_api import PlexApi
+
+
 class Walker:
     """
     Class dealing with finding and walking library, movies/shows, episodes
     """
 
-    def __init__(self):
+    def __init__(self, plex: PlexApi, mf: MediaFactory):
+        self.plex = plex
+        self.mf = mf
         self.library = []
         self.show = []
         self.movie = []
@@ -18,7 +24,25 @@ class Walker:
         self.movie.append(movie)
 
     def find_movies(self):
-        pass
+        """
+        Iterate over movie sections unless specific movie is requested
+        """
+        for section in self.movie_sections():
+            for pm in section.items():
+                m = self.mf.resolve(pm)
+                if not m:
+                    continue
+                yield m
+
+    def movie_sections(self):
+        """
+        Return movie sections, optionally filter only matching section names
+        """
+        sections = self.plex.movie_sections()
+        if self.library:
+            # Filter by matching section names
+            sections = [x for x in sections if x.title in self.library]
+        return sections
 
     def find_episodes(self):
         pass

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -9,7 +9,9 @@ class Walker:
     Class dealing with finding and walking library, movies/shows, episodes
     """
 
-    def __init__(self, plex: PlexApi, mf: MediaFactory):
+    def __init__(self, plex: PlexApi, mf: MediaFactory, movies=True, shows=True):
+        self.walk_movies = movies
+        self.walk_shows = shows
         self.plex = plex
         self.mf = mf
         self.library = []
@@ -29,6 +31,9 @@ class Walker:
         """
         Iterate over movie sections unless specific movie is requested
         """
+        if not self.walk_movies:
+            return
+
         if self.movie:
             movies = self.media_from_titles("movie", self.movie)
         else:
@@ -41,6 +46,9 @@ class Walker:
             yield movie
 
     def find_episodes(self):
+        if not self.walk_shows:
+            return
+
         if self.show:
             shows = self.media_from_titles("show", self.show)
         else:

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from plex_trakt_sync.decorators import measure_time
 from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.plex_api import PlexApi
 
@@ -67,8 +68,9 @@ class Walker:
             sections = [x for x in sections if x.title in titles]
 
         for section in sections:
-            it = self.progressbar(section.items(), length=len(section), label=f"Processing {section.title}")
-            yield from it
+            with measure_time(f"{section.title} processed"):
+                it = self.progressbar(section.items(), length=len(section), label=f"Processing {section.title}")
+                yield from it
 
     def media_from_titles(self, libtype: str, titles: List[str]):
         it = self.progressbar(titles, label=f"Processing {libtype}s")

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,0 +1,24 @@
+class Walker:
+    """
+    Class dealing with finding and walking library, movies/shows, episodes
+    """
+
+    def __init__(self):
+        self.library = []
+        self.show = []
+        self.movie = []
+
+    def add_library(self, library):
+        self.library.append(library)
+
+    def add_show(self, show):
+        self.show.append(show)
+
+    def add_movie(self, movie):
+        self.movie.append(movie)
+
+    def find_movies(self):
+        pass
+
+    def find_episodes(self):
+        pass

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3 -m pytest
+from plex_trakt_sync.walker import Walker
+
+
+def test_walker():
+    w = Walker()
+
+    w.add_library("TV Shows")
+    w.add_show("Breaking Bad")
+    w.add_movie("Batman Begins")
+    w.find_episodes()
+    w.find_movies()
+
+    assert type(w) == Walker

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3 -m pytest
 from plex_trakt_sync.walker import Walker
+from tests.conftest import get_plex_api, get_media_factory
+
+plex = get_plex_api()
+mf = get_media_factory()
 
 
 def test_walker():
-    w = Walker()
+    w = Walker(plex, mf)
 
     w.add_library("TV Shows")
     w.add_show("Breaking Bad")

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -8,11 +8,15 @@ mf = get_media_factory()
 
 def test_walker():
     w = Walker(plex, mf)
+    assert type(w) == Walker
 
     w.add_library("TV Shows")
+    w.add_library("Movies (Tuti)")
     w.add_show("Breaking Bad")
     w.add_movie("Batman Begins")
-    w.find_episodes()
-    w.find_movies()
 
-    assert type(w) == Walker
+    episodes = list(w.find_episodes())
+    movies = list(w.find_movies())
+
+    assert len(episodes) == 0
+    assert len(movies) == 0


### PR DESCRIPTION
Prototype for the class that can be configured as what to find and walk.

This refactors filtering to Waker class, making sync command to do just;

```python

    for movie in walker.find_movies():
        print(movie)

    for episode in walker.find_episodes():
        print(episode)
```