### PR TITLE
Measure_time end label ≠ progress label

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -57,7 +57,8 @@ def sync_watched(m: Media):
 def for_each_pair(sections, mf: MediaFactory):
     for section in sections:
         label = f"Processing {section.title}"
-        with measure_time(label):
+        end_label = f"{section.title} processed"
+        with measure_time(end_label):
             pb = click.progressbar(section.items(), length=len(section), show_pos=True, label=label)
             with pb as items:
                 for pm in items:


### PR DESCRIPTION
For logs to be gramatically correct and be clear about what is done and what is still in progress, this PR turns "_processing xx_" into "_xx processed_".

Before PR:
```
Processing TV Shows  [####################################]  16/16
INFO: Processing TV Shows in 12.7 seconds
```
After PR:
```
Processing TV Shows  [####################################]  16/16
INFO: TV Shows processed in 12.7 seconds
```