### PR TITLE
Add error logging for search returning wrong media type

### DIFF
--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -214,9 +214,14 @@ class TraktApi:
     def search_by_id(self, media_id: str, id_type: str, media_type: str):
         search = trakt.sync.search_by_id(media_id, id_type=id_type, media_type=media_type)
         # look for the first wanted type in the results
+        # NOTE: this is not needed, kept around for caution
         for m in search:
-            if m.media_type == f"{media_type}s":
-                return m
+            if m.media_type != f"{media_type}s":
+                logger.error(
+                    f"Internal error, wrong media type: {m.media_type}. Please report this to PlexTraktSync developers"
+                )
+                continue
+            return m
 
         return None
 


### PR DESCRIPTION
The check for media type in response should be removed:
- https://github.com/Taxel/PlexTraktSync/blob/75dc59ef463f678cb48998ac372582bb2c0f9935/plex_trakt_sync/trakt_api.py#L218


as the media type is always passed in query:
- https://github.com/Taxel/PlexTraktSync/blob/75dc59ef463f678cb48998ac372582bb2c0f9935/plex_trakt_sync/trakt_api.py#L215

I didn't remove it yet, added logging in case Trakt or Trakt API is misbehaving.