### PR TITLE
Add webhook command for Tautulli

### DIFF
--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -7,6 +7,7 @@ from plex_trakt_sync.commands.plex_login import plex_login
 from plex_trakt_sync.commands.sync import sync
 from plex_trakt_sync.commands.trakt_login import trakt_login
 from plex_trakt_sync.commands.watch import watch
+from plex_trakt_sync.commands.webhook import webhook
 
 
 @click.group(invoke_without_command=True)
@@ -26,3 +27,4 @@ cli.add_command(plex_login)
 cli.add_command(sync)
 cli.add_command(trakt_login)
 cli.add_command(watch)
+cli.add_command(webhook)

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -21,4 +21,9 @@ def webhook(bind: str, port: int):
 
     with socketserver.TCPServer((bind, port), HttpRequestHandler) as httpd:
         click.echo(f"Serving at http://{bind}:{port}")
-        httpd.serve_forever()
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        httpd.server_close()
+        click.echo("Stopping httpd...")

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -21,11 +21,11 @@ class WebhookHandler:
 
     def handle(self, payload):
         logger.debug(f"Handle: {payload}")
-        if "ratingKey" not in payload:
+        if "rating_key" not in payload:
             logger.debug(f"Skip, no ratingKey in payload")
             return
 
-        rating_key = int(payload["ratingKey"])
+        rating_key = int(payload["rating_key"])
         logger.debug(f"RatingKey: {rating_key}")
         if rating_key:
             self.sync(rating_key)

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -1,14 +1,53 @@
-import http.server
+import json
 import socketserver
 from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
 
 import click
 
+from plex_trakt_sync.logging import logger
 
-class HttpRequestHandler(http.server.CGIHTTPRequestHandler):
+TAUTULLI_WEBHOOK_URL = "https://github.com/Taxel/PlexTraktSync#tautulli-webhook"
+
+
+class HttpRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        self.send_error(HTTPStatus.NOT_FOUND, "File not found")
-        return None
+        self.set_response()
+        self.wfile.write(f"PlexTraktSync Webhook for Tautulli. See {TAUTULLI_WEBHOOK_URL}".encode('utf-8'))
+
+    def do_POST(self):
+        payload = self.get_payload()
+        if not payload:
+            return False
+
+        self.set_response()
+        self.wfile.write('{"status": "ok"}'.encode('utf-8'))
+
+    def get_payload(self):
+        content_length = int(self.headers['Content-Length'] or 0)
+        if not content_length:
+            return self.error(f"No Content-Length header")
+
+        post_data = self.rfile.read(content_length)
+        if not post_data:
+            return self.error(f"No POST data provided")
+        try:
+            payload = json.loads(post_data)
+        except json.decoder.JSONDecodeError as e:
+            return self.error(f"Unable to decode payload: {e}")
+
+        return payload
+
+    def error(self, message: str):
+        logger.error(message)
+        self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, explain=message)
+
+        return False
+
+    def set_response(self, status=200, content_type="text/plain"):
+        self.send_response(status)
+        self.send_header("Content-type", f"{content_type}; charset=utf-8")
+        self.end_headers()
 
 
 @click.command()

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -92,8 +92,8 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
 
 
 @click.command()
-@click.option("--bind", help="Address to listen on", default="localhost")
-@click.option("--port", help="TCP port port to listen on", default=7707)
+@click.option("--bind", help="Address to listen on", show_default=True, default="localhost")
+@click.option("--port", help="TCP port to listen on", show_default=True, default=7707)
 def webhook(bind: str, port: int):
     """
     Listen for WebHook data from HTTP

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -51,7 +51,7 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
         self.set_response()
         self.wfile.write(f"PlexTraktSync Webhook for Tautulli. See {TAUTULLI_WEBHOOK_URL}".encode('utf-8'))
 
-    def do_POST(self):
+    def do_PUT(self):
         payload = self.get_payload()
         if not payload:
             return False

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -1,7 +1,14 @@
 import http.server
 import socketserver
+from http import HTTPStatus
 
 import click
+
+
+class HttpRequestHandler(http.server.CGIHTTPRequestHandler):
+    def do_GET(self):
+        self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+        return None
 
 
 @click.command()
@@ -12,7 +19,6 @@ def webhook(bind: str, port: int):
     Listen for WebHook data from HTTP
     """
 
-    Handler = http.server.SimpleHTTPRequestHandler
-    with socketserver.TCPServer((bind, port), Handler) as httpd:
+    with socketserver.TCPServer((bind, port), HttpRequestHandler) as httpd:
         click.echo(f"Serving at http://{bind}:{port}")
         httpd.serve_forever()

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -1,9 +1,18 @@
+import http.server
+import socketserver
+
 import click
 
 
 @click.command()
-def webhook():
+@click.option("--bind", help="Address to listen on", default="localhost")
+@click.option("--port", help="TCP port port to listen on", default=7707)
+def webhook(bind: str, port: int):
     """
     Listen for WebHook data from HTTP
     """
-    pass
+
+    Handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer((bind, port), Handler) as httpd:
+        click.echo(f"Serving at http://{bind}:{port}")
+        httpd.serve_forever()

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -1,0 +1,9 @@
+import click
+
+
+@click.command()
+def webhook():
+    """
+    Listen for WebHook data from HTTP
+    """
+    pass


### PR DESCRIPTION
The webhook can be used for Tautulli Webhook Notification Agent endpoint:
- https://github.com/Tautulli/Tautulli/wiki/Notification-Agents-Guide#webhook

```
➔ ./plex_trakt_sync.sh webhook --help
Usage: main.py webhook [OPTIONS]

  Listen for WebHook data from HTTP

Options:
  --bind TEXT     Address to listen on  [default: localhost]
  --port INTEGER  TCP port to listen on  [default: 7707]
  --help          Show this message and exit.
```

NOTE: This webhook doesn't do right now anything else than find a matching Plex item and print it.