### PR TITLE
Fix addPlexItemToLists by adding media_type

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -68,7 +68,7 @@ def sync_all(walker: Walker, trakt: TraktApi, server: PlexServer):
         trakt_liked_lists = trakt.liked_lists
 
     if trakt_watchlist_movies:
-        listutil.addList(None, "Trakt Watchlist", traktid_list=trakt_watchlist_movies)
+        listutil.addList(None, "Trakt Watchlist", trakt_list=trakt_watchlist_movies)
 
     for lst in trakt_liked_lists:
         listutil.addList(lst['username'], lst['listname'])
@@ -82,14 +82,14 @@ def sync_all(walker: Walker, trakt: TraktApi, server: PlexServer):
         sync_ratings(movie)
         sync_watched(movie)
         # add to plex lists
-        listutil.addPlexItemToLists(movie.trakt_id, movie.plex.item)
+        listutil.addPlexItemToLists(movie)
 
     for episode in walker.find_episodes():
         sync_collection(episode)
         sync_watched(episode)
 
         # add to plex lists
-        listutil.addPlexItemToLists(episode.trakt_id, episode.plex.item)
+        listutil.addPlexItemToLists(episode)
 
     with measure_time("Updated plex watchlist"):
         listutil.updatePlexLists(server)

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -127,9 +127,7 @@ class TraktApi:
         if not CONFIG['sync']['watchlist']:
             return []
 
-        return list(
-            map(lambda m: m.trakt, self.me.watchlist_movies)
-        )
+        return self.me.watchlist_movies
 
     @property
     @memoize

--- a/plex_trakt_sync/trakt_list_util.py
+++ b/plex_trakt_sync/trakt_list_util.py
@@ -14,16 +14,16 @@ class TraktList():
         self.name = listname
         self.plex_items = []
         if username is not None:
-            self.traktids = dict(zip(map(lambda e: e.trakt, [elem for elem in UserList._get(listname, username).get_items() if isinstance(elem, (Movie, TVEpisode))]), count(1)))
+            self.trakt_items = dict(zip([(elem.media_type, elem.trakt) for elem in UserList._get(listname, username)._items if isinstance(elem, (Movie, TVEpisode))], count(1)))
 
     @staticmethod
-    def from_traktid_list(listname, traktid_list):
+    def from_trakt_list(listname, trakt_list):
         l = TraktList(None, listname)
-        l.traktids = dict(zip(traktid_list, count(1)))
+        l.trakt_items = dict(zip([(elem.media_type, elem.trakt) for elem in trakt_list], count(1)))
         return l
 
-    def addPlexItem(self, traktid, plex_item):
-        rank = self.traktids.get(traktid)
+    def addPlexItem(self, trakt_item, plex_item):
+        rank = self.trakt_items.get((trakt_item.media_type, trakt_item.trakt))
         if rank is not None:
             self.plex_items.append((rank, plex_item))
             if isinstance(plex_item, Episode):
@@ -47,9 +47,9 @@ class TraktListUtil():
     def __init__(self):
         self.lists = []
 
-    def addList(self, username, listname, traktid_list=None):
-        if traktid_list is not None:
-            self.lists.append(TraktList.from_traktid_list(listname, traktid_list))
+    def addList(self, username, listname, trakt_list=None):
+        if trakt_list is not None:
+            self.lists.append(TraktList.from_trakt_list(listname, trakt_list))
             logger.info("Downloaded List {}".format(listname))
             return
         try:
@@ -58,9 +58,9 @@ class TraktListUtil():
         except (NotFoundException, OAuthException):
             logger.warning("Failed to get list {} by user {}".format(listname, username))
 
-    def addPlexItemToLists(self, traktid, plex_item):
+    def addPlexItemToLists(self, m):
         for l in self.lists:
-            l.addPlexItem(traktid, plex_item)
+            l.addPlexItem(m.trakt, m.plex.item)
 
     def updatePlexLists(self, plex):
         for l in self.lists:


### PR DESCRIPTION
Adds `media_type` in lists to prevent mismatch of movies & episodes items based of their trakt id.

- [x]  check impact on duration for huge lists : lookup in dict are O(1) (discussed in #54)
- [x] check successfully done with IMDB top 250 rated movies 

fixes #228 