### PR TITLE
Add http_cache decorator

### DIFF
--- a/plex_trakt_sync/decorators/__init__.py
+++ b/plex_trakt_sync/decorators/__init__.py
@@ -1,3 +1,4 @@
+from .http_cache import http_cache
 from .measure_time import measure_time
 from .memoize import memoize
 from .nocache import nocache

--- a/plex_trakt_sync/decorators/http_cache.py
+++ b/plex_trakt_sync/decorators/http_cache.py
@@ -1,0 +1,14 @@
+from functools import wraps
+
+import requests_cache
+
+from plex_trakt_sync.path import trakt_cache
+
+
+def http_cache(method, expire_after=None):
+    @wraps(method)
+    def inner(self, *args, **kwargs):
+        with requests_cache.enabled(trakt_cache, expire_after=expire_after):
+            return method(self, *args, **kwargs)
+
+    return inner

--- a/plex_trakt_sync/requests_cache.py
+++ b/plex_trakt_sync/requests_cache.py
@@ -1,4 +1,7 @@
+import requests
 import requests_cache
 from .path import trakt_cache
 
 requests_cache.install_cache(trakt_cache)
+
+session = requests.Session()


### PR DESCRIPTION
Opposite of `@nocache`, to indicate the method needs to be cached.

In the future add support for `ttl` parameter.