### PR TITLE
Change "playlist not found" log level

### DIFF
--- a/plex_trakt_sync/trakt_list_util.py
+++ b/plex_trakt_sync/trakt_list_util.py
@@ -36,7 +36,7 @@ class TraktList():
             try:
                 plex.playlist(self.name).delete()
             except (NotFound, BadRequest):
-                logger.error("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
+                logger.debug("Playlist %s not found, so it could not be deleted. Actual playlists: %s" % (self.name, plex.playlists()))
                 pass
             if len(self.plex_items) > 0:
                 _, plex_items_sorted = zip(*sorted(dict(reversed(self.plex_items)).items()))


### PR DESCRIPTION
A playlist missing in Plex is not supposed to be an error because :

- at first sync, it is normal that plex playlist are not yet created
- user can remove any plex playlist if he wants to

When #124 will be fixed, the lists sync logic will probably change.
But in the meantime, this PR moves "playlist not found" log level from **error** to **debug**.

User can get confused with such errror message and I understand https://github.com/Taxel/PlexTraktSync/issues/228#issuecomment-826988411
Especially if the message states that the playlist needs to be deleted 😄 


```
ERROR: Playlist Rotten Tomatoes: Best of 2019 not found, so it could not be deleted. Actual playlists: [<Playlist:/playlists/282615:70's-Comedies>, <Playlist:/playlists/280507:80s-Comedy>, <Playlist:/playlists/282612:90's-Comedies>, <Playlist:/playlists/282613:2000's-Comedies>, <Playlist:/playlists/261465:All-Music>, <Playlist:/playlists/261476:All-Music>, <Playlist:/playlists/261466:Recently-Added>, <Playlist:/playlists/261475:Recently-Added>, <Playlist:/playlists/261467:Recently-Played>, <Playlist:/playlists/261477:Recently-Played>, <Playlist:/playlists/128363:Action>, <Playlist:/playlists/141517:Blake-and-Diane>, <Playlist:/playlists/372604:Blake-and-Diane-Movi>, <Playlist:/playlists/128362:Comedy>, <Playlist:/playlists/141481:Drama>, <Playlist:/playlists/362220:Reality-TV>, <Playlist:/playlists/141480:Sci-Fi>]
ERROR: Playlist IMDB: Top Rated Movies not found, so it could not be deleted. Actual playlists: [<Playlist:/playlists/282615:70's-Comedies>, <Playlist:/playlists/280507:80s-Comedy>, <Playlist:/playlists/282612:90's-Comedies>, <Playlist:/playlists/282613:2000's-Comedies>, <Playlist:/playlists/261465:All-Music>, <Playlist:/playlists/261476:All-Music>, <Playlist:/playlists/261466:Recently-Added>, <Playlist:/playlists/261475:Recently-Added>, <Playlist:/playlists/261467:Recently-Played>, <Playlist:/playlists/261477:Recently-Played>, <Playlist:/playlists/128363:Action>, <Playlist:/playlists/141517:Blake-and-Diane>, <Playlist:/playlists/372604:Blake-and-Diane-Movi>, <Playlist:/playlists/128362:Comedy>, <Playlist:/playlists/141481:Drama>, <Playlist:/playlists/362220:Reality-TV>, <Playlist:/playlists/141480:Sci-Fi>]
```