### PR TITLE
Remove slow server info printing

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -75,7 +75,6 @@ def sync_all(walker: Walker, trakt: TraktApi, server: PlexServer):
 
     with requests_cache.disabled():
         logger.info("Server version {} updated at: {}".format(server.version, server.updatedAt))
-        logger.info("Recently added: {}".format(server.library.recentlyAdded()[:5]))
 
     for movie in walker.find_movies():
         sync_collection(movie)


### PR DESCRIPTION
Removes printing of:
1. <del>server version</del>
2. last added media

those are not useful, wastes time on roundtrip for the requests, wastes resources on the server to calculate the result, and slows down the script startup.

for me, those take off 1-3 seconds of startup time.

if such information is required for debugging, we can add specific command for that.