### PR TITLE
Add advanced options for cache printing

### DIFF
--- a/plex_trakt_sync/commands/cache.py
+++ b/plex_trakt_sync/commands/cache.py
@@ -6,10 +6,10 @@ from requests_cache import CachedSession
 from plex_trakt_sync.path import trakt_cache
 
 
-def get_sorted_cache(session: CachedSession, sorting: str):
+def get_sorted_cache(session: CachedSession, sorting: str, reverse: bool):
     sorters = {
-        "size": partial(sorted, reverse=True, key=lambda x: len(x[1].content)),
-        "date": partial(sorted, reverse=True, key=lambda x: x[1].created_at),
+        "size": partial(sorted, reverse=reverse, key=lambda x: len(x[1].content)),
+        "date": partial(sorted, reverse=reverse, key=lambda x: x[1].created_at),
     }
     sorter = sorters[sorting]
     yield from sorter(session.cache._get_valid_responses())
@@ -40,7 +40,13 @@ def limit_iterator(items, limit: int):
     default=20,
     show_default=True, help="Limit entries to be printed"
 )
-def cache(sort: str, limit: int):
+@click.option(
+    "--reverse",
+    is_flag=True,
+    default=False,
+    help="Sort reverse"
+)
+def cache(sort: str, limit: int, reverse: bool):
     """
     Manage and analyze Requests Cache.
     """
@@ -48,6 +54,6 @@ def cache(sort: str, limit: int):
     click.echo(f"Cache status:\n{session.cache}\n")
 
     click.echo(f"URLs:")
-    sorted = get_sorted_cache(session, sort)
+    sorted = get_sorted_cache(session, sort, reverse)
     for i, (k, r) in limit_iterator(sorted, limit):
         click.echo(f"- {i + 1:3d}. {r.created_at}: {r.url}: {len(r.content)} bytes")

--- a/plex_trakt_sync/commands/cache.py
+++ b/plex_trakt_sync/commands/cache.py
@@ -6,13 +6,23 @@ from requests_cache import CachedSession
 from plex_trakt_sync.path import trakt_cache
 
 
-def get_sorted_cache(session: CachedSession):
-    sorter = partial(sorted, reverse=True, key=lambda x: len(x[1].content))
+def get_sorted_cache(session: CachedSession, sorting: str):
+    sorters = {
+        "size": partial(sorted, reverse=True, key=lambda x: len(x[1].content)),
+        "date": partial(sorted, reverse=True, key=lambda x: x[1].created_at),
+    }
+    sorter = sorters[sorting]
     yield from sorter(session.cache._get_valid_responses())
 
 
 @click.command()
-def cache():
+@click.option(
+    "--sort",
+    type=click.Choice(["size", "date"], case_sensitive=False),
+    default="size",
+    show_default=True, help="Sort mode"
+)
+def cache(sort: str):
     """
     Manage and analyze Requests Cache.
     """
@@ -20,5 +30,5 @@ def cache():
     click.echo(f"Cache status:\n{session.cache}\n")
 
     click.echo(f"URLs:")
-    for k, r in get_sorted_cache(session):
+    for k, r in get_sorted_cache(session, sort):
         click.echo(f"- {r.created_at}: {r.url}: {len(r.content)} bytes")

--- a/plex_trakt_sync/commands/cache.py
+++ b/plex_trakt_sync/commands/cache.py
@@ -1,7 +1,14 @@
+from functools import partial
+
 import click
 from requests_cache import CachedSession
 
 from plex_trakt_sync.path import trakt_cache
+
+
+def get_sorted_cache(session: CachedSession):
+    sorter = partial(sorted, reverse=True, key=lambda x: len(x[1].content))
+    yield from sorter(session.cache._get_valid_responses())
 
 
 @click.command()
@@ -13,5 +20,5 @@ def cache():
     click.echo(f"Cache status:\n{session.cache}\n")
 
     click.echo(f"URLs:")
-    for url in session.cache.urls:
-        click.echo(f"- {url}")
+    for k, r in get_sorted_cache(session):
+        click.echo(f"- {r.created_at}: {r.url}: {len(r.content)} bytes")


### PR DESCRIPTION
```
➔  ./plex_trakt_sync.sh cache --help
Usage: main.py cache [OPTIONS]

  Manage and analyze Requests Cache.

Options:
  --sort [size|date]  Sort mode  [default: size]
  --limit INTEGER     Limit entries to be printed  [default: 20]
  --reverse           Sort reverse
  --help              Show this message and exit.
```