### PR TITLE
Fix Plex requests being cached

### DIFF
--- a/plex_trakt_sync/plex_server.py
+++ b/plex_trakt_sync/plex_server.py
@@ -1,9 +1,20 @@
 import plexapi.server
 from plex_trakt_sync.config import CONFIG, PLEX_PLATFORM
+from plex_trakt_sync.decorators import nocache
 from plex_trakt_sync.logging import logger
 
 
+class PlexServer:
+    @nocache
+    def connect(self):
+        return _get_plex_server()
+
+
 def get_plex_server():
+    return PlexServer().connect()
+
+
+def _get_plex_server():
     plex_token = CONFIG["PLEX_TOKEN"]
     plex_baseurl = CONFIG["PLEX_BASEURL"]
     plex_fallbackurl = CONFIG["PLEX_FALLBACKURL"]


### PR DESCRIPTION
Add @nocache to get_plex_server method, Add wrapper class as `@nocache` requires class methods.

The breakage came form this being get_plex_server being not called with request cache disabled:

```py
    with requests_cache.disabled():
        server = get_plex_server()
```

Somehow that affected also other calls made by `server` later on.

Fixes https://github.com/Taxel/PlexTraktSync/issues/307