### PR TITLE
Move .env init check out of config to sync command

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -131,6 +131,13 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
     git_version = git_version_info()
     if git_version:
         logger.info(f"PlexTraktSync [{git_version}]")
+
+    if not CONFIG["PLEX_TOKEN"] or not CONFIG["TRAKT_USERNAME"]:
+        click.echo("First run, please follow those configuration instructions.")
+        from get_env_data import get_env_data
+        get_env_data()
+        CONFIG.initialize()
+
     logger.info(f"Syncing with Plex {CONFIG['PLEX_USERNAME']} and Trakt {CONFIG['TRAKT_USERNAME']}")
 
     movies = sync_option in ["all", "movies"]

--- a/plex_trakt_sync/config.py
+++ b/plex_trakt_sync/config.py
@@ -44,17 +44,11 @@ class Config(dict):
         config = self.load_json(config_file)
         self.update(config)
 
-        self.initialized = True
-
         load_dotenv()
-        if not getenv("PLEX_TOKEN") or not getenv("TRAKT_USERNAME"):
-            print("First run, please follow those configuration instructions.")
-            from get_env_data import get_env_data
-            get_env_data()
-            load_dotenv()
-
         for key in self.env_keys:
             self[key] = getenv(key)
+
+        self.initialized = True
 
     def save(self):
         with open(env_file, "w") as txt:


### PR DESCRIPTION
This allows using other commands than sync without config being present:

- Plex Login: https://github.com/Taxel/PlexTraktSync/pull/230
- Trakt Login: https://github.com/Taxel/PlexTraktSync/pull/243

refs:
- https://github.com/Taxel/PlexTraktSync/issues/306