### PR TITLE
Add database access library

### DIFF
--- a/plex_trakt_sync/commands/inspect.py
+++ b/plex_trakt_sync/commands/inspect.py
@@ -51,9 +51,10 @@ def inspect(input):
     except Exception as e:
         print(f"Error: {e}")
 
-    if input == 6114:
-        mi = mf.resolve(m)
-        watched_at = mi.trakt_api.last_watched_at(mi.trakt)
+    mi = mf.resolve(m)
+    watched_at = mi.trakt_api.last_watched_at(mi.trakt)
+    print(f"Trakt watched at: {watched_at}")
 
+    if input == 6114:
         db = PlexDatabase(Database('com.plexapp.plugins.library.db'))
         db.mark_watched(mi, watched_at)

--- a/plex_trakt_sync/commands/inspect.py
+++ b/plex_trakt_sync/commands/inspect.py
@@ -53,9 +53,7 @@ def inspect(input):
 
     if input == 6114:
         mi = mf.resolve(m)
-        wms = mi.trakt_api.me.watched_movies
-        wm = [x for x in wms if x.trakt == mi.trakt_id][0]
-        watched_at = wm.last_watched_at
+        watched_at = mi.trakt_api.last_watched_at(mi.trakt)
 
         db = PlexDatabase(Database('com.plexapp.plugins.library.db'))
         db.mark_watched(mi, watched_at)

--- a/plex_trakt_sync/commands/inspect.py
+++ b/plex_trakt_sync/commands/inspect.py
@@ -52,9 +52,8 @@ def inspect(input):
         print(f"Error: {e}")
 
     mi = mf.resolve(m)
-    watched_at = mi.trakt_api.last_watched_at(mi.trakt)
-    print(f"Trakt watched at: {watched_at}")
+    print(f"Trakt watched at: {mi.trakt_last_watched_at}")
 
     if input == 6114:
         db = PlexDatabase(Database('com.plexapp.plugins.library.db'))
-        db.mark_watched(mi, watched_at)
+        db.mark_watched(mi, mi.trakt_last_watched_at)

--- a/plex_trakt_sync/commands/inspect.py
+++ b/plex_trakt_sync/commands/inspect.py
@@ -1,6 +1,8 @@
 import click
 from plexapi.server import PlexServer
 from plex_trakt_sync.config import CONFIG
+from plex_trakt_sync.database import PlexDatabase, Database
+from plex_trakt_sync.media import MediaFactory
 from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.trakt_api import TraktApi
 from plex_trakt_sync.version import git_version_info
@@ -21,6 +23,7 @@ def inspect(input):
     server = PlexServer(url, token)
     plex = PlexApi(server)
     trakt = TraktApi()
+    mf = MediaFactory(plex=plex, trakt=trakt)
 
     if input.isnumeric():
         input = int(input)
@@ -47,3 +50,12 @@ def inspect(input):
         print(f"Trakt match: {tm}")
     except Exception as e:
         print(f"Error: {e}")
+
+    if input == 6114:
+        mi = mf.resolve(m)
+        wms = mi.trakt_api.me.watched_movies
+        wm = [x for x in wms if x.trakt == mi.trakt_id][0]
+        watched_at = wm.last_watched_at
+
+        db = PlexDatabase(Database('com.plexapp.plugins.library.db'))
+        db.mark_watched(mi, watched_at)

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -1,6 +1,8 @@
 import sqlite3
+from datetime import datetime
 
 from plex_trakt_sync.logging import logger
+from plex_trakt_sync.media import Media
 
 
 class Database(object):
@@ -44,3 +46,62 @@ class Database(object):
 
     def has_uncommited(self):
         return self._uncommited
+
+
+class PlexDatabase:
+    _insert_watched = """
+        INSERT INTO metadata_item_views (
+            account_id,
+            guid,
+            metadata_type,
+            library_section_id,
+            grandparent_title,
+            parent_index,
+            parent_title,
+            "index",
+            title,
+            thumb_url,
+            viewed_at,
+            grandparent_guid,
+            originally_available_at,
+            device_id
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+    """
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    def mark_watched(self, media: Media, time: datetime):
+        account_id = 1
+        metadata_type = 1
+        library_section_id = 2
+        grandparent_title = ''
+        parent_index = -1
+        parent_title = ''
+        index = 1
+        title = 'Coma'
+        thumb_url = 'metadata://posters/com.plexapp.agents.imdb_3eea3b08fc7094167eee68cca64f8be407be0cbe'
+        grandparent_guid = ''
+        originally_available_at = '2019-11-19 00:00:00'
+        device_id = 20
+
+        with self.db as db:
+            viewed_at = db.format_time(time)
+            db.cursor.execute(self._insert_watched, (
+                account_id,
+                media.plex.guid,
+                metadata_type,
+                library_section_id,
+                grandparent_title,
+                parent_index,
+                parent_title,
+                index,
+                title,
+                thumb_url,
+                viewed_at,
+                grandparent_guid,
+                originally_available_at,
+                device_id
+            ))

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -40,6 +40,10 @@ class Database(object):
 
         self._connection.close()
 
+    def execute(self, query, *args):
+        self._uncommited = True
+        return self.cursor.execute(query, *args)
+
     def commit(self):
         self._connection.commit()
         self._uncommited = False
@@ -114,7 +118,7 @@ class PlexDatabase:
         with self.db as db:
             originally_available_at = db.format_time(pm.originallyAvailableAt)
             viewed_at = db.format_time(time)
-            db.cursor.execute(self._insert_watched, (
+            db.execute(self._insert_watched, (
                 account_id,
                 media.plex.guid,
                 metadata_type,
@@ -130,7 +134,7 @@ class PlexDatabase:
                 originally_available_at,
                 device_id
             ))
-            db.cursor.execute(self._update_metadata_item_settings, (
-                time,
+            db.execute(self._update_metadata_item_settings, (
+                viewed_at,
                 media.plex.guid,
             ))

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -1,7 +1,9 @@
 import sqlite3
 from datetime import datetime
+from typing import Union
 
 from plexapi.server import PlexServer
+from plexapi.video import Movie, Episode
 
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.media import Media
@@ -92,6 +94,7 @@ class PlexDatabase:
 
     def mark_watched(self, media: Media, time: datetime):
         plex: PlexServer = media.plex_api.plex
+        pm: Union[Movie, Episode] = media.plex.item
 
         account = plex.systemAccount(0)
         device = plex.systemDevice(1)
@@ -107,9 +110,9 @@ class PlexDatabase:
         title = 'Coma'
         thumb_url = 'metadata://posters/com.plexapp.agents.imdb_3eea3b08fc7094167eee68cca64f8be407be0cbe'
         grandparent_guid = ''
-        originally_available_at = '2019-11-19 00:00:00'
 
         with self.db as db:
+            originally_available_at = db.format_time(pm.originallyAvailableAt)
             viewed_at = db.format_time(time)
             db.cursor.execute(self._insert_watched, (
                 account_id,

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -1,0 +1,42 @@
+import sqlite3
+
+from plex_trakt_sync.logging import logger
+
+
+class Database(object):
+    _uncommited = False
+
+    def __init__(self, database_path: str):
+        try:
+            self.filename = database_path
+            self._connection = sqlite3.connect(database_path)
+            self._cursor = self._connection.cursor()
+            self._cursor.execute('ANALYZE')
+
+        except sqlite3.OperationalError as e:
+            logger.error(e)
+            raise e
+
+        except sqlite3.DatabaseError as e:
+            logger.error(e)
+            raise e
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._uncommited:
+            self.commit()
+
+        self._connection.close()
+
+    def commit(self):
+        self._connection.commit()
+        self._uncommited = False
+
+    def rollback(self):
+        self._connection.rollback()
+        self._uncommited = False
+
+    def has_uncommited(self):
+        return self._uncommited

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -1,6 +1,8 @@
 import sqlite3
 from datetime import datetime
 
+from plexapi.server import PlexServer
+
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.media import Media
 
@@ -89,7 +91,13 @@ class PlexDatabase:
         self.db = db
 
     def mark_watched(self, media: Media, time: datetime):
-        account_id = 1
+        plex: PlexServer = media.plex_api.plex
+
+        account = plex.systemAccount(0)
+        device = plex.systemDevice(1)
+
+        account_id = account.id
+        device_id = device.id
         metadata_type = 1
         library_section_id = 2
         grandparent_title = ''
@@ -100,7 +108,6 @@ class PlexDatabase:
         thumb_url = 'metadata://posters/com.plexapp.agents.imdb_3eea3b08fc7094167eee68cca64f8be407be0cbe'
         grandparent_guid = ''
         originally_available_at = '2019-11-19 00:00:00'
-        device_id = 20
 
         with self.db as db:
             viewed_at = db.format_time(time)

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -21,6 +21,10 @@ class Database(object):
             logger.error(e)
             raise e
 
+    @property
+    def cursor(self):
+        return self._cursor
+
     def __enter__(self):
         return self
 

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -134,6 +134,7 @@ class PlexDatabase:
                 originally_available_at,
                 device_id
             ))
+            # TODO: if uypdate fails, must insert
             db.execute(self._update_metadata_item_settings, (
                 viewed_at,
                 media.plex.guid,

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -70,6 +70,15 @@ class PlexDatabase:
         )
     """
 
+    _update_metadata_item_settings = """
+        UPDATE metadata_item_settings
+        SET
+            view_count = view_count+1,
+            last_viewed_at = ?
+        WHERE
+            guid = ?
+    """
+
     def __init__(self, db: Database):
         self.db = db
 
@@ -104,4 +113,8 @@ class PlexDatabase:
                 grandparent_guid,
                 originally_available_at,
                 device_id
+            ))
+            db.cursor.execute(self._update_metadata_item_settings, (
+                time,
+                media.plex.guid,
             ))

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -47,6 +47,12 @@ class Database(object):
     def has_uncommited(self):
         return self._uncommited
 
+    def format_time(self, time: datetime):
+        """
+        Format datetime for sqlite, Plex dates are in localtime.
+        """
+        return time.astimezone().replace(tzinfo=None).isoformat(' ', timespec='seconds')
+
 
 class PlexDatabase:
     _insert_watched = """

--- a/plex_trakt_sync/database.py
+++ b/plex_trakt_sync/database.py
@@ -102,14 +102,14 @@ class PlexDatabase:
         account_id = account.id
         device_id = device.id
         metadata_type = 1
-        library_section_id = 2
-        grandparent_title = ''
+        library_section_id = pm.librarySectionID
+        grandparent_title = None
         parent_index = -1
-        parent_title = ''
+        parent_title = None
         index = 1
-        title = 'Coma'
-        thumb_url = 'metadata://posters/com.plexapp.agents.imdb_3eea3b08fc7094167eee68cca64f8be407be0cbe'
-        grandparent_guid = ''
+        title = pm.title
+        thumb_url = None
+        grandparent_guid = None
 
         with self.db as db:
             originally_available_at = db.format_time(pm.originallyAvailableAt)

--- a/plex_trakt_sync/media.py
+++ b/plex_trakt_sync/media.py
@@ -2,6 +2,7 @@ from plexapi.exceptions import PlexApiException
 from requests import RequestException, ReadTimeout
 from trakt.errors import TraktException
 
+from plex_trakt_sync.decorators import memoize
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.plex_api import PlexLibraryItem, PlexApi
 from plex_trakt_sync.trakt_api import TraktApi
@@ -67,6 +68,11 @@ class Media:
 
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)
+
+    @property
+    @memoize
+    def trakt_last_watched_at(self):
+        return self.trakt_api.last_watched_at(self.trakt)
 
     @property
     def trakt_rating(self):

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -1,4 +1,6 @@
 from typing import Union
+from datetime import datetime
+
 import trakt
 
 from plex_trakt_sync import pytrakt_extensions
@@ -166,6 +168,15 @@ class TraktApi:
     @time_limit()
     def mark_watched(self, m, time):
         m.mark_as_seen(time)
+
+    @memoize
+    def last_watched_at(self, m: Union[Movie, TVEpisode]):
+        match = [x for x in self.me.watched_movies if x.trakt == m.trakt]
+        if not match:
+            return None
+        watched_at = match[0].last_watched_at
+
+        return datetime.strptime(watched_at, '%Y-%m-%dT%H:%M:%S.000Z')
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -1,5 +1,5 @@
 from typing import Union
-from datetime import datetime
+from datetime import datetime, timezone
 
 import trakt
 
@@ -176,7 +176,10 @@ class TraktApi:
             return None
         watched_at = match[0].last_watched_at
 
-        return datetime.strptime(watched_at, '%Y-%m-%dT%H:%M:%S.000Z')
+        date = datetime.strptime(watched_at, '%Y-%m-%dT%H:%M:%S.000Z')
+        utcdate = date.replace(tzinfo=timezone.utc)
+
+        return utcdate
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
Updates Plex SQLite database directly to get accurate entries for last played.

The changes were produced by reverse engineering database dumps:
```
echo .dump | sqlite3 /config/Databases/com.plexapp.plugins.library.db
```

After removing a play from Plex Web, such changes from the dump was revealed:

```diff
-INSERT INTO metadata_item_views VALUES(249,1,'com.plexapp.agents.imdb://tt6087226?lang=en',1,2,'',-1,'',1,'Coma','metadata://posters/com.plexapp.agents.imdb_943cd9578781fdd50c6cc1ea60ea26eb6f200044','2020-07-23 11:11:48','','2019-11-19 00:00:00',20);
-INSERT INTO metadata_item_settings VALUES(235,1,'com.plexapp.agents.imdb://tt6087226?lang=en',10.0,NULL,1,'2020-07-23 11:11:48','2020-07-23 11:11:48','2020-07-23 11:11:49',0,NULL,81870,'','2020-07-23 11:11:48');
+INSERT INTO metadata_item_settings VALUES(235,1,'com.plexapp.agents.imdb://tt6087226?lang=en',10.0,NULL,0,NULL,'2020-07-23 11:11:48','2021-05-16 15:50:07',0,NULL,136688,'','2020-07-23 11:11:48');
```

refs:
- https://github.com/reclosedev/requests-cache/blob/5417069b431ec1e665bebe4c2bbeec0774d86bef/requests_cache/backends/sqlite.py#L94