### PR TITLE
include commands and decorators folders as .dockerignore exclusions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@
 !/Pipfile.lock
 !/config.default.json
 !/plex_trakt_sync/*.py
+!/plex_trakt_sync/commands/*.py
+!/plex_trakt_sync/decorators/*.py


### PR DESCRIPTION
It seems that the py files in the subfolders are being ignored and not being copied to the image.

the globstar syntax `!/plex_trakt_sync/**/*.py`, and even single folder wildcard syntax `!/plex_trakt_sync/*/*.py` don't seem to work for me either, so I had to specify the folder exclusions individually.