### PR TITLE
Add websocket-client 1.0.1 dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ python-dotenv = "==0.15.0"
 python-git-info = "==0.6.1"
 requests-cache = "==0.6.3"
 trakt = "==3.1.0"
+websocket-client = "==1.0.1"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a7198f235d31d57dd1775bc1c2f1017ac8ea09b5b415901c6230ac97867562de"
+            "sha256": "f7d6135f4124b5ea62cc67881608545d46754fdec5438cc62c318fab89534bbb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -141,6 +141,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.5"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:3e2bf58191d4619b161389a95bdce84ce9e0b24eb8107e7e590db682c2d0ca81",
+                "sha256:abf306dc6351dcef07f4d40453037e51cc5d9da2ef60d0fc5d0fe3bcda255372"
+            ],
+            "index": "pypi",
+            "version": "==1.0.1"
         }
     },
     "develop": {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==0.15.0
 python-git-info==0.6.1
 requests-cache==0.6.3
 trakt==3.1.0
+websocket-client==1.0.1


### PR DESCRIPTION
The `websocket` package is required to run in "watch" mode:
- https://github.com/Taxel/PlexTraktSync/issues/312

Fixes https://github.com/Taxel/PlexTraktSync/issues/312

<!--

This adds these new dependencies:
- websocket 0.2.1
  - gevent 21.1.2
  - greenlet 1.1.0
  - zope.event 4.5.0
  - zope.interface 5.4.0


-->