### PR TITLE
Call new login commands in case tokens are missing

### DIFF
--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -3,6 +3,7 @@ import click
 from plex_trakt_sync.commands.cache import cache
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
+from plex_trakt_sync.commands.login import login
 from plex_trakt_sync.commands.plex_login import plex_login, has_plex_token
 from plex_trakt_sync.commands.sync import sync
 from plex_trakt_sync.commands.trakt_login import trakt_login, has_trakt_token
@@ -27,6 +28,7 @@ def cli(ctx):
 cli.add_command(cache)
 cli.add_command(clear_collections)
 cli.add_command(inspect)
+cli.add_command(login)
 cli.add_command(plex_login)
 cli.add_command(sync)
 cli.add_command(trakt_login)

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -3,7 +3,7 @@ import click
 from plex_trakt_sync.commands.cache import cache
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
-from plex_trakt_sync.commands.plex_login import plex_login
+from plex_trakt_sync.commands.plex_login import plex_login, has_plex_token
 from plex_trakt_sync.commands.sync import sync
 from plex_trakt_sync.commands.trakt_login import trakt_login
 from plex_trakt_sync.commands.watch import watch
@@ -17,6 +17,8 @@ def cli(ctx):
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
     if not ctx.invoked_subcommand:
+        if not has_plex_token():
+            plex_login()
         sync()
 
 

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -5,7 +5,7 @@ from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
 from plex_trakt_sync.commands.plex_login import plex_login, has_plex_token
 from plex_trakt_sync.commands.sync import sync
-from plex_trakt_sync.commands.trakt_login import trakt_login
+from plex_trakt_sync.commands.trakt_login import trakt_login, has_trakt_token
 from plex_trakt_sync.commands.watch import watch
 from plex_trakt_sync.commands.webhook import webhook
 
@@ -19,6 +19,8 @@ def cli(ctx):
     if not ctx.invoked_subcommand:
         if not has_plex_token():
             plex_login()
+        if not has_trakt_token():
+            trakt_login()
         sync()
 
 

--- a/plex_trakt_sync/cli.py
+++ b/plex_trakt_sync/cli.py
@@ -4,9 +4,9 @@ from plex_trakt_sync.commands.cache import cache
 from plex_trakt_sync.commands.clear_collections import clear_collections
 from plex_trakt_sync.commands.inspect import inspect
 from plex_trakt_sync.commands.login import login
-from plex_trakt_sync.commands.plex_login import plex_login, has_plex_token
+from plex_trakt_sync.commands.plex_login import plex_login
 from plex_trakt_sync.commands.sync import sync
-from plex_trakt_sync.commands.trakt_login import trakt_login, has_trakt_token
+from plex_trakt_sync.commands.trakt_login import trakt_login
 from plex_trakt_sync.commands.watch import watch
 from plex_trakt_sync.commands.webhook import webhook
 
@@ -18,10 +18,6 @@ def cli(ctx):
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
     if not ctx.invoked_subcommand:
-        if not has_plex_token():
-            plex_login()
-        if not has_trakt_token():
-            trakt_login()
         sync()
 
 

--- a/plex_trakt_sync/commands/login.py
+++ b/plex_trakt_sync/commands/login.py
@@ -1,0 +1,15 @@
+import click
+
+from plex_trakt_sync.commands.plex_login import has_plex_token, plex_login
+from plex_trakt_sync.commands.trakt_login import has_trakt_token, trakt_login
+
+
+@click.command()
+def login():
+    """
+    Log in to Plex and Trakt if needed
+    """
+    if not has_plex_token():
+        plex_login()
+    if not has_trakt_token():
+        trakt_login()

--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -130,6 +130,10 @@ def choose_server(account: MyPlexAccount):
             click.secho(f"{e}, Try another server, {type(e)}")
 
 
+def has_plex_token():
+    return CONFIG["PLEX_TOKEN"] is not None and CONFIG["PLEX_TOKEN"] != "-"
+
+
 @click.command()
 @click.option("--username", help="Plex login", default=CONFIG["PLEX_USERNAME"])
 @click.option("--password", help="Plex password")
@@ -138,7 +142,7 @@ def plex_login(username, password):
     Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.
     """
 
-    if CONFIG["PLEX_TOKEN"]:
+    if has_plex_token():
         if not click.confirm(PROMPT_PLEX_RELOGIN, default=True):
             return
 

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -1,6 +1,7 @@
 import click
 from plexapi.server import PlexServer
 
+from plex_trakt_sync.commands.login import login
 from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.requests_cache import requests_cache
 from plex_trakt_sync.plex_server import get_plex_server
@@ -132,12 +133,7 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
     if git_version:
         logger.info(f"PlexTraktSync [{git_version}]")
 
-    if not CONFIG["PLEX_TOKEN"] or not CONFIG["TRAKT_USERNAME"]:
-        click.echo("First run, please follow those configuration instructions.")
-        from get_env_data import get_env_data
-        get_env_data()
-        CONFIG.initialize()
-
+    login.main(standalone_mode=False)
     logger.info(f"Syncing with Plex {CONFIG['PLEX_USERNAME']} and Trakt {CONFIG['TRAKT_USERNAME']}")
 
     movies = sync_option in ["all", "movies"]

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -1,10 +1,12 @@
 from json import JSONDecodeError
+from os.path import exists
 
 import click
 import trakt.core
 from trakt.errors import ForbiddenException
 
 from plex_trakt_sync.config import CONFIG
+from plex_trakt_sync.path import pytrakt_file
 from plex_trakt_sync.style import title, success, error, prompt
 from plex_trakt_sync.trakt_api import TraktApi
 
@@ -37,6 +39,8 @@ def trakt_authenticate():
 
 
 def has_trakt_token():
+    if not exists(pytrakt_file):
+        return False
     return CONFIG["TRAKT_USERNAME"] is not None and CONFIG["TRAKT_USERNAME"] != "None"
 
 

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -19,6 +19,7 @@ TRAKT_LOGIN_SUCCESS = success(
 def trakt_authenticate():
     click.echo(title("Sign in to Trakt"))
     trakt.core.AUTH_METHOD = trakt.core.DEVICE_AUTH
+    trakt.core.CONFIG_PATH = pytrakt_file
 
     click.echo("If you do not have a client ID and secret. Please visit the following url to create them.")
     click.echo("  https://trakt.tv/oauth/applications")

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -29,6 +29,7 @@ def trakt_authenticate():
         client_id = click.prompt(PROMPT_TRAKT_CLIENT_ID, type=str)
         client_secret = click.prompt(PROMPT_TRAKT_CLIENT_SECRET, type=str)
 
+        click.echo("Attempting to authenticate with Trakt")
         try:
             return trakt.init(client_id=client_id, client_secret=client_secret, store=True)
         except (ForbiddenException, JSONDecodeError) as e:

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -36,7 +36,7 @@ def trakt_authenticate():
 
 
 def has_trakt_token():
-    return CONFIG["TRAKT_USERNAME"] is not None
+    return CONFIG["TRAKT_USERNAME"] is not None and CONFIG["TRAKT_USERNAME"] != "None"
 
 
 @click.command()

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -34,6 +34,10 @@ def trakt_authenticate():
             click.echo(error(f"Log in to Trakt failed: {e}, Try again."))
 
 
+def has_trakt_token():
+    return CONFIG["TRAKT_USERNAME"] is not None
+
+
 @click.command()
 def trakt_login():
     """


### PR DESCRIPTION
This replaces need for `get_env_data` code.

- adds new `login` command. used internally, but users can invoke too
- calls `trakt-login` and `plex-login` commands if respective tokens are missing

The `get_env_data` along with the `get_env_data.py` will be removed in as separate PR.