### PR TITLE
Add ensure_login method without click decorator

### DIFF
--- a/plex_trakt_sync/commands/login.py
+++ b/plex_trakt_sync/commands/login.py
@@ -4,12 +4,16 @@ from plex_trakt_sync.commands.plex_login import has_plex_token, plex_login
 from plex_trakt_sync.commands.trakt_login import has_trakt_token, trakt_login
 
 
+def ensure_login():
+    if not has_plex_token():
+        plex_login()
+    if not has_trakt_token():
+        trakt_login()
+
+
 @click.command()
 def login():
     """
     Log in to Plex and Trakt if needed
     """
-    if not has_plex_token():
-        plex_login()
-    if not has_trakt_token():
-        trakt_login()
+    ensure_login()

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -1,7 +1,7 @@
 import click
 from plexapi.server import PlexServer
 
-from plex_trakt_sync.commands.login import login
+from plex_trakt_sync.commands.login import ensure_login
 from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.requests_cache import requests_cache
 from plex_trakt_sync.plex_server import get_plex_server
@@ -133,7 +133,7 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
     if git_version:
         logger.info(f"PlexTraktSync [{git_version}]")
 
-    login.main(standalone_mode=False)
+    ensure_login()
     logger.info(f"Syncing with Plex {CONFIG['PLEX_USERNAME']} and Trakt {CONFIG['TRAKT_USERNAME']}")
 
     movies = sync_option in ["all", "movies"]


### PR DESCRIPTION
This solves the problem that adding `click` decorator changed the behavior of the method.

When the first problem of click calling `sys.exit` was fixed with `standalone=False`, then next problem is that options are passed to the wrong command, i.e to `login` command, not to `sync` command.