### PR TITLE
Handle trakt bad response & ends script

### DIFF
--- a/plex_trakt_sync/decorators/rate_limit.py
+++ b/plex_trakt_sync/decorators/rate_limit.py
@@ -22,7 +22,9 @@ def rate_limit(retries=5):
                     return fn(*args, **kwargs)
                 except (RateLimitException, RequestException, TraktInternalException) as e:
                     if retry == retries:
-                        raise e
+                        logger.error(f"Trakt error: {e}")
+                        logger.error(f"Trakt didn't respond properly, script abort now. Please try again later.")
+                        exit(1)
 
                     if isinstance(e, RateLimitException):
                         seconds = int(e.response.headers.get("Retry-After", 1))


### PR DESCRIPTION
Instead of raising a python error and crash when Trakt do not respond properly, it will explain the problem as coming from Trakt, tell user to retry later and abort the script run.

closes #333 