### PR TITLE
Add support for forward declare of annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project adds a two-way-sync between trakt.tv and Plex Media Server. It
 requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions,
 unlike the Plex app provided by Trakt.
 
-[python-versions-badge]: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue
+[python-versions-badge]: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue
 
 ## Features
 
@@ -22,7 +22,7 @@ unlike the Plex app provided by Trakt.
 
 ## Pre-requisites
 
-The script is known to work with Python 3.6-3.9 versions.
+The script is known to work with Python 3.7-3.9 versions.
 
 ## Installing
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import datetime
 from typing import Union
 


### PR DESCRIPTION
This bumps Python minimum version to 3.7

_Extracted from https://github.com/Taxel/PlexTraktSync/pull/330_