### PR TITLE
Refactor: Add factory class for controlling API instances

### DIFF
--- a/plex_trakt_sync/commands/clear_collections.py
+++ b/plex_trakt_sync/commands/clear_collections.py
@@ -1,6 +1,7 @@
 import click
+
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.logging import logger
-from plex_trakt_sync.trakt_api import TraktApi
 
 
 @click.command()
@@ -15,7 +16,7 @@ def clear_collections(confirm, dry_run):
         click.echo('You need to pass --confirm or --dry-run option to proceed')
         return
 
-    trakt = TraktApi()
+    trakt = factory.trakt_api()
 
     for movie in trakt.movie_collection:
         logger.info(f"Deleting: {movie}")

--- a/plex_trakt_sync/commands/inspect.py
+++ b/plex_trakt_sync/commands/inspect.py
@@ -1,8 +1,5 @@
 import click
-from plexapi.server import PlexServer
-from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.plex_api import PlexApi
-from plex_trakt_sync.trakt_api import TraktApi
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.version import git_version_info
 
 
@@ -16,11 +13,8 @@ def inspect(input):
     git_version = git_version_info() or 'Unknown version'
     print(f"PlexTraktSync inspect [{git_version}]")
 
-    url = CONFIG["PLEX_BASEURL"]
-    token = CONFIG["PLEX_TOKEN"]
-    server = PlexServer(url, token)
-    plex = PlexApi(server)
-    trakt = TraktApi()
+    plex = factory.plex_api()
+    trakt = factory.trakt_api()
 
     if input.isnumeric():
         input = int(input)

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -2,12 +2,11 @@ import click
 from plexapi.server import PlexServer
 
 from plex_trakt_sync.commands.login import ensure_login
-from plex_trakt_sync.media import MediaFactory, Media
+from plex_trakt_sync.factory import factory
+from plex_trakt_sync.media import Media
 from plex_trakt_sync.requests_cache import requests_cache
-from plex_trakt_sync.plex_server import get_plex_server
 from plex_trakt_sync.config import CONFIG
 from plex_trakt_sync.decorators import measure_time
-from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.trakt_api import TraktApi
 from plex_trakt_sync.trakt_list_util import TraktListUtil
 from plex_trakt_sync.logging import logger
@@ -139,10 +138,10 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
     movies = sync_option in ["all", "movies"]
     tv = sync_option in ["all", "tv"]
 
-    server = get_plex_server()
-    plex = PlexApi(server)
-    trakt = TraktApi(batch_size=batch_size)
-    mf = MediaFactory(plex, trakt)
+    server = factory.plex_server()
+    plex = factory.plex_api()
+    trakt = factory.trakt_api(batch_size=batch_size)
+    mf = factory.media_factory(batch_size=batch_size)
     w = Walker(plex, mf, movies=movies, shows=tv, progressbar=click.progressbar)
 
     if library:

--- a/plex_trakt_sync/commands/trakt_login.py
+++ b/plex_trakt_sync/commands/trakt_login.py
@@ -5,6 +5,7 @@ import click
 from trakt.errors import ForbiddenException
 
 from plex_trakt_sync.config import CONFIG
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.path import pytrakt_file
 from plex_trakt_sync.style import title, success, error, prompt
 from plex_trakt_sync.trakt_api import TraktApi
@@ -47,7 +48,7 @@ def trakt_login():
     Log in to Trakt Account to obtain Access Token.
     """
 
-    api = TraktApi()
+    api = factory.trakt_api()
     trakt_authenticate(api)
     user = api.me.username
 

--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -1,6 +1,7 @@
 import click
 from plexapi.server import PlexServer
 
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.listener import WebSocketListener, PLAYING
 from plex_trakt_sync.config import CONFIG
 from plex_trakt_sync.plex_api import PlexApi
@@ -86,11 +87,9 @@ def watch():
     Listen to events from Plex
     """
 
-    url = CONFIG["PLEX_BASEURL"]
-    token = CONFIG["PLEX_TOKEN"]
-    server = PlexServer(url, token)
-    trakt = TraktApi()
-    plex = PlexApi(server)
+    server = factory.plex_server()
+    trakt = factory.trakt_api()
+    plex = factory.plex_api()
 
     ws = WebSocketListener(server)
     ws.on(PLAYING, WatchStateUpdater(plex, trakt))

--- a/plex_trakt_sync/commands/webhook.py
+++ b/plex_trakt_sync/commands/webhook.py
@@ -5,11 +5,10 @@ from http.server import BaseHTTPRequestHandler
 
 import click
 
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.logging import logger
 from plex_trakt_sync.media import MediaFactory
 from plex_trakt_sync.plex_api import PlexApi
-from plex_trakt_sync.plex_server import get_plex_server
-from plex_trakt_sync.trakt_api import TraktApi
 
 TAUTULLI_WEBHOOK_URL = "https://github.com/Taxel/PlexTraktSync#tautulli-webhook"
 
@@ -100,10 +99,8 @@ def webhook(bind: str, port: int):
     """
 
     with socketserver.TCPServer((bind, port), HttpRequestHandler, bind_and_activate=False) as httpd:
-        server = get_plex_server()
-        plex = PlexApi(server)
-        trakt = TraktApi()
-        mf = MediaFactory(server, trakt)
+        plex = factory.plex_api()
+        mf = factory.media_factory()
 
         httpd.allow_reuse_address = True
         httpd.webhook = WebhookHandler(plex, mf)

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -33,5 +33,11 @@ class Factory:
 
         return mf
 
+    @memoize
+    def plex_server(self):
+        from plex_trakt_sync.plex_server import get_plex_server
+
+        return get_plex_server()
+
 
 factory = Factory()

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -35,3 +35,6 @@ class Factory:
         mf = MediaFactory(plex, trakt)
 
         return mf
+
+
+factory = Factory()

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -2,16 +2,14 @@ from plex_trakt_sync.decorators import memoize
 
 
 class Factory:
-    @property
     @memoize
-    def trakt_api(self):
+    def trakt_api(self, batch_size=None):
         from plex_trakt_sync.trakt_api import TraktApi
 
-        trakt = TraktApi()
+        trakt = TraktApi(batch_size=batch_size)
 
         return trakt
 
-    @property
     @memoize
     def plex_api(self):
         from plex_trakt_sync.config import CONFIG
@@ -25,13 +23,12 @@ class Factory:
 
         return plex
 
-    @property
     @memoize
     def media_factory(self):
         from plex_trakt_sync.media import MediaFactory
 
-        trakt = self.trakt_api
-        plex = self.plex_api
+        trakt = self.trakt_api()
+        plex = self.plex_api()
         mf = MediaFactory(plex, trakt)
 
         return mf

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -24,10 +24,10 @@ class Factory:
         return plex
 
     @memoize
-    def media_factory(self):
+    def media_factory(self, batch_size=None):
         from plex_trakt_sync.media import MediaFactory
 
-        trakt = self.trakt_api()
+        trakt = self.trakt_api(batch_size=batch_size)
         plex = self.plex_api()
         mf = MediaFactory(plex, trakt)
 

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -12,13 +12,9 @@ class Factory:
 
     @memoize
     def plex_api(self):
-        from plex_trakt_sync.config import CONFIG
         from plex_trakt_sync.plex_api import PlexApi
-        from plexapi.server import PlexServer
 
-        url = CONFIG["PLEX_BASEURL"]
-        token = CONFIG["PLEX_TOKEN"]
-        server = PlexServer(url, token)
+        server = self.plex_server()
         plex = PlexApi(server)
 
         return plex

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -1,0 +1,37 @@
+from plex_trakt_sync.decorators import memoize
+
+
+class Factory:
+    @property
+    @memoize
+    def trakt_api(self):
+        from plex_trakt_sync.trakt_api import TraktApi
+
+        trakt = TraktApi()
+
+        return trakt
+
+    @property
+    @memoize
+    def plex_api(self):
+        from plex_trakt_sync.config import CONFIG
+        from plex_trakt_sync.plex_api import PlexApi
+        from plexapi.server import PlexServer
+
+        url = CONFIG["PLEX_BASEURL"]
+        token = CONFIG["PLEX_TOKEN"]
+        server = PlexServer(url, token)
+        plex = PlexApi(server)
+
+        return plex
+
+    @property
+    @memoize
+    def media_factory(self):
+        from plex_trakt_sync.media import MediaFactory
+
+        trakt = self.trakt_api
+        plex = self.plex_api
+        mf = MediaFactory(plex, trakt)
+
+        return mf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ from typing import Union
 
 from trakt.tv import TVShow
 
-from plex_trakt_sync.decorators import memoize
+from plex_trakt_sync.factory import Factory
 
 MOCK_DATA_DIR = join_path(dirname(__file__), "mock_data")
+factory = Factory()
 
 
 def load_mock(name: str):
@@ -19,37 +20,3 @@ def make(cls=None, **kwargs) -> Union[TVShow]:
     cls = cls if cls is not None else "object"
     # https://stackoverflow.com/a/2827726/2314626
     return type(cls, (object,), kwargs)
-
-
-@memoize
-def get_trakt_api():
-    from plex_trakt_sync.trakt_api import TraktApi
-
-    trakt = TraktApi()
-
-    return trakt
-
-
-@memoize
-def get_plex_api():
-    from plex_trakt_sync.config import CONFIG
-    from plex_trakt_sync.plex_api import PlexApi
-    from plexapi.server import PlexServer
-
-    url = CONFIG["PLEX_BASEURL"]
-    token = CONFIG["PLEX_TOKEN"]
-    server = PlexServer(url, token)
-    plex = PlexApi(server)
-
-    return plex
-
-
-@memoize
-def get_media_factory():
-    from plex_trakt_sync.media import MediaFactory
-
-    trakt = get_trakt_api()
-    plex = get_plex_api()
-    mf = MediaFactory(plex, trakt)
-
-    return mf

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3 -m pytest
 from plex_trakt_sync.trakt_api import TraktBatch
-from tests.conftest import load_mock, get_trakt_api
+from tests.conftest import load_mock, factory
 from unittest.mock import Mock
 
-trakt = get_trakt_api()
+trakt = factory.trakt_api()
 
 
 def test_batch_size_none():

--- a/tests/test_new_agent.py
+++ b/tests/test_new_agent.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3 -m pytest
 from plex_trakt_sync.plex_api import PlexLibraryItem
-from tests.conftest import get_trakt_api, make
+from tests.conftest import make, factory
 
-trakt = get_trakt_api()
+trakt = factory.trakt_api()
 
 
 def test_tv_lookup():

--- a/tests/test_plex_search.py
+++ b/tests/test_plex_search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -m pytest
-from tests.conftest import get_plex_api
+from tests.conftest import factory
 
-plex = get_plex_api()
+plex = factory.plex_api()
 
 
 def test_plex_search():

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3 -m pytest
 from plex_trakt_sync.plex_api import PlexLibraryItem
-from tests.conftest import get_trakt_api, make
+from tests.conftest import make, factory
 
-trakt = get_trakt_api()
+trakt = factory.trakt_api()
 
 
 def test_tv_lookup():

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3 -m pytest
 from plex_trakt_sync.walker import Walker
-from tests.conftest import get_plex_api, get_media_factory
+from tests.conftest import factory
 
-plex = get_plex_api()
-mf = get_media_factory()
+plex = factory.plex_api()
+mf = factory.media_factory()
 
 
 def test_walker():


### PR DESCRIPTION
This simplifies code by moving object instantiation to a single place. Some places behaved differently because `get_plex_server()` wasn't used, but `PlexServer()` directly.