### PR TITLE
Walk over Plex guids as they come until trakt match

### DIFF
--- a/plex_trakt_sync/media.py
+++ b/plex_trakt_sync/media.py
@@ -96,12 +96,12 @@ class MediaFactory:
         self.trakt = trakt
 
     def resolve_any(self, pm: PlexLibraryItem, tm=None):
-        # quick search for old code (faster)
-        m = self.resolve(pm, tm)
-        if m:
-            return m
+        # old code reads only first guid
+        #m = self.resolve(pm, tm)
+        #if m:
+        #    return m
 
-        # walk over all guids (slower)
+        # walk over all guids
         for guid in pm.guids:
             m = self.resolve_guid(guid, tm)
             if m:
@@ -139,7 +139,7 @@ class MediaFactory:
             return None
 
         if tm is None:
-            logger.warning(f"Skipping {guid.pm}: Not found on Trakt")
+            logger.debug(f"Skipping {guid.pm}: Not found on Trakt")
             return None
 
         return Media(guid.pm, tm, plex_api=self.plex, trakt_api=self.trakt)

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -102,18 +102,7 @@ class PlexLibraryItem:
         guids = [PlexGuid(guid.id, self.type, self) for guid in self.item.guids]
         if not guids:
             guids = [self.guid]
-
-        # take guid in this order:
-        # - tmdb, tvdb, then imdb
-        # https://github.com/Taxel/PlexTraktSync/issues/313#issuecomment-838447631
-        sort_order = {
-            "tmdb": 1,
-            "tvdb": 2,
-            "imdb": 3,
-            "local": 100,
-        }
-        ordered = sorted(guids, key=lambda guid: sort_order[guid.provider])
-        return ordered
+        return guids
 
     @property
     @memoize


### PR DESCRIPTION
Draft PR for discussion and testing

- removes plex guids sorting (not needed and slows the script)
- ~~prevent tvdb movie request to Trakt (comply to trakt API doc)~~ --> extracted to #343
- walks over guids until matching result from Trakt

The Trakt API states that tvdb is only for shows and episodes :
https://trakt.docs.apiary.io/#reference/search/id-lookup/get-id-lookup-results

fixes #318
fixes #338