### PR TITLE
Prevent tvdb movie search trakt request

### DIFF
--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -224,6 +224,12 @@ class TraktApi:
 
     @rate_limit()
     def search_by_id(self, media_id: str, id_type: str, media_type: str):
+        if id_type == "tvdb" and media_type == "movie":
+            # Skip invalid search.
+            # The Trakt API states that tvdb is only for shows and episodes:
+            # https://trakt.docs.apiary.io/#reference/search/id-lookup/get-id-lookup-results
+            return None
+
         search = trakt.sync.search_by_id(media_id, id_type=id_type, media_type=media_type)
         # look for the first wanted type in the results
         # NOTE: this is not needed, kept around for caution

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -228,6 +228,7 @@ class TraktApi:
             # Skip invalid search.
             # The Trakt API states that tvdb is only for shows and episodes:
             # https://trakt.docs.apiary.io/#reference/search/id-lookup/get-id-lookup-results
+            logger.debug("tvdb does not support movie provider")
             return None
 
         search = trakt.sync.search_by_id(media_id, id_type=id_type, media_type=media_type)


### PR DESCRIPTION
_Extracted from https://github.com/Taxel/PlexTraktSync/pull/341_

The Trakt API states that tvdb is only for shows and episodes :
- https://trakt.docs.apiary.io/#reference/search/id-lookup/get-id-lookup-results

Plex should not be able to match tvdb id for movies, so it can't exist as guid..., but it can exist as guid in Plex:
- https://github.com/Taxel/PlexTraktSync/issues/318#issuecomment-855386958

Closes #318