### PR TITLE
Refactor: Remove requests_cache local module

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -5,7 +5,7 @@ from plex_trakt_sync.factory import factory
 from plex_trakt_sync.media import Media
 from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.config import CONFIG
-from plex_trakt_sync.decorators import measure_time
+from plex_trakt_sync.decorators.measure_time import measure_time
 from plex_trakt_sync.trakt_api import TraktApi
 from plex_trakt_sync.trakt_list_util import TraktListUtil
 from plex_trakt_sync.logging import logger

--- a/plex_trakt_sync/decorators/__init__.py
+++ b/plex_trakt_sync/decorators/__init__.py
@@ -1,6 +1,0 @@
-from .http_cache import http_cache
-from .measure_time import measure_time
-from .memoize import memoize
-from .nocache import nocache
-from .rate_limit import rate_limit
-from .time_limit import time_limit

--- a/plex_trakt_sync/decorators/http_cache.py
+++ b/plex_trakt_sync/decorators/http_cache.py
@@ -1,14 +1,15 @@
 from functools import wraps
 
-import requests_cache
-
+from plex_trakt_sync.factory import factory
 from plex_trakt_sync.path import trakt_cache
+
+cache = factory.requests_cache()
 
 
 def http_cache(method, expire_after=None):
     @wraps(method)
     def inner(self, *args, **kwargs):
-        with requests_cache.enabled(trakt_cache, expire_after=expire_after):
+        with cache.enabled(trakt_cache, expire_after=expire_after):
             return method(self, *args, **kwargs)
 
     return inner

--- a/plex_trakt_sync/decorators/nocache.py
+++ b/plex_trakt_sync/decorators/nocache.py
@@ -1,12 +1,14 @@
 from functools import wraps
 
-import requests_cache
+from plex_trakt_sync.factory import factory
+
+cache = factory.requests_cache()
 
 
 def nocache(method):
     @wraps(method)
     def inner(self, *args, **kwargs):
-        with requests_cache.disabled():
+        with cache.disabled():
             return method(self, *args, **kwargs)
 
     return inner

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -1,4 +1,4 @@
-from plex_trakt_sync.decorators import memoize
+from plex_trakt_sync.decorators.memoize import memoize
 
 
 class Factory:

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -35,5 +35,21 @@ class Factory:
 
         return get_plex_server()
 
+    @memoize
+    def session(self):
+        import requests
+        session = requests.Session()
+
+        return session
+
+    @memoize
+    def requests_cache(self):
+        import requests_cache
+        from plex_trakt_sync.path import trakt_cache
+
+        requests_cache.install_cache(trakt_cache)
+
+        return requests_cache
+
 
 factory = Factory()

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -6,7 +6,8 @@ from plexapi.exceptions import BadRequest, NotFound
 from plexapi.library import MovieSection, ShowSection, LibrarySection
 from plexapi.server import PlexServer
 
-from plex_trakt_sync.decorators import memoize, nocache
+from plex_trakt_sync.decorators.memoize import memoize
+from plex_trakt_sync.decorators.nocache import nocache
 from plex_trakt_sync.config import CONFIG
 from trakt.utils import timestamp
 

--- a/plex_trakt_sync/plex_server.py
+++ b/plex_trakt_sync/plex_server.py
@@ -1,6 +1,6 @@
 import plexapi.server
 from plex_trakt_sync.config import CONFIG, PLEX_PLATFORM
-from plex_trakt_sync.decorators import nocache
+from plex_trakt_sync.decorators.nocache import nocache
 from plex_trakt_sync.logging import logger
 
 

--- a/plex_trakt_sync/requests_cache.py
+++ b/plex_trakt_sync/requests_cache.py
@@ -1,7 +1,0 @@
-import requests
-import requests_cache
-from .path import trakt_cache
-
-requests_cache.install_cache(trakt_cache)
-
-session = requests.Session()

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -11,7 +11,10 @@ from trakt.errors import OAuthException, ForbiddenException
 from trakt.sync import Scrobbler
 
 from plex_trakt_sync.logging import logger
-from plex_trakt_sync.decorators import memoize, nocache, rate_limit, time_limit
+from plex_trakt_sync.decorators.memoize import memoize
+from plex_trakt_sync.decorators.nocache import nocache
+from plex_trakt_sync.decorators.rate_limit import rate_limit
+from plex_trakt_sync.decorators.time_limit import time_limit
 from plex_trakt_sync.config import CONFIG
 from plex_trakt_sync import pytrakt_extensions
 from plex_trakt_sync.path import pytrakt_file

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from plex_trakt_sync.decorators import measure_time
+from plex_trakt_sync.decorators.measure_time import measure_time
 from plex_trakt_sync.media import MediaFactory, Media
 from plex_trakt_sync.plex_api import PlexApi
 


### PR DESCRIPTION
Having a local module with the same name as the package is confusing. Confusing for IDE and then confusing to humans as IDE can't resolve symbols.