### PR TITLE
Ensure CachedSession uses same cache path as before

### DIFF
--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -38,7 +38,9 @@ class Factory:
     @memoize
     def session(self):
         from requests_cache import CachedSession
-        session = CachedSession()
+        from plex_trakt_sync.path import trakt_cache
+
+        session = CachedSession(trakt_cache)
 
         return session
 


### PR DESCRIPTION
Bugfix to https://github.com/Taxel/PlexTraktSync/pull/355