### PR TITLE
Update plexapi to 4.6.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 click = "==7.1.2"
 deprecated = "==1.2.12"
-plexapi = "==4.5.0"
+plexapi = "==4.6.1"
 python-dotenv = "==0.15.0"
 python-git-info = "==0.7.1"
 requests = ">=2.25.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d6b2ecda723ac7c4dbd004502c43506f7f11521540bfbe5c1f8281107f62839c"
+            "sha256": "c8dfd88169d15d73933402d1f53c491c9e1caa5f96a6c0784b30c51654c64599"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -73,11 +73,11 @@
         },
         "plexapi": {
             "hashes": [
-                "sha256:969d07b8b21368d8b0fdcc781b31b7b517369d95ee9db1b105b053a370207262",
-                "sha256:b46d97413fca657e9c1898547dc30cb10e186481610001ba76d59f4fd3948662"
+                "sha256:efd33bb7855437fec4a0b5a648f675aee56c0d5c7ce28caa17b1b4d11ab01437",
+                "sha256:fdb91a6d6ef8a0b025afb048fefbd4f234a72b5afa7b9a78298c0d97b50cd3e3"
             ],
             "index": "pypi",
-            "version": "==4.5.0"
+            "version": "==4.6.1"
         },
         "python-dotenv": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
 deprecated==1.2.12
-plexapi==4.5.0
+plexapi==4.6.1
 python-dotenv==0.15.0
 python-git-info==0.7.1
 requests-cache==0.6.3


### PR DESCRIPTION
- https://github.com/pkkid/python-plexapi/releases/tag/4.5.1
- https://github.com/pkkid/python-plexapi/releases/tag/4.5.2
- https://github.com/pkkid/python-plexapi/releases/tag/4.6.0
- https://github.com/pkkid/python-plexapi/releases/tag/4.6.1