### PR TITLE
Speedup .guids access for legacy agent

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -96,6 +96,7 @@ class PlexLibraryItem:
 
     @property
     @memoize
+    @deprecated("Use .guids directly")
     def guid(self):
         if not self.is_legacy_agent:
             return self.guids[0]

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -90,10 +90,14 @@ class PlexLibraryItem:
     def __init__(self, item):
         self.item = item
 
+    @memoize
+    def is_legacy_agent(self):
+        return not self.item.guid.startswith('plex://')
+
     @property
     @memoize
     def guid(self):
-        if self.item.guid.startswith('plex://') and len(self.item.guids) > 0:
+        if not self.is_legacy_agent:
             return self.guids[0]
         return PlexGuid(self.item.guid, self.type, self)
 
@@ -104,7 +108,7 @@ class PlexLibraryItem:
         # accessing .guids for legacy agent
         # will make another round-trip to plex server
         # and the result is always empty.
-        if not self.item.guid.startswith('plex://'):
+        if self.is_legacy_agent:
             return [self.guid]
 
         guids = [PlexGuid(guid.id, self.type, self) for guid in self.item.guids]

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -100,9 +100,14 @@ class PlexLibraryItem:
     @property
     @memoize
     def guids(self):
+        # return early if legacy agent
+        # accessing .guids for legacy agent
+        # will make another round-trip to plex server
+        # and the result is always empty.
+        if not self.item.guid.startswith('plex://'):
+            return [self.guid]
+
         guids = [PlexGuid(guid.id, self.type, self) for guid in self.item.guids]
-        if not guids:
-            guids = [self.guid]
 
         # take guid in this order:
         # - tmdb, tvdb, then imdb


### PR DESCRIPTION
return early in guids method, if legacy agent as accessing .guids for legacy agent
will make another round-trip to plex server and the result is always empty anyway.