### PR TITLE
Always walk all guids to find a match

### DIFF
--- a/plex_trakt_sync/media.py
+++ b/plex_trakt_sync/media.py
@@ -96,12 +96,6 @@ class MediaFactory:
         self.trakt = trakt
 
     def resolve_any(self, pm: PlexLibraryItem, tm=None):
-        # quick search for old code (faster)
-        m = self.resolve(pm, tm)
-        if m:
-            return m
-
-        # walk over all guids (slower)
         for guid in pm.guids:
             m = self.resolve_guid(guid, tm)
             if m:


### PR DESCRIPTION
_Replaces https://github.com/Taxel/PlexTraktSync/pull/341_

Walk over guids until matching result from Trakt.

Guids are processed in preferred order to minimize API calls:
- https://github.com/Taxel/PlexTraktSync/issues/313#issuecomment-838447631

This can be merged ok, since the performance problem has been eliminated:
- https://github.com/Taxel/PlexTraktSync/pull/358

fixes #318
fixes #338
