### PR TITLE
Remove py<3.6 support

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -226,10 +226,7 @@ class PlexLibraryItem:
         if not date:
             raise ValueError("Value can't be None")
 
-        try:
-            return date.astimezone(datetime.timezone.utc)
-        except ValueError:  # for py<3.6
-            return date
+        return date.astimezone(datetime.timezone.utc)
 
     def __repr__(self):
         return "<%s:%s:%s>" % (self.guid.provider, self.guid.id, self.item)


### PR DESCRIPTION
This project requires Python 3.7 (since 0.11.0), so code to support Python < 3.6 can be safely dropped.

refs:
- https://github.com/Taxel/PlexTraktSync/pull/336