### PR TITLE
Regenerate Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -31,13 +31,13 @@
             ],
             "version": "==2021.5.30"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
+                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==4.0.0"
+            "markers": "python_version >= '3'",
+            "version": "==2.0.1"
         },
         "click": {
             "hashes": [
@@ -57,11 +57,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.10"
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
         },
         "itsdangerous": {
             "hashes": [
@@ -139,11 +139,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
             "index": "pypi",
-            "version": "==2.25.1"
+            "version": "==2.26.0"
         },
         "requests-cache": {
             "hashes": [
@@ -166,7 +166,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "trakt": {


### PR DESCRIPTION
I tried to understand why updating requests-cache to 0.7.1 (#378) added [pyaml](https://pypi.org/project/pyaml/) dependency, so I regenerated `Pipfile.lock`.

somewhy the result is not identical:
- chardet 4.0.0 replaced with charset-normalizer 2.0.1
- requests updated to 2.26.0
- idna updated to 3.2
- typical markers flip-flop

Here's the full dependency graph:
```
$ pipenv graph
click==7.1.2
Deprecated==1.2.12
  - wrapt [required: >=1.10,<2, installed: 1.12.1]
PlexAPI==4.6.1
  - requests [required: Any, installed: 2.26.0]
    - certifi [required: >=2017.4.17, installed: 2021.5.30]
    - charset-normalizer [required: ~=2.0.0, installed: 2.0.1]
    - idna [required: >=2.5,<4, installed: 3.2]
    - urllib3 [required: >=1.21.1,<1.27, installed: 1.26.6]
python-dotenv==0.15.0
python-git-info==0.7.1
requests-cache==0.7.1
  - attrs [required: >=21.2,<22.0, installed: 21.2.0]
  - itsdangerous [required: >=2.0.1, installed: 2.0.1]
  - pyyaml [required: >=5.4, installed: 5.4.1]
  - requests [required: >=2.17,<3.0, installed: 2.26.0]
    - certifi [required: >=2017.4.17, installed: 2021.5.30]
    - charset-normalizer [required: ~=2.0.0, installed: 2.0.1]
    - idna [required: >=2.5,<4, installed: 3.2]
    - urllib3 [required: >=1.21.1,<1.27, installed: 1.26.6]
  - url-normalize [required: >=1.4,<2.0, installed: 1.4.3]
    - six [required: Any, installed: 1.16.0]
trakt==3.2.0
  - requests [required: >=2.25, installed: 2.26.0]
    - certifi [required: >=2017.4.17, installed: 2021.5.30]
    - charset-normalizer [required: ~=2.0.0, installed: 2.0.1]
    - idna [required: >=2.5,<4, installed: 3.2]
    - urllib3 [required: >=1.21.1,<1.27, installed: 1.26.6]
  - requests-oauthlib [required: >=1.3, installed: 1.3.0]
    - oauthlib [required: >=3.0.0, installed: 3.1.1]
    - requests [required: >=2.0.0, installed: 2.26.0]
      - certifi [required: >=2017.4.17, installed: 2021.5.30]
      - charset-normalizer [required: ~=2.0.0, installed: 2.0.1]
      - idna [required: >=2.5,<4, installed: 3.2]
      - urllib3 [required: >=1.21.1,<1.27, installed: 1.26.6]
websocket-client==1.0.1
```