### PR TITLE
Tqdm progressbar

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ requests-cache = "==0.7.1"
 trakt = "==3.2.0"
 urllib3 = ">=1.26.6"
 websocket-client = "==1.0.1"
+tqdm = "==4.61.2"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d3de1cd9a238bfcb6790fcdfc86c01a15fba7bf315d1626bd964035c2eedcd05"
+            "sha256": "05f5ca0efccfb0d2ae630b450ede10a9cc1f1605d09c2344a7c5974410033bb7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,11 +33,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
-                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
+                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
+                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.1"
+            "version": "==2.0.3"
         },
         "click": {
             "hashes": [
@@ -166,8 +166,16 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:5aa445ea0ad8b16d82b15ab342de6b195a722d75fc1ef9934a46bba6feafbc64",
+                "sha256:8bb94db0d4468fea27d004a0f1d1c02da3cdedc00fe491c0de986b76a04d6b0a"
+            ],
+            "index": "pypi",
+            "version": "==4.61.2"
         },
         "trakt": {
             "hashes": [

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -1,4 +1,5 @@
 import click
+from tqdm import tqdm
 
 from plex_trakt_sync.commands.login import ensure_login
 from plex_trakt_sync.factory import factory
@@ -142,7 +143,7 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
     plex = factory.plex_api()
     trakt = factory.trakt_api(batch_size=batch_size)
     mf = factory.media_factory(batch_size=batch_size)
-    w = Walker(plex, mf, movies=movies, shows=tv, progressbar=click.progressbar)
+    w = Walker(plex, mf, movies=movies, shows=tv, progressbar=tqdm)
 
     if library:
         logger.info(f"Filtering Library: {library}")
@@ -158,7 +159,7 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int)
         click.echo("Nothing to sync, this is likely due conflicting options given.")
         return
 
-    w.walk_details(print=click.echo)
+    w.walk_details(print=tqdm.write)
 
     with measure_time("Completed full sync"):
         sync_all(walker=w, trakt=trakt, plex=plex)

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -7,8 +7,6 @@ from .path import log_file
 
 
 class TqdmLoggingHandler(logging.StreamHandler):
-    def __init__(self, stream=None):
-        super().__init__(stream)
 
     def emit(self, record):
         try:

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -7,8 +7,8 @@ from .path import log_file
 
 
 class TqdmLoggingHandler(logging.StreamHandler):
-    def __init__(self, level=logging.NOTSET):
-        super().__init__(level)
+    def __init__(self, stream=None):
+        super().__init__(stream)
 
     def emit(self, record):
         try:

--- a/plex_trakt_sync/logging.py
+++ b/plex_trakt_sync/logging.py
@@ -1,7 +1,25 @@
 import logging
 import sys
+import tqdm
+
 from .factory import factory
 from .path import log_file
+
+
+class TqdmLoggingHandler(logging.StreamHandler):
+    def __init__(self, level=logging.NOTSET):
+        super().__init__(level)
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            tqdm.tqdm.write(msg)
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)  
+
 
 
 def initialize():
@@ -11,7 +29,7 @@ def initialize():
     log_format = '%(asctime)s %(levelname)s:%(message)s'
 
     # messages with info and above are printed to stdout
-    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler = TqdmLoggingHandler(sys.stdout)
     console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
     console_handler.setLevel(logging.INFO)
 

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -98,11 +98,11 @@ class Walker:
 
         for section in sections:
             with measure_time(f"{section.title} processed"):
-                it = self.progressbar(section.items(), length=len(section), label=f"Processing {section.title}")
+                it = self.progressbar(section.items(), total=len(section), desc=f"Processing {section.title}")
                 yield from it
 
     def media_from_titles(self, libtype: str, titles: List[str]):
-        it = self.progressbar(titles, label=f"Processing {libtype}s")
+        it = self.progressbar(titles, desc=f"Processing {libtype}s")
         for title in it:
             search = self.plex.search(title, libtype=libtype)
             yield from search
@@ -118,7 +118,7 @@ class Walker:
 
     def progressbar(self, iterable, **kwargs):
         if self._progressbar:
-            pb = self._progressbar(iterable, show_pos=True, **kwargs)
+            pb = self._progressbar(iterable, **kwargs)
             with pb as it:
                 yield from it
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests>=2.25.1
 trakt==3.2.0
 urllib3>=1.26.6
 websocket-client==1.0.1
+tqdm==4.61.2


### PR DESCRIPTION
I managed to fix #377 by using tqdm and some minimal changes. tqdm is even [recommended by click](https://click.palletsprojects.com/en/8.0.x/utils/#showing-progress-bars) if you want a more capable progress bar. It is also much faster.

> Note
If you find that you have requirements beyond what Click’s progress bar supports, try using tqdm.

The log messages are now printed in a different line without interrupting the progress bar:

![image](https://user-images.githubusercontent.com/15388116/126048101-1122eb02-fe9b-449b-8662-d6a129d0b68d.png)

Fixes #377