### PR TITLE
Fix Plex username being 'None'

### DIFF
--- a/plex_trakt_sync/commands/plex_login.py
+++ b/plex_trakt_sync/commands/plex_login.py
@@ -156,7 +156,7 @@ def plex_login(username, password):
     click.echo(success(f"Connection to {plex.friendlyName} established successfully!"))
 
     token = server.accessToken
-    user = username
+    user = account.username
     if server.owned:
         managed_user = choose_managed_user(account)
         if managed_user:


### PR DESCRIPTION
```
# ./plex_trakt_sync.sh 
INFO: Syncing with Plex None and Trakt twolaw
...
```