### PR TITLE
Fix resolution detection of Plex medias (uses picture width)

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -254,24 +254,24 @@ class PlexLibraryItem:
         """
         try:
             media = self.item.media[0]
-            height = media.height
-            assert height is not None
+            width = media.width
+            assert width is not None
         except (AttributeError, IndexError, TypeError, AssertionError):
             return None
         # 4k
-        if height > 1100:
+        if width >= 3840:
             return 'uhd_4k'
 
         # 1080
-        if height > 720:
+        if width >= 1920:
             return 'hd_1080p'
 
         # 720
-        if height > 576:
+        if width >= 1280:
             return 'hd_720p'
 
         # 576
-        if height > 480:
+        if width >= 768:
             return 'sd_576p'
 
         # 480


### PR DESCRIPTION
Reads Plex media picture **width** instead of picture **height** to get their correct resolutions.

discussed in:
- https://github.com/Taxel/PlexTraktSync/pull/366#issuecomment-878592575

closes #117


refs:
- https://github.com/trakt/Plex-Trakt-Scrobbler/pull/490