### PR TITLE
Make cache path configurable

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -3,6 +3,9 @@
     "logging": {
         "append": false
     },
+    "cache": {
+        "path": "trakt_cache"
+    },
     "sync": {
         "liked_lists": true,
         "watchlist": true,

--- a/plex_trakt_sync/commands/cache.py
+++ b/plex_trakt_sync/commands/cache.py
@@ -3,7 +3,7 @@ from functools import partial
 import click
 from requests_cache import CachedSession
 
-from plex_trakt_sync.path import trakt_cache
+from plex_trakt_sync.factory import factory
 
 
 def get_sorted_cache(session: CachedSession, sorting: str, reverse: bool):
@@ -83,6 +83,9 @@ def cache(sort: str, limit: int, reverse: bool, url: str):
     """
     Manage and analyze Requests Cache.
     """
+
+    config = factory.config()
+    trakt_cache = config["cache"]["path"]
     session = CachedSession(cache_name=trakt_cache, backend='sqlite')
 
     if url:

--- a/plex_trakt_sync/decorators/http_cache.py
+++ b/plex_trakt_sync/decorators/http_cache.py
@@ -1,10 +1,11 @@
 from functools import wraps
 
 from plex_trakt_sync.factory import factory
-from plex_trakt_sync.path import trakt_cache
 
 cache = factory.requests_cache()
 session = factory.session()
+config = factory.config()
+trakt_cache = config["cache"]["path"]
 
 
 def http_cache(method, expire_after=None):

--- a/plex_trakt_sync/factory.py
+++ b/plex_trakt_sync/factory.py
@@ -38,8 +38,9 @@ class Factory:
     @memoize
     def session(self):
         from requests_cache import CachedSession
-        from plex_trakt_sync.path import trakt_cache
 
+        config = self.config()
+        trakt_cache = config["cache"]["path"]
         session = CachedSession(trakt_cache)
 
         return session
@@ -47,7 +48,9 @@ class Factory:
     @memoize
     def requests_cache(self):
         import requests_cache
-        from plex_trakt_sync.path import trakt_cache
+
+        config = self.config()
+        trakt_cache = config["cache"]["path"]
 
         requests_cache.install_cache(trakt_cache)
 


### PR DESCRIPTION
The intent is to keep the cache out of project dir.

Example:

```json
{
    "cache": {
        "path": "~/.cache/PlexTraktSync/http_cache"
    },
```