### PR TITLE
Disable cache for guids resolve

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -130,6 +130,7 @@ class PlexLibraryItem:
     def guid(self):
         return self.guids[0]
 
+    @nocache
     @rate_limit()
     def get_guids(self):
         return self.item.guids


### PR DESCRIPTION
- Fixes https://github.com/Taxel/PlexTraktSync/issues/387
- Fixes https://github.com/Taxel/PlexTraktSync/issues/384
- Replaces https://github.com/Taxel/PlexTraktSync/pull/401

Problem is that the xml feed from section.all() does not contain data for media item .guids, so data for that is called when item.guids is first accessed, lazy loaded on demand.

Ideally this should be solved in PMS or python-plexapi:
- https://github.com/pkkid/python-plexapi/issues/808