### PR TITLE
Bring back guid error log verbosity

### DIFF
--- a/plex_trakt_sync/media.py
+++ b/plex_trakt_sync/media.py
@@ -130,13 +130,13 @@ class MediaFactory:
 
     def resolve_guid(self, guid: PlexGuid, tm=None):
         if guid.provider in ["local", "none", "agents.none"]:
-            logger.warning(f"Skipping {guid}: Provider {guid.provider} has no external Id")
+            logger.warning(f"Skipping {guid.pm}: Provider {guid.provider} has no external Id")
 
             return None
 
         if guid.provider not in ["imdb", "tmdb", "tvdb"]:
             logger.error(
-                f"Unable to parse a valid provider from guid:{guid}"
+                f"{guid.pm}: Unable to parse a valid provider from guid:{guid}"
             )
             return None
 


### PR DESCRIPTION
1ceb69d33b2a6f84465767357047663ce6b949a5 removed information (media type and media name) in two log messages, making more difficult for user to identify concerned media.

Exemple :
`Skipping <local://4392:<local:4392:<Movie:4392:Thomas-Vdb-Bon-Chien>>>: Provider local has no external Id`
became :
`Skipping local://4392: Provider local has no external Id`

This PR reverts it to bring back the full information in log messages.