### PR TITLE
Display correct guid and media type/name in guid error log

### DIFF
--- a/plex_trakt_sync/media.py
+++ b/plex_trakt_sync/media.py
@@ -130,13 +130,13 @@ class MediaFactory:
 
     def resolve_guid(self, guid: PlexGuid, tm=None):
         if guid.provider in ["local", "none", "agents.none"]:
-            logger.warning(f"Skipping {guid.pm}: Provider {guid.provider} has no external Id")
+            logger.warning(f"{guid.pm.item}: Skipping guid {guid} because provider {guid.provider} has no external Id")
 
             return None
 
         if guid.provider not in ["imdb", "tmdb", "tvdb"]:
             logger.error(
-                f"{guid.pm}: Unable to parse a valid provider from guid:{guid}"
+                f"{guid.pm.item}: Unable to parse a valid provider from guid {guid}"
             )
             return None
 
@@ -146,11 +146,11 @@ class MediaFactory:
             else:
                 tm = self.trakt.find_by_guid(guid)
         except (TraktException, RequestException) as e:
-            logger.warning(f"Skipping {guid.pm}: Trakt errors: {e}")
+            logger.warning(f"{guid.pm.item}: Skipping guid {guid} Trakt errors: {e}")
             return None
 
         if tm is None:
-            logger.warning(f"Skipping {guid.pm}: Not found on Trakt")
+            logger.warning(f"{guid.pm.item}: Skipping guid {guid} not found on Trakt")
             return None
 
         return Media(guid.pm, tm, plex_api=self.plex, trakt_api=self.trakt)


### PR DESCRIPTION
PR #415 is not correct because guid displayed in log is the first of PlexLibraryItem guids list.
This PR makes logger to display the guid effectively concerned by raised error.


`Skipping <local://4392:<Movie:4392:Thomas-Vdb-Bon-Chien>>: Provider local has no external Id`
becomes:
`<Movie:4392:Thomas-Vdb-Bon-Chien>: Skipping guid local://4392 because provider local has no external Id`

`Skipping <tmdb:30983/1/33:<Episode:4381:Case-Closed-s01e33>>: Not found on Trakt`
becomes:
`<Episode:4381:Case-Closed-s01e33>: Skipping tmdb:30983/1/33 not found on Trakt`


closes #417