### PR TITLE
only set docker "latest" tag on tagged commits

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,8 +44,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/0.') }}
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2.6.1


### PR DESCRIPTION
Create and publish a Docker image to GHCR
on push to main branch and tags

To get these containers use

- `$ docker pull ghcr.io/taxel/plextraktsync:latest` to get latest built $tagged commit
- `$ docker pull ghcr.io/taxel/plextraktsync:main` to get latest build on main branch

Also available are tagged builds and tag for a branch:
- `$ docker pull ghcr.io/taxel/plextraktsync:$tag`
- `$ docker pull ghcr.io/taxel/plextraktsync:0.x`

https://github.com/Taxel/PlexTraktSync/pull/413#issuecomment-893778111