### PR TITLE
Add __main__ module to run script as module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine3.13 AS base
 
 WORKDIR /app
-ENTRYPOINT ["/app/main.py"]
+ENTRYPOINT ["python", "-m", "plex_trakt_sync"]
 
 # Install app depedencies
 RUN pip install --no-cache-dir pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -20,3 +20,6 @@ tqdm = "==4.62.0"
 
 [requires]
 python_version = "3"
+
+[scripts]
+plex-trakt-sync = "python -m plex_trakt_sync"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively you can use [pipenv]:
 ```
 pip3 install pipenv
 pipenv install
-pipenv run python main.py
+pipenv run plex-trakt-sync
 ```
 
 [pipenv]: https://pipenv.pypa.io/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To connect to Trakt you need to create a new API app:
 - Enter `urn:ietf:wg:oauth:2.0:oob` as the redirect url
 - You can leave Javascript origins and the Permissions checkboxes blank
 
-Then, run `python3 main.py`.
+Then, run `python3 -m plex_trakt_sync`.
 
 At first run, you will be asked to setup Trakt and Plex access.
 Follow the instructions, your credentials and API keys will be stored in
@@ -77,7 +77,7 @@ To set up to run this script in a cronjob every two hours,
 type `crontab -e` in the terminal.
 
 ```
-0 */2 * * * cd ~/path/to/this/repo && ./plex_trakt_sync.sh
+0 */2 * * * cd ~/path/to/this/repo && python3 -m plex_trakt_sync
 ```
 
 ## Sync options
@@ -86,8 +86,8 @@ The `sync` subcommand supports `--sync=tv` and `--sync=movies` options,
 so you can sync only specific library types.
 
 ```
-➔ ./plex_trakt_sync.sh sync --help
-Usage: main.py sync [OPTIONS]
+➔ python3 -m plex_trakt_sync sync --help
+Usage: plex_trakt_sync sync [OPTIONS]
 
   Perform sync between Plex and Trakt
 
@@ -132,7 +132,7 @@ and scrobble plays.
 [plex-scrobbler]: https://blog.trakt.tv/plex-scrobbler-52db9b016ead
 
 ```shell
-$ ./plex_trakt_sync.sh watch
+$ python3 -m plex_trakt_sync watch
 ```
 
 NOTE: The `watch` command will scrobble all Plex Watches to Trakt as filtering

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ git clone -b 0.7.19 --depth=1 https://github.com/Taxel/PlexTraktSync
 
 In the extracted directory, install the required Python packages:
 ```
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Alternatively you can use [pipenv]:
 ```
-pip3 install pipenv
+python3 -m pip install pipenv
 pipenv install
 pipenv run plex-trakt-sync
 ```

--- a/plex_trakt_sync.sh
+++ b/plex_trakt_sync.sh
@@ -3,4 +3,4 @@ set -eu
 
 dir=$(dirname "$0")
 
-exec python3 "$dir/main.py" "$@"
+exec python3 -m plex_trakt_sync "$@"

--- a/plex_trakt_sync/__main__.py
+++ b/plex_trakt_sync/__main__.py
@@ -1,0 +1,3 @@
+from plex_trakt_sync.cli import cli
+
+cli()

--- a/plex_trakt_sync/__main__.py
+++ b/plex_trakt_sync/__main__.py
@@ -1,3 +1,16 @@
+if len(__package__) == 0:
+    import sys
+
+    print(f"""
+
+The '__main__' module does not seem to have been run in the context of a
+runnable package ... did you forget to add the '-m' flag?
+
+Usage: {sys.executable} -m plex_trakt_sync {' '.join(sys.argv[1:])}
+
+""")
+    sys.exit(2)
+
 from plex_trakt_sync.cli import cli
 
 cli()


### PR DESCRIPTION
Add `__main__.py` module, to be able to run as module.

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/427

There's an extra benefit of running as a module:
> A minor difference between scripts and modules is that when you import a module the system will attempt to use an existing .pyc file (provided it exists and is up to date and for that version of Python) and if it has to compile from a .py file it will attempt to save a .pyc file. When you run a .py file as script it does not attempt to load a previously compiled module, nor will it attempt to save the compiled code. For this reason it may be worth keeping scripts small to minimise startup time.

- https://stackoverflow.com/a/2997044/2314626