### PR TITLE
Use section.totalSize to figure out item count in section

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -354,8 +354,9 @@ class PlexLibrarySection:
     def __init__(self, section: LibrarySection):
         self.section = section
 
+    @nocache
     def __len__(self):
-        return len(self.all())
+        return self.section.totalSize
 
     @property
     def title(self):


### PR DESCRIPTION
520cf77 removed `@memoize`, so the `all()` was actually called twice.

This instead makes a simple API call with no data:

```
"GET /library/sections/1/all?includeCollections=0&X-Plex-Container-Size=0&X-Plex-Container-Start=0 HTTP/1.1" 200 335
```

For my library of 644 items (cache is filled) the timing is:
- before: 9.7s, 10.0s, 9.1s
- after: 6.6s, 6.4s, 6.4s