### PR TITLE
Buffer results in section.all() by page size

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -385,8 +385,8 @@ class PlexLibrarySection:
         return self.section.fetchItems(key, container_start=start, container_size=size)
 
     def items(self, max_items: int):
-        for item in (PlexLibraryItem(x) for x in self.all(max_items)):
-            yield item
+        for item in self.all(max_items):
+            yield PlexLibraryItem(item)
 
 
 class PlexApi:

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -355,7 +355,6 @@ class PlexLibrarySection:
     def __init__(self, section: LibrarySection):
         self.section = section
 
-    @memoize
     @nocache
     def __len__(self):
         return self.section.totalSize
@@ -364,12 +363,11 @@ class PlexLibrarySection:
     def title(self):
         return self.section.title
 
-    def all(self):
+    def all(self, max_items: int):
         libtype = self.section.TYPE
         key = self.section._buildSearchKey(libtype=libtype, returnKwargs=False)
         start = 0
         size = X_PLEX_CONTAINER_SIZE
-        length = len(self)
 
         while True:
             items = self.fetch_items(key, size, start)
@@ -379,18 +377,15 @@ class PlexLibrarySection:
             yield from items
 
             start += size
-            if start > length:
+            if start > max_items:
                 break
-
-        # clear cached value for next call to all() to be accurate if library changes
-        self.__len__.cache_clear()
 
     @nocache
     def fetch_items(self, key: str, size: int, start: int):
         return self.section.fetchItems(key, container_start=start, container_size=size)
 
-    def items(self):
-        for item in (PlexLibraryItem(x) for x in self.all()):
+    def items(self, max_items: int):
+        for item in (PlexLibraryItem(x) for x in self.all(max_items)):
             yield item
 
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -355,6 +355,7 @@ class PlexLibrarySection:
     def __init__(self, section: LibrarySection):
         self.section = section
 
+    @memoize
     @nocache
     def __len__(self):
         return self.section.totalSize
@@ -380,6 +381,9 @@ class PlexLibrarySection:
             start += size
             if start > length:
                 break
+
+        # clear cached value for next call to all() to be accurate if library changes
+        self.__len__.cache_clear()
 
     @nocache
     def fetch_items(self, key: str, size: int, start: int):

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -2,7 +2,7 @@ from typing import List
 
 from plex_trakt_sync.decorators.measure_time import measure_time
 from plex_trakt_sync.media import MediaFactory, Media
-from plex_trakt_sync.plex_api import PlexApi
+from plex_trakt_sync.plex_api import PlexApi, PlexLibrarySection
 
 
 class Walker:
@@ -91,14 +91,15 @@ class Walker:
                 continue
             yield from self.episode_from_show(show)
 
-    def media_from_sections(self, sections, titles: List[str]):
+    def media_from_sections(self, sections: List[PlexLibrarySection], titles: List[str]):
         if titles:
             # Filter by matching section names
             sections = [x for x in sections if x.title in titles]
 
         for section in sections:
             with measure_time(f"{section.title} processed"):
-                it = self.progressbar(section.items(), total=len(section), desc=f"Processing {section.title}")
+                total = len(section)
+                it = self.progressbar(section.items(total), total=total, desc=f"Processing {section.title}")
                 yield from it
 
     def media_from_titles(self, libtype: str, titles: List[str]):


### PR DESCRIPTION
Instead of getting all results via [plexapi.library.LibrarySection.all()], implement pager locally to buffer at most `X_PLEX_CONTAINER_SIZE` items at a time.

This should reduce memory consumption to a constant value.

Users with a large library may find the progress bar being more responsive: it starts to process items sooner.

[plexapi.library.LibrarySection.all()]: https://python-plexapi.readthedocs.io/en/latest/modules/library.html#plexapi.library.LibrarySection.all

NOTE: This uses private method section._buildSearchKey, which may break with any PlexAPI update. Instead, such yielding by page size should be implemented in PlexAPI itself.

About the implementation: it's important to have `fetch_items` with `@nocache` as a separate method (instead in method `all()` directly), as using `yield` in `all()` would pop out the no-cache behavior.

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/431