### PR TITLE
Add `no-progress-bar` option to the sync and unmatched commands

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -81,7 +81,14 @@ def sync_all(walker: Walker, trakt: TraktApi, plex: PlexApi, dry_run: bool):
     is_flag=True,
     help="Dry run: Do not make changes"
 )
-def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int, dry_run: bool):
+@click.option(
+    "--no-progress-bar", "no_progress_bar",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Don't output progress bars"
+)
+def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int, dry_run: bool, no_progress_bar: bool):
     """
     Perform sync between Plex and Trakt
     """
@@ -99,7 +106,8 @@ def sync(sync_option: str, library: str, show: str, movie: str, batch_size: int,
     plex = factory.plex_api()
     trakt = factory.trakt_api(batch_size=batch_size)
     mf = factory.media_factory(batch_size=batch_size)
-    w = Walker(plex, mf, movies=movies, shows=tv, progressbar=tqdm)
+    pb = None if no_progress_bar else tqdm
+    w = Walker(plex, mf, movies=movies, shows=tv, progressbar=pb)
 
     if library:
         logger.info(f"Filtering Library: {library}")

--- a/plex_trakt_sync/commands/unmatched.py
+++ b/plex_trakt_sync/commands/unmatched.py
@@ -6,8 +6,15 @@ from plex_trakt_sync.factory import factory
 from plex_trakt_sync.walker import Walker
 
 
+@click.option(
+    "--no-progress-bar", "no_progress_bar",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Don't output progress bars"
+)
 @click.command()
-def unmatched():
+def unmatched(no_progress_bar: bool):
     """
     List media that has no match in Plex
     """
@@ -15,7 +22,8 @@ def unmatched():
     ensure_login()
     plex = factory.plex_api()
     mf = factory.media_factory()
-    walker = Walker(plex, mf, progressbar=tqdm)
+    pb = None if no_progress_bar else tqdm
+    walker = Walker(plex, mf, progressbar=pb)
 
     if not walker.is_valid():
         click.echo("Nothing to scan, this is likely due conflicting options given.")


### PR DESCRIPTION
to allow them to not use the progress bar, this can be used to simplify the output for non-interactive situations

