### PR TITLE
Match xbmcnfotv also for xbmc-providers

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -68,6 +68,9 @@ class PlexGuid:
         if x == "xbmcnfo":
             CONFIG = factory.config()
             x = CONFIG["xbmc-providers"][self.media_type]
+        if x == "xbmcnfotv":
+            CONFIG = factory.config()
+            x = CONFIG["xbmc-providers"]["shows"]
 
         return x
 


### PR DESCRIPTION
When matching for `XBMCnfoTVImporter` the guid is `xbmcnfotv` not `xbmcnfo`:

- `com.plexapp.agents.xbmcnfotv://76290?lang=xn`

Fixes #452