### PR TITLE
Change working dir to application dir in launch wrapper

### DIFF
--- a/plex_trakt_sync.sh
+++ b/plex_trakt_sync.sh
@@ -2,5 +2,6 @@
 set -eu
 
 dir=$(dirname "$0")
+cd "$dir"
 
 exec python3 -m plex_trakt_sync "$@"


### PR DESCRIPTION
This makes cron job execution simpler, without the need to `cd`.