### PR TITLE
Ensure item.episodes() is invoked under @nocache

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -314,8 +314,12 @@ class PlexLibraryItem:
         return percent
 
     def episodes(self):
-        for ep in self.item.episodes():
+        for ep in self._get_episodes():
             yield PlexLibraryItem(ep)
+
+    @nocache
+    def _get_episodes(self):
+        return self.item.episodes()
 
     @property
     @memoize


### PR DESCRIPTION
NOTE: yield and @nocache do not play well. do not mix them in same
method.

This fixes episode state caching for a new plex agent.

Fixes https://github.com/Taxel/PlexTraktSync/issues/450

Internally for a new agent, `.all()` gives out xml with `<Directory ratingKey>` pointing to season, and Plex API internally makes /allLeaves call for episodes.

This means the `/allLeaves` call used to be cached.