### PR TITLE
Change Plex fallback url if run in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN pipenv install --system --deploy
 ENV \
 	PTS_CONFIG_DIR=/app/config \
 	PTS_CACHE_DIR=/app/config \
-	PTS_LOG_DIR=/app/config
+	PTS_LOG_DIR=/app/config \
+    PTS_IN_DOCKER=1
 
 VOLUME /app/config
 


### PR DESCRIPTION
`PLEX_FALLBACKURL=http://localhost:32400` in **.env** is irrelevant if script runs inside a docker container. In this case, _localhost_ refers to the container only but Plex is not in the same container.

This PR adds code to detect (during Plex credentials setup) if run inside docker, find container host ip adress and write `PLEX_FALLBACKURL=http://ip_address:32400` instead. 
172.17.0.1 is the default ip address of container's host.


This is not an important issue because the PLEX_FALLBACKURL is used only as last resort, when Plex connection fails.

~~Docker detection is made through _/.dockerenv_ file or _/proc/self/cgroup_ content.~~
~~_Another solution would be to create a dedicated environment variable (such as RUN_IN_DOCKER) at container creation so it could be read during setup._~~
