### PR TITLE
Update Docker base image to alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10-alpine3.13 AS base
+FROM python:3.10-alpine3.15 AS base
+
 WORKDIR /app
 
 # Install app depedencies


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.14.0-released.html

This requires the docker host to be fresh enough:

> The faccessat2 syscall has been enabled in musl. This can result in issues on docker hosts with older versions of docker (<20.10.0) and libseccomp (<2.4.4), which blocks this syscall.

----

https://alpinelinux.org/posts/Alpine-3.15.0-released.html