### PR TITLE
Fix duplicate watched status in trakt (due to movie in multiple Plex libraries)

### DIFF
--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -181,6 +181,7 @@ class TraktApi:
     @time_limit()
     def mark_watched(self, m, time):
         m.mark_as_seen(time)
+        self.watched_movies.add(m.trakt)
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
The idea of this PR :
The trakt `watched_movies` list used during sync is created when syncing the first movie of the first library.
It is later read to know the watched status of other movies, but it is memoized so not fetched from trakt server. Therefore, it can give a wrong not-watched status when a movie is scanned for the second time in the same sync session.

The idea is to update this list each time a movie is marked as watched in trakt.
With this list up-to-date, the script will know the correct watched status of a movie even if it has already been scanned in the same session.

https://github.com/Taxel/PlexTraktSync/blob/83ded352c7611ccb0399a1408c9c13b0b9581833/plex_trakt_sync/trakt_api.py#L90-L98

fixes #476 