### PR TITLE
Fix duplicate watched status in trakt (due to tv episode in multiple Plex libraries)

### DIFF
--- a/plex_trakt_sync/pytrakt_extensions.py
+++ b/plex_trakt_sync/pytrakt_extensions.py
@@ -140,6 +140,17 @@ class AllWatchedShows():
             return False
         return self.shows[trakt_id].seasons[season].get_completed(episode)
 
+    def add(self, trakt_id, season, episode):
+        episode_prog = {"number":episode, "completed":True}
+        season_prog = {"number":season, "episodes":[episode_prog]}
+        if trakt_id in self.shows:
+            if season in self.shows[trakt_id].seasons:
+                self.shows[trakt_id].seasons[season].episodes[episode] = EpisodeProgress(**episode_prog)
+            else:
+                self.shows[trakt_id].seasons[season] = SeasonProgress(**season_prog)
+        else:
+            self.shows[trakt_id] = ShowProgress(seasons=[season_prog])
+
 
 if __name__ == "__main__":
     print(get_liked_lists())

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -181,7 +181,10 @@ class TraktApi:
     @time_limit()
     def mark_watched(self, m, time):
         m.mark_as_seen(time)
-        self.watched_movies.add(m.trakt)
+        if m.media_type == "movies":
+            self.watched_movies.add(m.trakt)
+        if m.media_type == "episodes":
+            self.watched_shows.add(m.show.trakt, m.season, m.number)
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
Same as #477 but for tv shows.

fixes #476 

note : [pytrakt_extensions.py](https://github.com/Taxel/PlexTraktSync/blob/main/plex_trakt_sync/pytrakt_extensions.py) uses many `if value in dict.keys():` which [seems](https://stackabuse.com/python-check-if-key-exists-in-dictionary/) to be slower than `if value in dict:`
note 2 : please @glensc do not merge in a hurry.

