### PR TITLE
Fix finding show trakt id from trakt episode

### DIFF
--- a/plex_trakt_sync/pytrakt_extensions.py
+++ b/plex_trakt_sync/pytrakt_extensions.py
@@ -39,7 +39,7 @@ class LazyEpisode():
     @property
     def instance(self):
         if self._instance is None:
-            self._instance = TVEpisode(self.show, self.season, number=self.number, **self.ids)
+            self._instance = TVEpisode(self.show.title, self.season, number=self.number, **self.ids)
         return self._instance
 
 

--- a/plex_trakt_sync/trakt_api.py
+++ b/plex_trakt_sync/trakt_api.py
@@ -177,7 +177,7 @@ class TraktApi:
         if m.media_type == "movies":
             self.watched_movies.add(m.trakt)
         if m.media_type == "episodes":
-            self.watched_shows.add(m.show.trakt, m.season, m.number)
+            self.watched_shows.add(TVShow(m.show).trakt, m.season, m.number)
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
First, this PR needs to be merged :
- https://github.com/moogar0880/PyTrakt/pull/157

Then we could fix the `AttributeError: 'dict' object has no attribute 'trakt'` and properly get the show trakt id of every watched episodes.

Fixes #487 