### PR TITLE
Feature: Add example ActivityNotification to watch command

### DIFF
--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -25,8 +25,10 @@ class WatchStateUpdater:
         self.mf = mf
         self.scrobblers = ScrobblerCollection(trakt)
 
-    def find_by_key(self, key: str):
+    def find_by_key(self, key: str, reload=False):
         pm = self.plex.fetch_item(key)
+        if reload:
+            pm = self.plex.reload_item(pm)
         if not pm:
             return None
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -433,6 +433,7 @@ class PlexApi:
         return result
 
     @memoize
+    @nocache
     def fetch_item(self, key: Union[int, str]):
         media = self.plex.library.fetchItem(key)
         return PlexLibraryItem(media)

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -438,7 +438,7 @@ class PlexApi:
         media = self.plex.library.fetchItem(key)
         return PlexLibraryItem(media)
 
-    def reload_item(self, pm):
+    def reload_item(self, pm: PlexLibraryItem):
         self.fetch_item.cache_clear()
         return self.fetch_item(pm.item.ratingKey)
 


### PR DESCRIPTION
This shows that watching "play" / "unplayed" events from Plex Media Server is possible for https://github.com/Taxel/PlexTraktSync/issues/495

This prints:

```
Activity: <tmdb:xxx>: Watched: Plex: True, Trakt: False
Activity: <tmdb:xxx>: Watched: Plex: False, Trakt: False
```