### PR TITLE
Add username filter to watch command

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -13,6 +13,9 @@
         "collection": true,
         "ratings": true
     },
+    "watch": {
+        "username_filter": false
+    },
     "xbmc-providers": {
         "movies": "imdb",
         "shows": "tvdb"

--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -18,6 +18,26 @@ class ScrobblerCollection(dict):
         return value
 
 
+class SessionCollection(dict):
+    def __init__(self, plex: PlexApi):
+        super(dict, self).__init__()
+        self.plex = plex
+
+    def __missing__(self, key: str):
+        self.update_sessions()
+        if key not in self:
+            # Session probably ended
+            return None
+
+        return self[key]
+
+    def update_sessions(self):
+        sessions = self.plex.get_sessions()
+        self.clear()
+        for session in sessions:
+            self[str(session.sessionKey)] = session.usernames[0]
+
+
 class WatchStateUpdater:
     def __init__(self, plex: PlexApi, trakt: TraktApi, mf: MediaFactory):
         self.plex = plex

--- a/plex_trakt_sync/events.py
+++ b/plex_trakt_sync/events.py
@@ -49,6 +49,10 @@ class PlaySessionStateNotification(Event):
     def state(self):
         return self["state"]
 
+    @property
+    def session_key(self):
+        return self["sessionKey"]
+
 
 class Setting(Event):
     pass

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -524,3 +524,7 @@ class PlexApi:
     @nocache
     def mark_watched(self, m):
         m.markWatched()
+
+    @nocache
+    def get_sessions(self):
+        return self.plex.sessions()


### PR DESCRIPTION
To enable this feature, change `config.json`:
```json
    "watch": {
        "username_filter": true
    },
```

NOTE: it's important that you log in with plex account name, not email. i.e `PLEX_USERNAME` must be the account name.

Fixes https://github.com/Taxel/PlexTraktSync/issues/324, Replaces https://github.com/Taxel/PlexTraktSync/pull/480