### PR TITLE
Fix: Update match logic to match all conditions

### DIFF
--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -30,25 +30,30 @@ class EventDispatcher:
 
     def dispatch(self, event):
         for listener in self.event_listeners:
-            if not self.is_candidate(event, listener):
+            if not self.match_event(listener, event):
                 continue
 
             listener["listener"](event)
 
     @staticmethod
-    def is_candidate(event, listener):
+    def match_filter(event, name, value):
+        # test event property
+        if hasattr(event, name) and getattr(event, name) == value:
+            return True
+        # test event dictionary items
+        if name not in event:
+            return False
+        if event[name] not in value:
+            return False
+        return True
+
+    def match_event(self, listener, event):
         if not isinstance(event, listener["event_type"]):
             return False
 
         if listener["filters"]:
             for name, value in listener["filters"].items():
-                # test event property
-                if hasattr(event, name) and getattr(event, name) == value:
-                    return True
-                # test event dictionary items
-                if name not in event:
-                    return False
-                if event[name] not in value:
+                if not self.match_filter(event, name, value):
                     return False
 
         return True

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -47,6 +47,16 @@ def test_event_dispatcher():
     assert len(events) == 1, "Matched event=ended and progress=100"
 
     events = []
+    dispatcher = EventDispatcher().on(ActivityNotification, lambda x: events.append(x), event=["started"], progress=100)
+    dispatcher.event_handler(raw_events[4])
+    assert len(events) == 0, "Matched event=ended and progress=100"
+
+    events = []
+    dispatcher = EventDispatcher().on(ActivityNotification, lambda x: events.append(x), progress=100, event=["started"])
+    dispatcher.event_handler(raw_events[4])
+    assert len(events) == 0, "Matched progress=100 and event=started"
+
+    events = []
     dispatcher = EventDispatcher().on(ActivityNotification, lambda x: events.append(x), event=["ended"], progress=99)
     dispatcher.event_handler(raw_events[4])
     assert len(events) == 0, "No match for event=ended and progress=99"


### PR DESCRIPTION
Bugfix to https://github.com/Taxel/PlexTraktSync/pull/501 to fix logic error that mistakenly accepted the first match on object property.