### PR TITLE
Fix:  Update on_activity to match only type=library.refresh.items

### DIFF
--- a/plex_trakt_sync/commands/watch.py
+++ b/plex_trakt_sync/commands/watch.py
@@ -118,7 +118,7 @@ def watch():
     updater = WatchStateUpdater(plex, trakt, mf, config)
 
     ws.on(PlaySessionStateNotification, updater.on_play, state=["playing", "stopped", "paused"])
-    ws.on(ActivityNotification, updater.on_activity, event=["ended"], progress=100)
+    ws.on(ActivityNotification, updater.on_activity, type="library.refresh.items", event=["ended"], progress=100)
 
     print("Listening for events!")
     ws.listen()

--- a/plex_trakt_sync/events.py
+++ b/plex_trakt_sync/events.py
@@ -24,6 +24,10 @@ class AccountUpdateNotification(Event):
 
 class ActivityNotification(Event):
     @property
+    def type(self):
+        return self["Activity"]["type"]
+
+    @property
     def progress(self):
         return self["Activity"]["progress"]
 


### PR DESCRIPTION
This updates https://github.com/Taxel/PlexTraktSync/pull/499 so that it doesn't receive too much unwanted updates