### PR TITLE
Watch: Add different interval for restarts

### DIFF
--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -63,9 +63,9 @@ class EventDispatcher:
 
 
 class WebSocketListener:
-    def __init__(self, plex: PlexServer, interval=1, restart_interval=10):
+    def __init__(self, plex: PlexServer, poll_interval=5, restart_interval=15):
         self.plex = plex
-        self.interval = interval
+        self.poll_interval = poll_interval
         self.restart_interval = restart_interval
         self.dispatcher = EventDispatcher()
         self.logger = logging.getLogger("PlexTraktSync.WebSocketListener")
@@ -77,7 +77,7 @@ class WebSocketListener:
         while True:
             notifier = self.plex.startAlertListener(callback=self.dispatcher.event_handler)
             while notifier.is_alive():
-                sleep(self.interval)
+                sleep(self.poll_interval)
 
             self.dispatcher.event_handler(Error(msg='Server closed connection'))
             self.logger.error(f"Listener finished. Restarting in {self.restart_interval} seconds")

--- a/plex_trakt_sync/listener.py
+++ b/plex_trakt_sync/listener.py
@@ -63,9 +63,10 @@ class EventDispatcher:
 
 
 class WebSocketListener:
-    def __init__(self, plex: PlexServer, interval=1):
+    def __init__(self, plex: PlexServer, interval=1, restart_interval=10):
         self.plex = plex
         self.interval = interval
+        self.restart_interval = restart_interval
         self.dispatcher = EventDispatcher()
         self.logger = logging.getLogger("PlexTraktSync.WebSocketListener")
 
@@ -79,5 +80,5 @@ class WebSocketListener:
                 sleep(self.interval)
 
             self.dispatcher.event_handler(Error(msg='Server closed connection'))
-            self.logger.error(f"Listener finished. Restarting in {self.interval} seconds")
-            sleep(self.interval)
+            self.logger.error(f"Listener finished. Restarting in {self.restart_interval} seconds")
+            sleep(self.restart_interval)


### PR DESCRIPTION
Also decrease interval for loop polling. Websocket events are immediate, there's no reason to spam server so often as 1s. 