### PR TITLE
Fix: Lowercase docker image used for test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TEST_IMAGE: ghcr.io/${{ github.repository }}:ci-test
+  TEST_IMAGE: plextraktsync:ci-test
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
The image name needs to be lowercased for docker build to succeed:


```
/usr/bin/docker buildx build --build-arg APP_VERSION=0.14.0-3-g8cbf1f4_main --tag ghcr.io/Taxel/PlexTraktSync:ci-test --iidfile /tmp/docker-build-push-kpnBCT/iidfile --metadata-file /tmp/docker-build-push-kpnBCT/metadata-file --load .
error: invalid tag "ghcr.io/Taxel/PlexTraktSync:ci-test": repository name must be lowercase
Error: buildx failed with: error: invalid tag "ghcr.io/Taxel/PlexTraktSync:ci-test": repository name must be lowercase
```
- https://github.com/Taxel/PlexTraktSync/runs/3743383829?check_suite_focus=true


Use hardcoded docker image for test

As GitHub actions does not provide builtin lowercase method:
 - https://docs.github.com/en/actions/learn-github-actions/expressions#functions

just use fixed name, as the test image is not published anyway.

This is a bugfix to https://github.com/Taxel/PlexTraktSync/pull/518