### PR TITLE
Add multi arch support for Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -78,6 +78,7 @@ jobs:
           APP_VERSION: ${{ steps.vars.outputs.version }}
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add support for arm64, `armhf`/`armv7`. Close #522 