### PR TITLE
Add @rate_limit decorator for rating property to handle Plex Api errors

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -199,6 +199,7 @@ class PlexLibraryItem:
 
     @property
     @memoize
+    @rate_limit()
     def rating(self):
         return int(self.item.userRating) if self.item.userRating is not None else None
 


### PR DESCRIPTION
refs:
- https://github.com/Taxel/PlexTraktSync/issues/527