### PR TITLE
Build docker image without pipenv dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
 /*
-!/*.py
 !/Pipfile
 !/Pipfile.lock
 !/plex_trakt_sync/config.default.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ ENV \
 VOLUME /app/config
 
 # Copy things together
-COPY . .
+COPY plex_trakt_sync ./plex_trakt_sync/
 COPY --from=version /app/plex_trakt_sync/__init__.py plex_trakt_sync/
 COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,16 @@ RUN pip install pipenv
 COPY Pipfile* ./
 RUN pipenv install --deploy
 
+# Create __version__ from $APP_VERSION
+FROM base AS version
+ARG APP_VERSION=$APP_VERSION
+ENV APP_VERSION=$APP_VERSION
+
+RUN mkdir -p /app/plex_trakt_sync
+RUN echo "__version__ = '$APP_VERSION'" > plex_trakt_sync/__init__.py
+RUN cat plex_trakt_sync/__init__.py
+RUN python -c "from plex_trakt_sync import __version__; print(__version__)"
+
 FROM base
 ENTRYPOINT ["python", "-m", "plex_trakt_sync"]
 
@@ -21,7 +31,5 @@ VOLUME /app/config
 
 # Copy things together
 COPY . .
+COPY --from=version /app/plex_trakt_sync/__init__.py plex_trakt_sync/
 COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
-
-ARG APP_VERSION=$APP_VERSION
-ENV APP_VERSION=$APP_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.10-alpine3.13 AS base
-
 WORKDIR /app
-ENTRYPOINT ["python", "-m", "plex_trakt_sync"]
 
 # Install app depedencies
-RUN pip install --no-cache-dir pipenv
+FROM base AS build
+RUN pip install pipenv
 COPY Pipfile* ./
-RUN pipenv install --system --deploy
+RUN pipenv install --deploy
+
+FROM base
+ENTRYPOINT ["python", "-m", "plex_trakt_sync"]
 
 ENV \
 	PTS_CONFIG_DIR=/app/config \
@@ -17,7 +19,9 @@ ENV \
 
 VOLUME /app/config
 
-# Copy rest of the app
+# Copy things together
 COPY . .
+COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+
 ARG APP_VERSION=$APP_VERSION
 ENV APP_VERSION=$APP_VERSION

--- a/plex_trakt_sync/__init__.py
+++ b/plex_trakt_sync/__init__.py
@@ -1,7 +1,1 @@
-from os import getenv
-
-_version = getenv("APP_VERSION")
-if _version:
-    __version__ = _version
-else:
-    __version__ = "0.15.x"
+__version__ = "0.15.x"


### PR DESCRIPTION
This changes build logic, that pipenv is not included in final image.

pipenv is build time dependency used to lock dependencies.

- Before: 133MB
- After: 72.9MB