### PR TITLE
Raise pagination limit to 1000 liked lists

### DIFF
--- a/plex_trakt_sync/pytrakt_extensions.py
+++ b/plex_trakt_sync/pytrakt_extensions.py
@@ -4,7 +4,7 @@ from trakt.tv import TVEpisode
 
 @get
 def get_liked_lists():
-    data = yield 'users/likes/lists'
+    data = yield 'users/likes/lists?limit=1000'
     retVal = []
     for lst in data:
         thisList = {}


### PR DESCRIPTION
Removes the 10 items limit of liked lists.

Trakt API doc: [Get likes](https://trakt.docs.apiary.io/#reference/users/likes/get-likes), [Pagination](https://trakt.docs.apiary.io/#introduction/pagination)

fixes #564