### PR TITLE
Feature:  Add WalkPlanner that validates inputs against plex server

### DIFF
--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -1,4 +1,5 @@
 import click
+from click import ClickException
 from tqdm import tqdm
 
 from plex_trakt_sync.commands.login import ensure_login
@@ -118,4 +119,7 @@ def sync(
     wc.walk_details(print=tqdm.write)
 
     with measure_time("Completed full sync"):
-        sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=dry_run)
+        try:
+            sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=dry_run)
+        except RuntimeError as e:
+            raise ClickException(str(e))

--- a/plex_trakt_sync/commands/sync.py
+++ b/plex_trakt_sync/commands/sync.py
@@ -8,7 +8,7 @@ from plex_trakt_sync.logging import logger
 from plex_trakt_sync.plex_api import PlexApi
 from plex_trakt_sync.sync import Sync
 from plex_trakt_sync.version import git_version_info
-from plex_trakt_sync.walker import Walker
+from plex_trakt_sync.walker import Walker, WalkConfig
 
 
 def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
@@ -93,28 +93,29 @@ def sync(
     trakt = factory.trakt_api(batch_size=batch_size)
     mf = factory.media_factory(batch_size=batch_size)
     pb = factory.progressbar(not no_progress_bar)
-    w = Walker(plex=plex, trakt=trakt, mf=mf, movies=movies, shows=tv, progressbar=pb)
+    wc = WalkConfig(movies=movies, shows=tv)
+    w = Walker(plex=plex, trakt=trakt, mf=mf, config=wc, progressbar=pb)
 
     if id:
         logger.info(f"Syncing item: {id}")
-        w.add_id(library)
+        wc.add_id(id)
     if library:
         logger.info(f"Filtering Library: {library}")
-        w.add_library(library)
+        wc.add_library(library)
     if show:
-        w.add_show(show)
+        wc.add_show(show)
         logger.info(f"Syncing Show: {show}")
     if movie:
-        w.add_movie(movie)
+        wc.add_movie(movie)
         logger.info(f"Syncing Movie: {movie}")
 
-    if not w.is_valid():
+    if not wc.is_valid():
         click.echo("Nothing to sync, this is likely due conflicting options given.")
         return
 
     if dry_run:
         print("Enabled dry-run mode: not making actual changes")
-    w.walk_details(print=tqdm.write)
+    wc.walk_details(print=tqdm.write)
 
     with measure_time("Completed full sync"):
         sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=dry_run)

--- a/plex_trakt_sync/commands/unmatched.py
+++ b/plex_trakt_sync/commands/unmatched.py
@@ -2,7 +2,7 @@ import click
 
 from plex_trakt_sync.commands.login import ensure_login
 from plex_trakt_sync.factory import factory
-from plex_trakt_sync.walker import Walker
+from plex_trakt_sync.walker import Walker, WalkConfig
 
 
 @click.option(
@@ -23,13 +23,14 @@ def unmatched(no_progress_bar: bool):
     trakt = factory.trakt_api()
     mf = factory.media_factory()
     pb = factory.progressbar(not no_progress_bar)
-    walker = Walker(plex, trakt, mf, progressbar=pb)
+    wc = WalkConfig()
+    walker = Walker(plex, trakt, mf, wc, progressbar=pb)
 
-    if not walker.is_valid():
+    if not wc.is_valid():
         click.echo("Nothing to scan, this is likely due conflicting options given.")
         return
 
-    walker.walk_details(print=click.echo)
+    wc.walk_details(print=click.echo)
 
     failed = []
     for pm in walker.get_plex_movies():

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -372,6 +372,10 @@ class PlexLibrarySection:
         return self.section.totalSize
 
     @property
+    def type(self):
+        return self.section.type
+
+    @property
     def title(self):
         return self.section.title
 

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -379,6 +379,20 @@ class PlexLibrarySection:
     def title(self):
         return self.section.title
 
+    @nocache
+    def find_by_title(self, name: str):
+        try:
+            return self.section.get(name)
+        except NotFound:
+            return None
+
+    @nocache
+    def find_by_id(self, id: str):
+        try:
+            return self.section.fetchItem(int(id))
+        except NotFound:
+            return None
+
     def all(self, max_items: int):
         libtype = self.section.TYPE
         key = self.section._buildSearchKey(libtype=libtype, returnKwargs=False)

--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -404,6 +404,9 @@ class PlexLibrarySection:
         for item in self.all(max_items):
             yield PlexLibraryItem(item)
 
+    def __repr__(self):
+        return f"<PlexLibrarySection:{self.type}:{self.title}>"
+
 
 class PlexApi:
     """

--- a/plex_trakt_sync/walker.py
+++ b/plex_trakt_sync/walker.py
@@ -1,5 +1,6 @@
 from typing import List, NamedTuple
 
+from plex_trakt_sync.decorators.deprecated import deprecated
 from plex_trakt_sync.decorators.memoize import memoize
 from plex_trakt_sync.decorators.measure_time import measure_time
 from plex_trakt_sync.media import Media, MediaFactory
@@ -223,6 +224,7 @@ class Walker:
         it = self.progressbar(items, desc=f"Processing {libtype}s")
         yield from it
 
+    @deprecated("No longer used")
     def media_from_titles(self, libtype: str, titles: List[str]):
         it = self.progressbar(titles, desc=f"Processing {libtype}s")
         for title in it:

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3 -m pytest
-from plex_trakt_sync.walker import Walker
+from plex_trakt_sync.walker import Walker, WalkConfig
 from tests.conftest import factory
 
 plex = factory.plex_api()
+trakt = factory.trakt_api()
 mf = factory.media_factory()
 
 
 def test_walker():
-    w = Walker(plex, mf)
+    wc = WalkConfig()
+    w = Walker(plex, trakt, mf, wc)
     assert type(w) == Walker
 
-    w.add_library("TV Shows")
-    w.add_library("Movies (Tuti)")
-    w.add_show("Breaking Bad")
-    w.add_movie("Batman Begins")
+    wc.add_library("TV Shows")
+    wc.add_library("Movies (Tuti)")
+    wc.add_show("Breaking Bad")
+    wc.add_movie("Batman Begins")
 
     episodes = list(w.find_episodes())
     movies = list(w.find_movies())


### PR DESCRIPTION
For end-user, this validates input arguments before starting sync process by fetching matches from Plex Server.

This also handles filtering by libraries (sections), so if `--library` is passed then `--show` or `--id` will find only matches from the named libraries.

And `excluded-libraries` is now respected when `--show` or `--movie` option is used.

Fixes https://github.com/Taxel/PlexTraktSync/issues/291

Requires:
- https://github.com/Taxel/PlexTraktSync/pull/573
