### PR TITLE
Fix: handle Plex Server errors from _get_episodes method

### DIFF
--- a/plex_trakt_sync/plex_api.py
+++ b/plex_trakt_sync/plex_api.py
@@ -322,6 +322,7 @@ class PlexLibraryItem:
             yield PlexLibraryItem(ep)
 
     @nocache
+    @rate_limit()
     def _get_episodes(self):
         return self.item.episodes()
 


### PR DESCRIPTION
Probably this should be handled systematically, but happened once to me for this method, so it's a quick fix. Move along.