### PR TITLE
Fix multiple --ids support for sync

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -96,17 +96,13 @@ def sync(
     w = Walker(plex=plex, trakt=trakt, mf=mf, config=wc, progressbar=pb)
 
     if id:
-        logger.info(f"Syncing item: {id}")
         wc.add_id(id)
     if library:
-        logger.info(f"Filtering Library: {library}")
         wc.add_library(library)
     if show:
         wc.add_show(show)
-        logger.info(f"Syncing Show: {show}")
     if movie:
         wc.add_movie(movie)
-        logger.info(f"Syncing Movie: {movie}")
 
     if not wc.is_valid():
         click.echo("Nothing to sync, this is likely due conflicting options given.")

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -114,7 +114,7 @@ def sync(
 
     if dry_run:
         print("Enabled dry-run mode: not making actual changes")
-    wc.walk_details(print=tqdm.write)
+    w.print_plan(print=tqdm.write)
 
     with measure_time("Completed full sync"):
         try:

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import click
 from click import ClickException
 from tqdm import tqdm
@@ -35,8 +37,9 @@ def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
     show_default=True, help="Sync specific movie only"
 )
 @click.option(
-    "--id",
+    "--id", "ids",
     type=str,
+    multiple=True,
     show_default=True, help="Sync specific item only"
 )
 @click.option(
@@ -70,7 +73,7 @@ def sync(
         library: str,
         show: str,
         movie: str,
-        id: str,
+        ids: List[str],
         batch_size: int,
         dry_run: bool,
         no_progress_bar: bool,
@@ -95,8 +98,9 @@ def sync(
     wc = WalkConfig(movies=movies, shows=tv)
     w = Walker(plex=plex, trakt=trakt, mf=mf, config=wc, progressbar=pb)
 
-    if id:
-        wc.add_id(id)
+    if ids:
+        for id in ids:
+            wc.add_id(id)
     if library:
         wc.add_library(library)
     if show:

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -7,7 +7,7 @@ from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.media import Media, MediaFactory
-from plextraktsync.plex_api import PlexApi, PlexLibrarySection
+from plextraktsync.plex_api import PlexApi, PlexLibraryItem, PlexLibrarySection
 from plextraktsync.trakt_api import TraktApi
 
 
@@ -226,7 +226,8 @@ class Walker:
 
     def media_from_items(self, libtype: str, items: List):
         it = self.progressbar(items, desc=f"Processing {libtype}s")
-        yield from it
+        for m in it:
+            yield PlexLibraryItem(m)
 
     @deprecated("No longer used")
     def media_from_titles(self, libtype: str, titles: List[str]):

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -1,5 +1,8 @@
 from typing import List, NamedTuple
 
+from plexapi.library import MovieSection, ShowSection
+from plexapi.video import Movie, Show
+
 from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.decorators.memoize import memoize
@@ -47,10 +50,10 @@ class WalkConfig:
 
 
 class WalkPlan(NamedTuple):
-    movie_sections: List
-    show_sections: List
-    movies: List
-    shows: List
+    movie_sections: List[MovieSection]
+    show_sections: List[ShowSection]
+    movies: List[Movie]
+    shows: List[Show]
 
 
 class WalkPlanner:

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -1,6 +1,5 @@
 from typing import List, NamedTuple
 
-from plextraktsync.logging import logging
 from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.decorators.memoize import memoize
@@ -20,25 +19,20 @@ class WalkConfig:
     def __init__(self, movies=True, shows=True):
         self.walk_movies = movies
         self.walk_shows = shows
-        self.logger = logging.getLogger('PlexTraktSync.WalkConfig')
 
     def add_library(self, library):
         self.library.append(library)
-        self.logger.info(f"Filtering Library: {library}")
 
     def add_id(self, id):
         self.id.append(id)
-        self.logger.info(f"Syncing item: {id}")
 
     def add_show(self, show):
         self.show.append(show)
         self.walk_movies = False
-        self.logger.info(f"Syncing Show: {show}")
 
     def add_movie(self, movie):
         self.movie.append(movie)
         self.walk_shows = False
-        self.logger.info(f"Syncing Movie: {movie}")
 
     def is_valid(self):
         # Single item provided
@@ -50,18 +44,6 @@ class WalkConfig:
             return True
 
         return False
-
-    def walk_details(self, print=print):
-        print(f"Sync Movies: {self.walk_movies}")
-        print(f"Sync Shows: {self.walk_shows}")
-        if self.id:
-            print(f"Sync Id: {self.id}")
-        if self.library:
-            print(f"Walk libraries: {self.library}")
-        if self.show:
-            print(f"Walk Shows: {self.show}")
-        if self.movie:
-            print(f"Walk Movies: {self.movie}")
 
 
 class WalkPlan(NamedTuple):
@@ -181,6 +163,19 @@ class Walker:
     @memoize
     def plan(self):
         return WalkPlanner(self.plex, self.config).plan()
+
+    def print_plan(self, print=print):
+        if self.plan.movie_sections:
+            print(f"Sync Movie sections: {self.plan.movie_sections}")
+
+        if self.plan.show_sections:
+            print(f"Sync Show sections: {self.plan.show_sections}")
+
+        if self.plan.movies:
+            print(f"Sync Movies: {self.plan.movies}")
+
+        if self.plan.shows:
+            print(f"Sync Shows: {self.plan.shows}")
 
     def get_plex_movies(self):
         """

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -1,5 +1,6 @@
 from typing import List, NamedTuple
 
+from plextraktsync.logging import logging
 from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.decorators.memoize import memoize
@@ -19,20 +20,25 @@ class WalkConfig:
     def __init__(self, movies=True, shows=True):
         self.walk_movies = movies
         self.walk_shows = shows
+        self.logger = logging.getLogger('PlexTraktSync.WalkConfig')
 
     def add_library(self, library):
         self.library.append(library)
+        self.logger.info(f"Filtering Library: {library}")
 
     def add_id(self, id):
         self.id.append(id)
+        self.logger.info(f"Syncing item: {id}")
 
     def add_show(self, show):
         self.show.append(show)
         self.walk_movies = False
+        self.logger.info(f"Syncing Show: {show}")
 
     def add_movie(self, movie):
         self.movie.append(movie)
         self.walk_shows = False
+        self.logger.info(f"Syncing Movie: {movie}")
 
     def is_valid(self):
         # Single item provided


### PR DESCRIPTION
Fixes `--id` option repeat for Movies sync.

Noticed that specifying episodes with `--id` option doesn't do anything. To be fixed later.