### PR TITLE
Refactor: Rename "version" command to "info"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ plextraktsync
 ```
 
 NOTE: `pipx` install will use OS specific paths for Config, Logs, Cache, see [appdirs] documentation for details
-or check output of [version command](#version-command).
+or check output of [info command](#info-command).
 
 [appdirs]: https://pypi.org/project/appdirs
 [install-pipx]: https://github.com/pypa/pipx#install-pipx
@@ -224,20 +224,25 @@ Support for unmatched shows is not yet implemented.
 
 `python3 -m plextraktsync unmatched`
 
-### Version command
+### Info command
 
-Version command can be used to print package versions and locations of Cache, Config and Logs directories:
+The info command can be used to print package versions,
+account information,
+locations of Cache, Config and Logs directories
 
 ```
-$ plextraktsync version
-PlexTraktSync Version: 0.15.0
-PlexTraktSync Git Version: [0.15.0]
+$ plextraktsync info
+PlexTraktSync Version: 0.16.0
 Python Version: 3.10.0 (default, Oct  6 2021, 01:11:32) [Clang 13.0.0 (clang-1300.0.29.3)]
 Plex API Version: 4.7.2
 Trakt API Version: 3.2.1
 Cache Dir: /Users/glen/Library/Caches/PlexTraktSync
 Config Dir: /Users/glen/Library/Application Support/PlexTraktSync
 Log Dir: /Users/glen/Library/Logs/PlexTraktSync
+Plex username: nobody
+Trakt username: nobody
+Plex Server version: 1.24.3.5033-757abe6b4, updated at: 2021-02-21 17:00:00
+Server has 2 libraries: ['Movies', 'TV Shows']
 ```
 
 ### Watch

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -2,13 +2,13 @@ import click
 
 from plextraktsync.commands.cache import cache
 from plextraktsync.commands.clear_collections import clear_collections
+from plextraktsync.commands.info import info
 from plextraktsync.commands.inspect import inspect
 from plextraktsync.commands.login import login
 from plextraktsync.commands.plex_login import plex_login
 from plextraktsync.commands.sync import sync
 from plextraktsync.commands.trakt_login import trakt_login
 from plextraktsync.commands.unmatched import unmatched
-from plextraktsync.commands.version import version
 from plextraktsync.commands.watch import watch
 from plextraktsync.commands.webhook import webhook
 
@@ -25,12 +25,12 @@ def cli(ctx):
 
 cli.add_command(cache)
 cli.add_command(clear_collections)
+cli.add_command(info)
 cli.add_command(inspect)
 cli.add_command(login)
 cli.add_command(plex_login)
 cli.add_command(sync)
 cli.add_command(trakt_login)
 cli.add_command(unmatched)
-cli.add_command(version)
 cli.add_command(watch)
 cli.add_command(webhook)

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -4,6 +4,7 @@ import click
 from plexapi import VERSION as PLEX_API_VERSION
 from trakt import __version__ as TRAKT_API_VERSION
 
+from plextraktsync.factory import factory
 from plextraktsync.path import cache_dir, config_dir, log_dir
 from plextraktsync.version import version as get_version
 
@@ -23,3 +24,6 @@ def info():
     print(f"Cache Dir: {cache_dir}")
     print(f"Config Dir: {config_dir}")
     print(f"Log Dir: {log_dir}")
+
+    plex = factory.plex_api()
+    print(f"Enabled {len(plex.library_sections)} libraries in Plex Server: {plex.library_section_names}")

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -9,7 +9,7 @@ from plextraktsync.version import version as get_version
 
 
 @click.command()
-def version():
+def info():
     """
     Print application and environment version info
     """

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -26,4 +26,5 @@ def info():
     print(f"Log Dir: {log_dir}")
 
     plex = factory.plex_api()
+    print(f"Plex Server version: {plex.version}, updated at: {plex.updated_at}")
     print(f"Enabled {len(plex.library_sections)} libraries in Plex Server: {plex.library_section_names}")

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -25,6 +25,10 @@ def info():
     print(f"Config Dir: {config_dir}")
     print(f"Log Dir: {log_dir}")
 
+    config = factory.config()
+    print(f"Plex username: {config['PLEX_USERNAME']}")
+    print(f"Trakt username: {config['TRAKT_USERNAME']}")
+
     plex = factory.plex_api()
     print(f"Plex Server version: {plex.version}, updated at: {plex.updated_at}")
     print(f"Enabled {len(plex.library_sections)} libraries in Plex Server: {plex.library_section_names}")

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -8,14 +8,8 @@ from plextraktsync.commands.login import ensure_login
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.factory import factory
 from plextraktsync.logging import logger
-from plextraktsync.plex_api import PlexApi
-from plextraktsync.sync import Sync
 from plextraktsync.version import version
 from plextraktsync.walker import Walker
-
-
-def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
-    runner.sync(walker, dry_run=dry_run)
 
 
 @click.command()
@@ -110,9 +104,9 @@ def sync(
         print("Enabled dry-run mode: not making actual changes")
     w.print_plan(print=tqdm.write)
 
-    plex = factory.plex_api()
     with measure_time("Completed full sync"):
         try:
-            sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=config.dry_run)
+            runner = factory.sync()
+            runner.sync(walker=w, dry_run=config.dry_run)
         except RuntimeError as e:
             raise ClickException(str(e))

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -16,7 +16,6 @@ from plextraktsync.walker import Walker
 
 def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
     click.echo(f"Plex Server version: {plex.version}, updated at: {plex.updated_at}")
-    click.echo(f"Server has {len(plex.library_sections)} libraries: {plex.library_section_names}")
 
     runner.sync(walker, dry_run=dry_run)
 

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -15,8 +15,6 @@ from plextraktsync.walker import Walker
 
 
 def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
-    click.echo(f"Plex Server version: {plex.version}, updated at: {plex.updated_at}")
-
     runner.sync(walker, dry_run=dry_run)
 
 

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -74,10 +74,7 @@ def sync(
     """
 
     logger.info(f"PlexTraktSync [{version()}]")
-
     ensure_login()
-    CONFIG = factory.config()
-    logger.info(f"Syncing with Plex {CONFIG['PLEX_USERNAME']} and Trakt {CONFIG['TRAKT_USERNAME']}")
 
     movies = sync_option in ["all", "movies"]
     shows = sync_option in ["all", "tv", "shows"]


### PR DESCRIPTION
Rename "version" command to "info" and put all info printing to that command.

Besides putting all useful info to same place,
this improves privacy when people paste sync command output to bug reports. 