### PR TITLE
Fix: Disable tqdm ExperimentalWarning

### DIFF
--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -69,7 +69,11 @@ class Factory:
     @memoize
     def progressbar(self, enabled=True):
         if enabled:
+            import warnings
+            from tqdm import TqdmExperimentalWarning
             from tqdm.rich import tqdm
+
+            warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 
             return tqdm
 


### PR DESCRIPTION
Remove printing of this warning:

```
plextraktsync/walker.py:250: TqdmExperimentalWarning: rich is experimental/alpha
  pb = self._progressbar(iterable, **kwargs)
```