### PR TITLE
Refactor: Add RunConfig and factory for worker

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -91,10 +91,11 @@ def sync(
     movies = sync_option in ["all", "movies"]
     shows = sync_option in ["all", "tv", "shows"]
 
+    config = factory.run_config().update(batch_size=batch_size, dry_run=dry_run, progressbar=not no_progress_bar)
     plex = factory.plex_api()
-    trakt = factory.trakt_api(batch_size=batch_size)
-    mf = factory.media_factory(batch_size=batch_size)
-    pb = factory.progressbar(not no_progress_bar)
+    trakt = factory.trakt_api()
+    mf = factory.media_factory()
+    pb = factory.progressbar(config.progressbar)
     wc = WalkConfig(movies=movies, shows=shows)
     w = Walker(plex=plex, trakt=trakt, mf=mf, config=wc, progressbar=pb)
 

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -11,7 +11,7 @@ from plextraktsync.logging import logger
 from plextraktsync.plex_api import PlexApi
 from plextraktsync.sync import Sync
 from plextraktsync.version import version
-from plextraktsync.walker import WalkConfig, Walker
+from plextraktsync.walker import Walker
 
 
 def sync_all(walker: Walker, plex: PlexApi, runner: Sync, dry_run: bool):
@@ -92,12 +92,8 @@ def sync(
     shows = sync_option in ["all", "tv", "shows"]
 
     config = factory.run_config().update(batch_size=batch_size, dry_run=dry_run, progressbar=not no_progress_bar)
-    plex = factory.plex_api()
-    trakt = factory.trakt_api()
-    mf = factory.media_factory()
-    pb = factory.progressbar(config.progressbar)
-    wc = WalkConfig(movies=movies, shows=shows)
-    w = Walker(plex=plex, trakt=trakt, mf=mf, config=wc, progressbar=pb)
+    wc = factory.walk_config().update(movies=movies, shows=shows)
+    w = factory.walker()
 
     if ids:
         for id in ids:
@@ -117,8 +113,9 @@ def sync(
         print("Enabled dry-run mode: not making actual changes")
     w.print_plan(print=tqdm.write)
 
+    plex = factory.plex_api()
     with measure_time("Completed full sync"):
         try:
-            sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=dry_run)
+            sync_all(walker=w, plex=plex, runner=factory.sync(), dry_run=config.dry_run)
         except RuntimeError as e:
             raise ClickException(str(e))

--- a/plextraktsync/commands/unmatched.py
+++ b/plextraktsync/commands/unmatched.py
@@ -18,11 +18,12 @@ def unmatched(no_progress_bar: bool):
     List media that has no match in Plex
     """
 
+    config = factory.run_config().update(progressbar=not no_progress_bar)
     ensure_login()
     plex = factory.plex_api()
     trakt = factory.trakt_api()
     mf = factory.media_factory()
-    pb = factory.progressbar(not no_progress_bar)
+    pb = factory.progressbar(config.progressbar)
     wc = WalkConfig()
     walker = Walker(plex, trakt, mf, wc, progressbar=pb)
 

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from json import JSONDecodeError
 from os import getenv
 from os.path import exists
@@ -17,6 +18,22 @@ PLEX_PLATFORM = "PlexTraktSync"
 Constant in seconds for how much to wait between Trakt POST API calls.
 """
 TRAKT_POST_DELAY = 1.1
+
+
+@dataclass
+class RunConfig:
+    """
+    Class to hold runtime config parameters
+    """
+    dry_run: bool = False
+    batch_size: int = 1
+    progressbar: bool = True
+
+    def update(self, **kwargs):
+        for name, value in kwargs.items():
+            self.__setattr__(name, value)
+
+        return self
 
 
 class Config(dict):

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -90,6 +90,28 @@ class Factory:
         return config
 
     @memoize
+    def walk_config(self):
+        from plextraktsync.walker import WalkConfig
+
+        wc = WalkConfig()
+
+        return wc
+
+    @memoize
+    def walker(self):
+        from plextraktsync.walker import Walker
+
+        config = self.run_config()
+        walk_config = self.walk_config()
+        plex = self.plex_api()
+        trakt = self.trakt_api()
+        mf = self.media_factory()
+        pb = self.progressbar(config.progressbar)
+        w = Walker(plex=plex, trakt=trakt, mf=mf, config=walk_config, progressbar=pb)
+
+        return w
+
+    @memoize
     def config(self):
         from plextraktsync.config import CONFIG
 

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -4,10 +4,11 @@ from plextraktsync.decorators.memoize import memoize
 
 class Factory:
     @memoize
-    def trakt_api(self, batch_size=None):
+    def trakt_api(self):
         from plextraktsync.trakt_api import TraktApi
 
-        trakt = TraktApi(batch_size=batch_size)
+        config = self.run_config()
+        trakt = TraktApi(batch_size=config.batch_size)
 
         return trakt
 
@@ -21,10 +22,10 @@ class Factory:
         return plex
 
     @memoize
-    def media_factory(self, batch_size=None):
+    def media_factory(self):
         from plextraktsync.media import MediaFactory
 
-        trakt = self.trakt_api(batch_size=batch_size)
+        trakt = self.trakt_api()
         plex = self.plex_api()
         mf = MediaFactory(plex, trakt)
 
@@ -79,6 +80,14 @@ class Factory:
             return tqdm
 
         return None
+
+    @memoize
+    def run_config(self):
+        from plextraktsync.config import RunConfig
+
+        config = RunConfig()
+
+        return config
 
     @memoize
     def config(self):

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -23,6 +23,14 @@ class WalkConfig:
         self.walk_movies = movies
         self.walk_shows = shows
 
+    def update(self, movies=None, shows=None):
+        if movies is not None:
+            self.walk_movies = movies
+        if shows is not None:
+            self.walk_shows = shows
+
+        return self
+
     def add_library(self, library):
         self.library.append(library)
 


### PR DESCRIPTION
This simplifies code needing to pass parameters around multiple methods. For example `media_factory(batch_size=batch_size)` was present just to be passed to `factory.trakt_api()`.

To get walker instance with defaults, can now just call `factory.walker()`