### PR TITLE
Chore: Cleanup long deprecated methods

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -133,16 +133,6 @@ class MediaFactory:
 
         return None
 
-    @deprecated("use resolve_any")
-    def resolve(self, pm: PlexLibraryItem, tm=None):
-        try:
-            guid = pm.guid
-        except (PlexApiException, RequestException) as e:
-            logger.error(f"Skipping {pm}: {e}")
-            return None
-
-        return self.resolve_guid(guid, tm)
-
     def resolve_guid(self, guid: PlexGuid, tm=None):
         if guid.provider in ["local", "none", "agents.none"]:
             logger.warning(f"{guid.pm.item}: Skipping guid {guid} because provider {guid.provider} has no external Id")

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -175,30 +175,6 @@ class PlexLibraryItem:
 
     @property
     @memoize
-    @deprecated("Use .guid.provider directly")
-    def provider(self):
-        return self.guid.provider
-
-    @property
-    @memoize
-    @deprecated("Use .guid.id directly")
-    def id(self):
-        return self.guid.id
-
-    @property
-    @memoize
-    @deprecated("Use .guid.is_episode directly")
-    def is_episode(self):
-        return self.guid.is_episode
-
-    @property
-    @memoize
-    @deprecated("Use .guid.show_id directly")
-    def show_id(self):
-        return self.guid.show_id
-
-    @property
-    @memoize
     @rate_limit(retries=1)
     def rating(self):
         if self.item.userRating is None:

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -10,7 +10,6 @@ from plexapi.library import LibrarySection, MovieSection, ShowSection
 from plexapi.server import PlexServer, SystemAccount, SystemDevice
 from trakt.utils import timestamp
 
-from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.rate_limit import rate_limit
@@ -127,12 +126,6 @@ class PlexLibraryItem:
     @memoize
     def is_legacy_agent(self):
         return not self.item.guid.startswith('plex://')
-
-    @property
-    @memoize
-    @deprecated("Use .guids directly")
-    def guid(self):
-        return self.guids[0]
 
     @nocache
     @rate_limit()

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -20,7 +20,6 @@ from plextraktsync.factory import factory
 from plextraktsync.logging import logger
 from plextraktsync.path import pytrakt_file
 from plextraktsync.plex_api import PlexGuid, PlexLibraryItem
-from plextraktsync.pytrakt_extensions import AllWatchedShows
 
 
 class ScrobblerProxy:

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -11,7 +11,6 @@ from trakt.sync import Scrobbler
 from trakt.tv import TVEpisode, TVSeason, TVShow
 
 from plextraktsync import pytrakt_extensions
-from plextraktsync.decorators.deprecated import deprecated
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.rate_limit import rate_limit
@@ -218,11 +217,6 @@ class TraktApi:
 
         return self.search_by_id(guid.id, id_type=guid.provider, media_type=guid.type)
 
-    @memoize
-    @deprecated("Use find_by_guid")
-    def find_by_media(self, pm: PlexLibraryItem):
-        return self.find_by_guid(pm.guid)
-
     @rate_limit()
     def search_by_id(self, media_id: str, id_type: str, media_type: str):
         if id_type == "tvdb" and media_type == "movie":
@@ -258,10 +252,6 @@ class TraktApi:
             if not guid.is_episode:
                 return self.find_by_guid(guid)
             return None
-
-    @deprecated("Use find_episode_guid")
-    def find_episode(self, tm: TVShow, pe: PlexLibraryItem, lookup=None):
-        return self.find_episode_guid(tm, pe.guid, lookup)
 
     def flush(self):
         """


### PR DESCRIPTION
Drop the methods that used only one guid. The methods are not in use.