### PR TITLE
Fix: Catch error from plan validaion

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -97,9 +97,13 @@ def sync(
         click.echo("Nothing to sync, this is likely due conflicting options given.")
         return
 
+    try:
+        w.print_plan(print=tqdm.write)
+    except RuntimeError as e:
+        raise ClickException(str(e))
+
     if dry_run:
         print("Enabled dry-run mode: not making actual changes")
-    w.print_plan(print=tqdm.write)
 
     with measure_time("Completed full sync"):
         try:


### PR DESCRIPTION
Plan validation happens in `w.print_plan`, so add exception check.

The sync method can throw as well, so keep the exception:

```
Error: Unexpected call: episode without show property
```


