### PR TITLE
Feature: Deep merge config.defaults.json

### DIFF
--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -63,7 +63,7 @@ class Config(dict):
                 fp.write(json.dumps(defaults, indent=4))
 
         config = self.load_json(self.config_file)
-        self.update(config)
+        self.merge(config, self)
 
         load_dotenv(self.env_file)
         for key in self.env_keys:
@@ -75,6 +75,18 @@ class Config(dict):
         self.initialized = True
 
         self["cache"]["path"] = self["cache"]["path"].replace("$PTS_CACHE_DIR", cache_dir)
+
+    # https://stackoverflow.com/a/20666342/2314626
+    def merge(self, source, destination):
+        for key, value in source.items():
+            if isinstance(value, dict):
+                # get node or create one
+                node = destination.setdefault(key, {})
+                self.merge(value, node)
+            else:
+                destination[key] = value
+
+        return destination
 
     def save(self):
         with open(self.env_file, "w") as txt:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,25 @@ from os import environ
 from plextraktsync.factory import factory
 
 
+def test_config_merge():
+    config = factory.config()
+
+    override = {
+        "root": {
+            "key1": "value1"
+        }
+    }
+    config.merge(override, config)
+    override = {
+        "root": {
+            "key2": "value2"
+        }
+    }
+    config.merge(override, config)
+    assert config["root"]["key1"] == "value1"
+    assert config["root"]["key2"] == "value2"
+
+
 def test_config():
     config = factory.config()
 


### PR DESCRIPTION
This helps in cases when config.default.json will have new key under section that already has a value:

// config.json
```json
    "logging": {
        "append": false
    },
```

// config.default.json
```json
    "logging": {
        "append": true,
        "filename": "plextraktsync.log"
    },
```

without this changeset, the final config would be:

```json
    "logging": {
        "append": false
    },
```

but needs to be:

```json
    "logging": {
        "append": false,
        "filename": "plextraktsync.log"
    },
```
