### PR TITLE
Decorate mark_watched with rate_limit to retry Plex Server errors

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -518,6 +518,7 @@ class PlexApi:
             yield h
 
     @nocache
+    @rate_limit()
     def mark_watched(self, m):
         m.markWatched()
 


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/606