### PR TITLE
Remove unnecessary request to trakt api to get show trakt id

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -78,7 +78,10 @@ class Media:
         return watched.get_completed(self.show_trakt_id, self.season_number, self.episode_number)
 
     def mark_watched_trakt(self):
-        self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
+        if self.is_movie:
+            self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
+        if self.is_episode:
+            self.trakt_api.mark_watched(self.trakt, self.plex.seen_date, self.show_trakt_id)
 
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -169,12 +169,12 @@ class TraktApi:
     @nocache
     @rate_limit()
     @time_limit()
-    def mark_watched(self, m, time):
+    def mark_watched(self, m, time, show_trakt_id=None):
         m.mark_as_seen(time)
         if m.media_type == "movies":
             self.watched_movies.add(m.trakt)
-        if m.media_type == "episodes":
-            self.watched_shows.add(TVShow(m.show).trakt, m.season, m.number)
+        if m.media_type == "episodes" and show_trakt_id:
+            self.watched_shows.add(show_trakt_id, m.season, m.number)
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
Show trakt id is needed for episodes added in `watched_shows` during sync (to keep this list up-to-date in real time).
Instead of requesting Trakt API based on show name, we can get this id from the `show_trakt_id` attribute.

Fixes #615