### PR TITLE
Fix: Do not cast show_id to integer to avoid error in valid_trakt_id method

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -105,7 +105,7 @@ class PlexGuid:
         if not show.isnumeric():
             raise ValueError(f"show_id is not numeric: {show}")
 
-        return int(show)
+        return show
 
     @property
     @memoize


### PR DESCRIPTION
Happens when trying to inspect an epsode

```
    if media_id[0:2] == 'tt' and media_id[2:].isnumeric():
TypeError: 'int' object is not subscriptable
```