### PR TITLE
Fix: restore python 3.8 support

### DIFF
--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -91,7 +91,7 @@ class WalkPlanner:
         if not self.config.id:
             return [None, None, None]
 
-        results = defaultdict(list[Movie, Show, Episode])
+        results = defaultdict(list)
         for id in self.config.id:
             found = self.find_from_sections_by_id(show_sections, id, results) if self.config.walk_shows else None
             if found:


### PR DESCRIPTION
The typing was incorrect anyway:
```py
      list[Movie, Show, Episode]
```

The values are actually strings, not objects.

refs:
- https://github.com/Taxel/PlexTraktSync/issues/619#issuecomment-991923551
- https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections