### PR TITLE
Feature: Use plextraktsync.log as log filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /dist/
 /docker-compose.override.yml
 /last_update.log
+/plextraktsync.log
 /tests/.env
 /tests/config.json
 /trakt_cache.sqlite

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Academy Award Nominees" but might not be ideal for lists that are updated
 often). Here are the execution times on my Plex server: First run - 1228
 seconds, second run - 111 seconds
 
-You can view sync progress in the `last_update.log` file which will be created.
+You can view sync progress in the `plextraktsync.log` file which will be created.
 
 ## Commands
 

--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -2,7 +2,7 @@
     "log_debug_messages": false,
     "logging": {
         "filename": "plextraktsync.log",
-        "append": false
+        "append": true
     },
     "cache": {
         "path": "$PTS_CACHE_DIR/trakt_cache"

--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -1,6 +1,7 @@
 {
     "log_debug_messages": false,
     "logging": {
+        "debug": false,
         "filename": "plextraktsync.log",
         "append": true
     },

--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -1,5 +1,4 @@
 {
-    "log_debug_messages": false,
     "logging": {
         "debug": false,
         "filename": "plextraktsync.log",

--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -1,6 +1,7 @@
 {
     "log_debug_messages": false,
     "logging": {
+        "filename": "plextraktsync.log",
         "append": false
     },
     "cache": {

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -6,7 +6,10 @@ from .factory import factory
 def initialize():
     CONFIG = factory.config()
     # global log level for all messages
-    log_level = logging.DEBUG if CONFIG['log_debug_messages'] else logging.INFO
+    if ("log_debug_messages" in CONFIG and CONFIG["log_debug_messages"]) or CONFIG["logging"]["debug"]:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
     log_file = CONFIG["logging"]["filename"]
     log_format = '%(asctime)s %(levelname)s:%(message)s'
 

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -1,13 +1,13 @@
 import logging
 
 from .factory import factory
-from .path import log_file
 
 
 def initialize():
     CONFIG = factory.config()
     # global log level for all messages
     log_level = logging.DEBUG if CONFIG['log_debug_messages'] else logging.INFO
+    log_file = CONFIG["logging"]["filename"]
     log_format = '%(asctime)s %(levelname)s:%(message)s'
 
     # messages with info and above are printed to stdout


### PR DESCRIPTION
This enables append=true to keep all logs, therefore having last_update as log filename is no longer appropriate.

Also, moved all logging options under "logging" in config file.