### PR TITLE
Fix: Prevent rating key access filling cache with stale data

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -90,8 +90,10 @@ class Media:
     def trakt_rating(self):
         if self.trakt.media_type == 'movies':
             rating = self.trakt_api.movie_ratings.get(self.trakt.trakt, None)
-        if self.trakt.media_type == 'episodes':
+        elif self.trakt.media_type == 'episodes':
             rating = self.trakt_api.episode_ratings.get(self.trakt.trakt, None)
+        else:
+            raise RuntimeError(f"Unsupported media type: {self.trakt.media_type}")
         if rating:
             return int(rating)
         return None

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -169,6 +169,7 @@ class PlexLibraryItem:
         return self.item.type
 
     @property
+    @nocache
     @rate_limit(retries=1)
     def rating(self):
         if self.item.userRating is None:


### PR DESCRIPTION
This may call fetch by plex and it may be cached
or later code could prevent last seen date being incorrect

Probably fixes https://github.com/Taxel/PlexTraktSync/issues/631 and fixes https://github.com/Taxel/PlexTraktSync/issues/619