### PR TITLE
Refactor: Fetch Plex userRatings in a separate call

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -72,6 +72,8 @@ def inspect_media(id):
         m.show = ms
 
     print(f"Trakt: {m.trakt_url}")
+    print(f"Plex Rating: {m.plex_rating}")
+    print(f"Trakt Rating: {m.trakt_rating}")
     print(f"Watched on Plex: {m.watched_on_plex}")
     print(f"Watched on Trakt: {m.watched_on_trakt}")
 

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -384,6 +384,15 @@ class PlexLibrarySection:
         except NotFound:
             return None
 
+    def find_with_rating(self):
+        filters = {
+            'and': [
+                {'userRating>>': -1},
+            ]
+        }
+
+        return self.section.search(filters=filters)
+
     @nocache
     def find_by_id(self, id: Union[str, int]) -> Optional[Union[Movie, Show, Episode]]:
         try:

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -121,6 +121,25 @@ class PlexGuid:
         return self.guid
 
 
+class PlexRatingCollection(dict):
+    def __init__(self, plex: PlexApi):
+        super(dict, self).__init__()
+        self.plex = plex
+
+    def __missing__(self, section_id):
+        section = self.plex.library_sections[section_id]
+        ratings = self.ratings(section)
+        self[section_id] = ratings
+
+        return ratings
+
+    @flatten_dict
+    def ratings(self, section: PlexLibrarySection):
+        ratings = section.find_with_rating()
+        for item in ratings:
+            yield item.ratingKey, item.userRating
+
+
 class PlexLibraryItem:
     def __init__(self, item: Union[Movie, Show, Episode]):
         self.item = item

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -389,8 +389,9 @@ class PlexLibraryItem:
 
 
 class PlexLibrarySection:
-    def __init__(self, section: LibrarySection):
+    def __init__(self, section: LibrarySection, plex=None):
         self.section = section
+        self.plex = plex
 
     @nocache
     def __len__(self):
@@ -450,7 +451,7 @@ class PlexLibrarySection:
 
     def items(self, max_items: int):
         for item in self.all(max_items):
-            yield PlexLibraryItem(item)
+            yield PlexLibraryItem(item, plex=self.plex)
 
     def __repr__(self):
         return f"<PlexLibrarySection:{self.type}:{self.title}>"
@@ -530,7 +531,7 @@ class PlexApi:
         for section in self.plex.library.sections():
             if section.title in CONFIG["excluded-libraries"]:
                 continue
-            yield section.key, PlexLibrarySection(section)
+            yield section.key, PlexLibrarySection(section, plex=self)
 
     @property
     def library_section_names(self):

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from plexapi import X_PLEX_CONTAINER_SIZE
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
@@ -126,7 +126,7 @@ class PlexRatingCollection(dict):
         super(dict, self).__init__()
         self.plex = plex
 
-    def __missing__(self, section_id):
+    def __missing__(self, section_id: int):
         section = self.plex.library_sections[section_id]
         ratings = self.ratings(section)
         self[section_id] = ratings
@@ -526,7 +526,7 @@ class PlexApi:
     @memoize
     @flatten_dict
     @nocache
-    def library_sections(self) -> dict[PlexLibrarySection[MovieSection, ShowSection]]:
+    def library_sections(self) -> Dict[int, PlexLibrarySection]:
         CONFIG = factory.config()
         for section in self.plex.library.sections():
             if section.title in CONFIG["excluded-libraries"]:

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -538,6 +538,11 @@ class PlexApi:
     def system_account(self, account_id: int) -> SystemAccount:
         return self.plex.systemAccount(account_id)
 
+    @property
+    @memoize
+    def ratings(self):
+        return PlexRatingCollection(self)
+
     @nocache
     def rate(self, m, rating):
         m.rate(rating)


### PR DESCRIPTION
Since rating fetching for all items is super slow:
- https://github.com/Taxel/PlexTraktSync/pull/666#issuecomment-997428206

add method to find Plex items that have rating value present.