### PR TITLE
Fix: Don't setup duplicate logging for Plex

### DIFF
--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -33,7 +33,6 @@ def initialize():
         from plexapi import log as logger, loghandler
         logger.removeHandler(loghandler)
         logger.setLevel(logging.DEBUG)
-        logger.addHandler(file_handler)
 
 
 initialize()

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -30,7 +30,8 @@ def initialize():
 
     # Set debug for other components as well
     if log_level == logging.DEBUG:
-        from plexapi import log as logger
+        from plexapi import log as logger, loghandler
+        logger.removeHandler(loghandler)
         logger.setLevel(logging.DEBUG)
         logger.addHandler(file_handler)
 


### PR DESCRIPTION
Plex entries were duplicated once debug log is enabled.