### PR TITLE
Fix: Avoid crashing when Plex server is not found

### DIFF
--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -6,7 +6,7 @@ from subprocess import check_output
 from typing import List
 
 import click
-from click import Choice
+from click import Choice, ClickException
 from plexapi.exceptions import NotFound, Unauthorized
 from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
 from plexapi.server import PlexServer
@@ -117,6 +117,9 @@ def choose_server(account: MyPlexAccount):
     while True:
         try:
             server = pick_server(account)
+            if not server:
+                raise ClickException("Unable to find server from Plex account")
+
             # Connect to obtain baseUrl
             click.echo(title(f"Attempting to connect to {server.name}. This may take time and print some errors."))
             click.echo(title("Server connections:"))


### PR DESCRIPTION
Avoid crashing when Plex server is not found

Just exit with a short error. Fix for https://github.com/Taxel/PlexTraktSync/issues/677

```
➜ python -m plextraktsync plex-login
You already have Plex Access Token, do you want to log in again? [Y/n]:
Please enter your Plex username or e-mail [*redacted*]:
If you have 2 Factor Authentication enabled on Plex you can append the code to your password below (eg. passwordCODE)
Please enter your Plex password:
Login to MyPlex was successful!
Error: Unable to find server from Plex account
➜
```