### PR TITLE
Fix login with managed users

### DIFF
--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -42,7 +42,7 @@ def myplex_login(username, password):
 
 
 def choose_managed_user(account: MyPlexAccount):
-    users = [u.title for u in account.users() if u.friend]
+    users = [u.title for u in account.users()]
     if not users:
         return None
 


### PR DESCRIPTION
Skip friend check. Managed users do not have a separate account (with email address)

I have tested it and it works great.

x-ref:
- https://github.com/Taxel/PlexTraktSync/discussions/680#discussioncomment-1929301