### PR TITLE
Delegate __contains__ to inner dict to support contains queries

### DIFF
--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -54,6 +54,11 @@ class Config(dict):
             self.initialize()
         return dict.__getitem__(self, item)
 
+    def __contains__(self, item):
+        if not self.initialized:
+            self.initialize()
+        return dict.__contains__(self, item)
+
     def initialize(self):
         defaults = self.load_json(default_config_file)
         self.update(defaults)


### PR DESCRIPTION
Fixes regression from https://github.com/Taxel/PlexTraktSync/pull/664

The side effect was that old `log_debug_messages` wasn't respected