### PR TITLE
Feature: Handle watch activity for episodes

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -63,6 +63,15 @@ class WatchStateUpdater:
             return None
 
         m = self.mf.resolve_any(pm)
+        if not m:
+            return None
+
+        # setup show property for trakt watched status
+        if m.is_episode:
+            ps = self.plex.fetch_item(m.plex.item.grandparentRatingKey)
+            ms = self.mf.resolve_any(ps)
+            m.show = ms
+
         return m
 
     def on_error(self, error: Error):


### PR DESCRIPTION
The Activity monitor not to error when episode is opened.

NOTE: the activity only prints, performs no actions (yet).