### PR TITLE
Feature:  Add on_delete listener to watcher

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -49,6 +49,7 @@ class WatchStateUpdater:
         self.mf = mf
         self.logger = logging.getLogger("PlexTraktSync.WatchStateUpdater")
         self.scrobblers = ScrobblerCollection(trakt, config["watch"]["scrobble_threshold"])
+        self.remove_collection = config["watch"]["remove_collection"]
         if config["watch"]["username_filter"]:
             self.username_filter = config["PLEX_USERNAME"]
         else:
@@ -86,12 +87,15 @@ class WatchStateUpdater:
         self.logger.info(f"Activity: {m}: Watched: Plex: {m.watched_on_plex}, Trakt: {m.watched_on_trakt}")
 
     def on_delete(self, event: TimelineEntry):
+        self.logger.info(f"Deleted {event.title}")
+
         m = self.find_by_key(event.item_id)
         if not m:
             return
 
-        movie = m.plex.item
-        self.logger.info(f"Deleted {event.title}: {movie}")
+        if self.remove_collection:
+            m.remove_from_collection()
+            self.logger.info(f"Removed from Collection: {m}")
 
     def on_play(self, event: PlaySessionStateNotification):
         if not self.can_scrobble(event):

--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -2,7 +2,7 @@ import click
 
 from plextraktsync.config import Config
 from plextraktsync.events import (ActivityNotification, Error,
-                                  PlaySessionStateNotification)
+                                  PlaySessionStateNotification, TimelineEntry)
 from plextraktsync.factory import factory
 from plextraktsync.listener import WebSocketListener
 from plextraktsync.logging import logging
@@ -85,6 +85,14 @@ class WatchStateUpdater:
             return
         self.logger.info(f"Activity: {m}: Watched: Plex: {m.watched_on_plex}, Trakt: {m.watched_on_trakt}")
 
+    def on_delete(self, event: TimelineEntry):
+        m = self.find_by_key(event.item_id)
+        if not m:
+            return
+
+        movie = m.plex.item
+        self.logger.info(f"Deleted {event.title}: {movie}")
+
     def on_play(self, event: PlaySessionStateNotification):
         if not self.can_scrobble(event):
             return
@@ -137,6 +145,7 @@ def watch():
 
     ws.on(PlaySessionStateNotification, updater.on_play, state=["playing", "stopped", "paused"])
     ws.on(ActivityNotification, updater.on_activity, type="library.refresh.items", event=["ended"], progress=100)
+    ws.on(TimelineEntry, updater.on_delete, state=9, metadata_state="deleted")
     ws.on(Error, updater.on_error)
 
     print("Listening for events!")

--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -22,6 +22,7 @@
     },
     "watch": {
         "scrobble_threshold": 80,
+        "remove_collection": false,
         "username_filter": true
     },
     "xbmc-providers": {

--- a/plextraktsync/events.py
+++ b/plextraktsync/events.py
@@ -81,7 +81,21 @@ class StatusNotification(Event):
 
 
 class TimelineEntry(Event):
-    pass
+    @property
+    def state(self):
+        return self["state"]
+
+    @property
+    def item_id(self):
+        return int(self["itemID"])
+
+    @property
+    def metadata_state(self):
+        return self["metadataState"]
+
+    @property
+    def title(self):
+        return self["title"]
 
 
 class EventFactory:

--- a/plextraktsync/listener.py
+++ b/plextraktsync/listener.py
@@ -44,6 +44,9 @@ class EventDispatcher:
         # test event dictionary items
         if name not in event:
             return False
+        # accept only arrays
+        if not isinstance(value, list):
+            return False
         if event[name] not in value:
             return False
         return True

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -64,6 +64,9 @@ class Media:
     def add_to_collection(self):
         self.trakt_api.add_to_collection(self.trakt, self.plex)
 
+    def remove_from_collection(self):
+        self.trakt_api.remove_from_library(self.trakt)
+
     @property
     def watched_on_plex(self):
         return self.plex.item.isWatched


### PR DESCRIPTION
This detects media delete events and deletes them from trakt collection if `config["watch"] ["remove_collection"]` is `true`.

The delete event payload looks like this:

```py
{
    'type': 'timeline',
    'size': 1,
    'TimelineEntry': [{
        'identifier': 'com.plexapp.plugins.library',
        'sectionID': '2',
        'itemID': '16336',
        'parentItemID': '16325',
        'rootItemID': '16324',
        'type': 4,
        'title': 'Pioneer One S01 E02',
        'state': 9,
        'metadataState': 'deleted',
        'updatedAt': 1641766793
    }]
}
```

This can be used for removing trakt collection on delete on plex:
- https://github.com/Taxel/PlexTraktSync/issues/374

Example:
```
INFO: Deleted Pioneer One S01 E05
INFO: Removed from Collection: <tvdb:170551/1/5:<Episode:16326:Pioneer-One-s01e05>>
```

NOTE: Deleting an episode results season and show become empty, those are deleted too (magic by plex):
```
INFO: Deleted Pioneer One
INFO: Removed from Collection: <tvdb:170551:<Show:16324:Pioneer-One>>
INFO: Deleted Season 1
INFO: Deleted Pioneer One S01 E06
INFO: Removed from Collection: <tvdb:170551/1/6:<Episode:16334:Pioneer-One-s01e06>>
```

NOTE: trakt.tv website takes some time when collection state is removed, so the change is not immediately visible.

Requires:
- https://github.com/Taxel/PlexTraktSync/pull/702