### PR TITLE
Refactor: Simplify event dispatcher to accept only properties

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -148,7 +148,7 @@ def watch():
     updater = WatchStateUpdater(plex, trakt, mf, config)
 
     ws.on(PlaySessionStateNotification, updater.on_play, state=["playing", "stopped", "paused"])
-    ws.on(ActivityNotification, updater.on_activity, type="library.refresh.items", event=["ended"], progress=100)
+    ws.on(ActivityNotification, updater.on_activity, type="library.refresh.items", event="ended", progress=100)
     ws.on(TimelineEntry, updater.on_delete, state=9, metadata_state="deleted")
     ws.on(Error, updater.on_error)
 

--- a/plextraktsync/events.py
+++ b/plextraktsync/events.py
@@ -41,6 +41,10 @@ class ActivityNotification(Event):
     def key(self):
         return self["Activity"]["Context"]["key"]
 
+    @property
+    def event(self):
+        return self["event"]
+
 
 class BackgroundProcessingQueueEventNotification(Event):
     pass

--- a/plextraktsync/listener.py
+++ b/plextraktsync/listener.py
@@ -37,19 +37,22 @@ class EventDispatcher:
             listener["listener"](event)
 
     @staticmethod
-    def match_filter(event, name, value):
-        # test event property
-        if hasattr(event, name) and getattr(event, name) == value:
+    def match_filter(event, key, match):
+        if hasattr(event, key):
+            # test event property
+            value = getattr(event, key)
+        elif key in event:
+            # test event dictionary items
+            value = event[key]
+        else:
+            return False
+
+        # check for arrays
+        if isinstance(match, list) and value in match:
             return True
-        # test event dictionary items
-        if name not in event:
-            return False
-        # accept only arrays
-        if not isinstance(value, list):
-            return False
-        if event[name] not in value:
-            return False
-        return True
+
+        # check for scalars
+        return value == match
 
     def match_event(self, listener, event):
         if not isinstance(event, listener["event_type"]):

--- a/plextraktsync/listener.py
+++ b/plextraktsync/listener.py
@@ -38,18 +38,13 @@ class EventDispatcher:
 
     @staticmethod
     def match_filter(event, key, match):
-        if hasattr(event, key):
-            # test event property
-            value = getattr(event, key)
-        elif key in event:
-            # test event dictionary items
-            value = event[key]
-        else:
+        if not hasattr(event, key):
             return False
+        value = getattr(event, key)
 
         # check for arrays
-        if isinstance(match, list) and value in match:
-            return True
+        if isinstance(match, list):
+            return value in match
 
         # check for scalars
         return value == match


### PR DESCRIPTION
Previously event dictionary was accepted as well, but it was only a single use, add a property for that instead.