### PR TITLE
Use cached_property decorator to cache properties

### DIFF
--- a/plextraktsync/decorators/cached_property.py
+++ b/plextraktsync/decorators/cached_property.py
@@ -1,0 +1,24 @@
+try:
+    from functools import cached_property
+except ImportError:
+    # For py<3.8
+    # https://docs.python.org/3.8/library/functools.html
+    # https://github.com/pydanny/cached-property/blob/409f24286e16ea3086af463edea6b80cdd62deed/cached_property.py#L18-L47
+
+    class cached_property(object):
+        """
+        A property that is only computed once per instance and then replaces itself
+        with an ordinary attribute. Deleting the attribute resets the property.
+        Source: https://github.com/bottlepy/bottle/commit/fa7733e075da0d790d809aa3d2f53071897e6f76
+        """
+
+        def __init__(self, func):
+            self.__doc__ = getattr(func, "__doc__")
+            self.func = func
+
+        def __get__(self, obj, cls):
+            if obj is None:
+                return self
+
+            value = obj.__dict__[self.func.__name__] = self.func(obj)
+            return value

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -2,6 +2,7 @@ from plexapi.exceptions import PlexApiException
 from requests import RequestException
 from trakt.errors import TraktException
 
+from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.logging import logger
 from plextraktsync.plex_api import PlexApi, PlexGuid, PlexLibraryItem
 from plextraktsync.trakt_api import TraktApi
@@ -45,11 +46,11 @@ class Media:
             raise RuntimeError(f"Unexpected call: episode without show property")
         return self.show.trakt_id
 
-    @property
+    @cached_property
     def is_movie(self):
         return self.plex.type == "movie"
 
-    @property
+    @cached_property
     def is_episode(self):
         return self.plex.type == "episode"
 

--- a/plextraktsync/path.py
+++ b/plextraktsync/path.py
@@ -2,7 +2,7 @@ import site
 from os import getenv, makedirs
 from os.path import abspath, dirname, exists, join
 
-from plextraktsync.decorators.memoize import memoize
+from plextraktsync.decorators.cached_property import cached_property
 
 
 class Path:
@@ -21,33 +21,28 @@ class Path:
         self.env_file = join(self.config_dir, ".env")
         self.log_file = join(self.log_dir, "last_update.log")
 
-    @property
-    @memoize
+    @cached_property
     def config_dir(self):
         d = self.app_dir.user_config_dir if self.installed else self.app_path
         return getenv("PTS_CONFIG_DIR", d)
 
-    @property
-    @memoize
+    @cached_property
     def cache_dir(self):
         d = self.app_dir.user_cache_dir if self.installed else self.app_path
         return getenv("PTS_CACHE_DIR", d)
 
-    @property
-    @memoize
+    @cached_property
     def log_dir(self):
         d = self.app_dir.user_log_dir if self.installed else self.app_path
         return getenv("PTS_LOG_DIR", d)
 
-    @property
-    @memoize
+    @cached_property
     def app_dir(self):
         from appdirs import AppDirs
 
         return AppDirs(self.app_name)
 
-    @property
-    @memoize
+    @cached_property
     def installed(self):
         """
         Return true if this package is installed to site-packages

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -12,6 +12,7 @@ from plexapi.server import PlexServer, SystemAccount, SystemDevice
 from plexapi.video import Episode, Movie, Show
 from trakt.utils import timestamp
 
+from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_dict, flatten_list
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.nocache import nocache
@@ -52,13 +53,11 @@ class PlexGuid:
         self.type = type
         self.pm = pm
 
-    @property
-    @memoize
+    @cached_property
     def media_type(self):
         return f"{self.type}s"
 
-    @property
-    @memoize
+    @cached_property
     def provider(self):
         if self.guid_is_imdb_legacy:
             return "imdb"
@@ -76,8 +75,7 @@ class PlexGuid:
 
         return x
 
-    @property
-    @memoize
+    @cached_property
     def id(self):
         if self.guid_is_imdb_legacy:
             return self.guid
@@ -85,8 +83,7 @@ class PlexGuid:
         x = x.split("?")[0]
         return x
 
-    @property
-    @memoize
+    @cached_property
     def is_episode(self):
         """
         Return true of the id is in form of <show>/<season>/<episode>
@@ -97,8 +94,7 @@ class PlexGuid:
 
         return False
 
-    @property
-    @memoize
+    @cached_property
     def show_id(self):
         if not self.is_episode:
             raise ValueError("show_id is not valid for non-episodes")
@@ -109,8 +105,7 @@ class PlexGuid:
 
         return show
 
-    @property
-    @memoize
+    @cached_property
     def guid_is_imdb_legacy(self):
         guid = self.guid
 
@@ -154,8 +149,7 @@ class PlexLibraryItem:
     def get_guids(self):
         return self.item.guids
 
-    @property
-    @memoize
+    @cached_property
     def guids(self):
         # return early if legacy agent
         # accessing .guids for legacy agent
@@ -178,18 +172,15 @@ class PlexLibraryItem:
         ordered = sorted(guids, key=lambda guid: sort_order[guid.provider])
         return ordered
 
-    @property
-    @memoize
+    @cached_property
     def media_type(self):
         return f"{self.type}s"
 
-    @property
-    @memoize
+    @cached_property
     def type(self):
         return self.item.type
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit(retries=1)
     def rating(self):
@@ -351,13 +342,11 @@ class PlexLibraryItem:
     def _get_episodes(self):
         return self.item.episodes()
 
-    @property
-    @memoize
+    @cached_property
     def season_number(self):
         return self.item.seasonNumber
 
-    @property
-    @memoize
+    @cached_property
     def episode_number(self):
         return self.item.index
 
@@ -465,8 +454,7 @@ class PlexApi:
     def __init__(self, plex: PlexServer):
         self.plex = plex
 
-    @property
-    @memoize
+    @cached_property
     def plex_base_url(self):
         return f"https://app.plex.tv/desktop/#!/server/{self.plex.machineIdentifier}"
 
@@ -510,20 +498,17 @@ class PlexApi:
         for media in result:
             yield PlexLibraryItem(media)
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     def version(self):
         return self.plex.version
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     def updated_at(self):
         return self.plex.updatedAt
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @flatten_dict
     def library_sections(self) -> Dict[int, PlexLibrarySection]:
@@ -547,8 +532,7 @@ class PlexApi:
     def system_account(self, account_id: int) -> SystemAccount:
         return self.plex.systemAccount(account_id)
 
-    @property
-    @memoize
+    @cached_property
     def ratings(self):
         return PlexRatingCollection(self)
 

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -1,6 +1,6 @@
 from plextraktsync.config import Config
+from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.measure_time import measure_time
-from plextraktsync.decorators.memoize import memoize
 from plextraktsync.logging import logger
 from plextraktsync.media import Media
 from plextraktsync.trakt_list_util import TraktListUtil
@@ -17,8 +17,7 @@ class SyncConfig:
     def __contains__(self, key):
         return key in self.config
 
-    @property
-    @memoize
+    @cached_property
     def trakt_to_plex(self):
         return {
             "watched_status": self.get("trakt_to_plex", "watched_status"),
@@ -27,8 +26,7 @@ class SyncConfig:
             "watchlist": self.get("trakt_to_plex", "watchlist"),
         }
 
-    @property
-    @memoize
+    @cached_property
     def plex_to_trakt(self):
         return {
             "watched_status": self.get("plex_to_trakt", "watched_status"),
@@ -36,13 +34,11 @@ class SyncConfig:
             "collection": self.get("plex_to_trakt", "collection"),
         }
 
-    @property
-    @memoize
+    @cached_property
     def sync_ratings(self):
         return self.trakt_to_plex["ratings"] or self.plex_to_trakt["ratings"]
 
-    @property
-    @memoize
+    @cached_property
     def sync_watched_status(self):
         return self.trakt_to_plex["watched_status"] or self.plex_to_trakt["watched_status"]
 

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -11,6 +11,7 @@ from trakt.sync import Scrobbler
 from trakt.tv import TVEpisode, TVSeason, TVShow
 
 from plextraktsync import pytrakt_extensions
+from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.rate_limit import rate_limit
@@ -69,8 +70,7 @@ class TraktApi:
 
         return trakt.init(client_id=client_id, client_secret=client_secret, store=True)
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def me(self):
@@ -80,15 +80,13 @@ class TraktApi:
             logger.fatal("Trakt authentication error: {}".format(str(e)))
             raise e
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def liked_lists(self):
         return pytrakt_extensions.get_liked_lists()
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def watched_movies(self):
@@ -96,15 +94,13 @@ class TraktApi:
             map(lambda m: m.trakt, self.me.watched_movies)
         )
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def movie_collection(self):
         return self.me.movie_collection
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def show_collection(self):
@@ -118,29 +114,25 @@ class TraktApi:
             raise ValueError("Must be valid media type")
         media.remove_from_library()
 
-    @property
-    @memoize
+    @cached_property
     def movie_collection_set(self):
         return set(
             map(lambda m: m.trakt, self.movie_collection)
         )
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def watched_shows(self):
         return pytrakt_extensions.allwatched()
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def watchlist_movies(self):
         return self.me.watchlist_movies
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def movie_ratings(self):
@@ -149,8 +141,7 @@ class TraktApi:
             ratings[r['movie']['ids']['trakt']] = r['rating']
         return ratings
 
-    @property
-    @memoize
+    @cached_property
     @nocache
     @rate_limit()
     def episode_ratings(self):

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -3,8 +3,8 @@ from typing import List, NamedTuple
 
 from plexapi.video import Episode, Movie, Show
 
+from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.measure_time import measure_time
-from plextraktsync.decorators.memoize import memoize
 from plextraktsync.media import Media, MediaFactory
 from plextraktsync.plex_api import (PlexApi, PlexGuid, PlexLibraryItem,
                                     PlexLibrarySection)
@@ -186,8 +186,7 @@ class Walker:
         self.mf = mf
         self.config = config
 
-    @property
-    @memoize
+    @cached_property
     def plan(self):
         return WalkPlanner(self.plex, self.config).plan()
 


### PR DESCRIPTION
Some mitigation to https://github.com/Taxel/PlexTraktSync/issues/431

Instead of stacking `@property` and `@memoize` decorators, use `@cached_property`,  after which memory usage seems to be a bit better:

Tested with a library of 176 shows:

version | base memory | process end memory | difference
-- | -- | -- | --
0.18.6 | 44612 | 165000 | 120388 
cached_property | 45180 | 78384 | 33204

the command for measuring memory usage (RSS column):
```
htop -p $(ps -ef |awk '/[p]lextraktsync/{print $2}')
```

Fallback for order python versions (python<3.8) taken from:
- https://github.com/pydanny/cached-property/blob/409f24286e16ea3086af463edea6b80cdd62deed/cached_property.py#L18-L47
