### PR TITLE
Fix: Add guards of unsupported media type

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -61,6 +61,8 @@ class Media:
     def is_collected(self):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.movie_collection_set
+        elif not self.is_episode:
+            raise RuntimeError(f"is_collected: Unsupported media type: {self.trakt.media_type}")
 
         collected = self.trakt_api.collected(self.show.trakt)
         return collected.get_completed(self.season_number, self.episode_number)
@@ -79,6 +81,8 @@ class Media:
     def watched_on_trakt(self):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.watched_movies
+        elif not self.is_episode:
+            raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.trakt.media_type}")
 
         watched = self.trakt_api.watched_shows
         return watched.get_completed(self.show_trakt_id, self.season_number, self.episode_number)
@@ -86,8 +90,10 @@ class Media:
     def mark_watched_trakt(self):
         if self.is_movie:
             self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
-        if self.is_episode:
+        elif self.is_episode:
             self.trakt_api.mark_watched(self.trakt, self.plex.seen_date, self.show_trakt_id)
+        else:
+            raise RuntimeError(f"mark_watched_trakt: Unsupported media type: {self.trakt.media_type}")
 
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)
@@ -99,7 +105,7 @@ class Media:
         elif self.trakt.media_type == 'episodes':
             rating = self.trakt_api.episode_ratings.get(self.trakt.trakt, None)
         else:
-            raise RuntimeError(f"Unsupported media type: {self.trakt.media_type}")
+            raise RuntimeError(f"trakt_rating: Unsupported media type: {self.trakt.media_type}")
         if rating:
             return int(rating)
         return None

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -166,8 +166,10 @@ class TraktApi:
         m.mark_as_seen(time)
         if m.media_type == "movies":
             self.watched_movies.add(m.trakt)
-        if m.media_type == "episodes" and show_trakt_id:
+        elif m.media_type == "episodes" and show_trakt_id:
             self.watched_shows.add(show_trakt_id, m.season, m.number)
+        else:
+            raise RuntimeError(f"mark_watched: Unsupported media type: {m.media_type}")
 
     def add_to_collection(self, m, pm: PlexLibraryItem):
         if m.media_type == "movies":


### PR DESCRIPTION
_Extracted from https://github.com/Taxel/PlexTraktSync/pull/720_


There are more types than movies and episodes.
This can avoid treating a show as an episode.