### PR TITLE
Feature: Move memoize from trakt_api to media class

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -142,7 +142,7 @@ class MediaFactory:
         self.plex = plex
         self.trakt = trakt
 
-    def resolve_any(self, pm: PlexLibraryItem, tm=None):
+    def resolve_any(self, pm: PlexLibraryItem, show: Media = None):
         try:
             guids = pm.guids
         except (PlexApiException, RequestException) as e:
@@ -150,13 +150,13 @@ class MediaFactory:
             return None
 
         for guid in guids:
-            m = self.resolve_guid(guid, tm)
+            m = self.resolve_guid(guid, show)
             if m:
                 return m
 
         return None
 
-    def resolve_guid(self, guid: PlexGuid, tm=None):
+    def resolve_guid(self, guid: PlexGuid, show: Media = None):
         if guid.provider in ["local", "none", "agents.none"]:
             logger.warning(f"{guid.pm.item}: Skipping guid {guid} because provider {guid.provider} has no external Id")
 
@@ -169,8 +169,8 @@ class MediaFactory:
             return None
 
         try:
-            if tm:
-                tm = self.trakt.find_episode_guid(tm, guid)
+            if show:
+                tm = self.trakt.find_episode_guid(guid, show.seasons)
             else:
                 tm = self.trakt.find_by_guid(guid)
         except (TraktException, RequestException) as e:

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -77,6 +77,13 @@ class Media:
     def remove_from_collection(self):
         self.trakt_api.remove_from_library(self.trakt)
 
+    @cached_property
+    def seasons(self):
+        if self.media_type != "shows":
+            raise RuntimeError(f"seasons: Unsupported media type: {self.media_type}")
+
+        return self.trakt_api.lookup(self.trakt)
+
     @property
     def watched_on_plex(self):
         return self.plex.item.isWatched

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -68,8 +68,15 @@ class Media:
         elif not self.is_episode:
             raise RuntimeError(f"is_collected: Unsupported media type: {self.media_type}")
 
-        collected = self.trakt_api.collected(self.show.trakt)
+        collected = self.show.collected
         return collected.get_completed(self.season_number, self.episode_number)
+
+    @cached_property
+    def collected(self):
+        if self.media_type != "shows":
+            raise RuntimeError(f"show_collected: Unsupported media type: {self.media_type}")
+
+        return self.trakt_api.collected(self.trakt)
 
     def add_to_collection(self):
         self.trakt_api.add_to_collection(self.trakt, self.plex)

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -226,7 +226,6 @@ class TraktApi:
 
         self.batch.add_to_collection(m.media_type, item)
 
-    @memoize
     @nocache
     @rate_limit()
     def collected(self, tm: TVShow):

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -232,7 +232,6 @@ class TraktApi:
     def collected(self, tm: TVShow):
         return pytrakt_extensions.collected(tm.trakt)
 
-    @memoize
     @nocache
     @rate_limit()
     def lookup(self, tm: TVShow):
@@ -245,7 +244,9 @@ class TraktApi:
     def find_by_guid(self, guid: PlexGuid):
         if guid.type == "episode" and guid.is_episode:
             ts = self.search_by_id(guid.show_id, id_type=guid.provider, media_type="show")
-            return self.find_episode_guid(ts, guid)
+            lookup = self.lookup(ts)
+
+            return self.find_episode_guid(guid, lookup)
 
         return self.search_by_id(guid.id, id_type=guid.provider, media_type=guid.type)
 
@@ -293,11 +294,10 @@ class TraktApi:
         # must be shorter than 12 numbers
         return len(media_id) < 12
 
-    def find_episode_guid(self, tm: TVShow, guid: PlexGuid, lookup=None):
+    def find_episode_guid(self, guid: PlexGuid, lookup):
         """
         Find Trakt Episode from Guid of Plex Episode
         """
-        lookup = lookup if lookup else self.lookup(tm)
         try:
             return lookup[guid.pm.season_number][guid.pm.episode_number].instance
         except KeyError:

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -253,7 +253,7 @@ class Walker:
             show = self.mf.resolve_guid(guid)
             if not show:
                 continue
-            me = self.mf.resolve_any(PlexLibraryItem(pe), show.trakt)
+            me = self.mf.resolve_any(PlexLibraryItem(pe), show)
             if not me:
                 continue
 
@@ -274,7 +274,7 @@ class Walker:
 
     def episode_from_show(self, show: Media):
         for pe in show.plex.episodes():
-            me = self.mf.resolve_any(pe, show.trakt)
+            me = self.mf.resolve_any(pe, show)
             if not me:
                 continue
 

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -46,7 +46,8 @@ def test_find_episode():
     ))
 
     guid = pe.guids[0]
-    te = trakt.find_episode_guid(tm, guid)
+    lookup = trakt.lookup(tm)
+    te = trakt.find_episode_guid(guid, lookup)
     assert te.season == 1
     assert te.episode == 1
     assert te.imdb == "tt11909222"


### PR DESCRIPTION
remove `@memoize` from:
- trakt_api::collected -> moved to media::collected
- trakt_api::lookup -> moved to media::seasons

so the cache is per episode/movie, not in the global traki_api class

see usage report:
- https://github.com/Taxel/PlexTraktSync/issues/431#issuecomment-1013444604