### PR TITLE
Performance: Drop memoize of find_by_guid

### DIFF
--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -239,7 +239,6 @@ class TraktApi:
         """
         return pytrakt_extensions.lookup_table(tm)
 
-    @memoize
     def find_by_guid(self, guid: PlexGuid):
         if guid.type == "episode" and guid.is_episode:
             ts = self.search_by_id(guid.show_id, id_type=guid.provider, media_type="show")


### PR DESCRIPTION
It's not useful for sync run and only consumes memory for cache that
nobody needs:
- https://github.com/Taxel/PlexTraktSync/issues/431#issuecomment-1013709208

originally added in ef991ea66b520bf243cfd0774afb379c5a1e6442

Fixes https://github.com/Taxel/PlexTraktSync/issues/431