### PR TITLE
Feature: Add handling of BadResponseException

### DIFF
--- a/plextraktsync/decorators/retry.py
+++ b/plextraktsync/decorators/retry.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from time import sleep
 
-from plexapi.exceptions import BadRequest
+from plexapi.exceptions import BadRequest, BadResponseException
 from requests import ReadTimeout, RequestException
 from trakt.errors import TraktInternalException
 
@@ -25,12 +25,17 @@ def retry(retries=5):
                     return fn(*args, **kwargs)
                 except (
                         BadRequest,
+                        BadResponseException,
                         ReadTimeout,
                         RequestException,
                         TraktInternalException,
                 ) as e:
                     if count == retries:
                         logger.error(f"Error: {e}")
+
+                        if isinstance(e, BadResponseException):
+                            logger.error(f"Details: {e.details}")
+
                         logger.error(
                             "API didn't respond properly, script will abort now. Please try again later."
                         )


### PR DESCRIPTION
Not sure what the handling should be. So added it to retry list.

```
WARNING  Bad Response - Response could not be parsed for plextraktsync.trakt_api.collected(), retrying after 1
         seconds (try: 1/5)
WARNING  Bad Response - Response could not be parsed for plextraktsync.trakt_api.lookup(), retrying after 1 seconds
         (try: 1/5)
WARNING  Bad Response - Response could not be parsed for plextraktsync.trakt_api.lookup(), retrying after 2 seconds
         (try: 2/5)
WARNING  Bad Response - Response could not be parsed for plextraktsync.trakt_api.lookup(), retrying after 3 seconds
         (try: 3/5)
WARNING  Retry using search for specific Plex Episode
```

Requires:
- https://github.com/moogar0880/PyTrakt/pull/181
- https://github.com/Taxel/PlexTraktSync/pull/1123