### PR TITLE
Fix: Discard pipx error output

### DIFF
--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -11,7 +11,7 @@ def execx(command: Union[str, List[str]]):
     if isinstance(command, str):
         command = command.split(' ')
 
-    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     return process.communicate()[0]
 
 


### PR DESCRIPTION
older pipx gives:
```
pipx: error: unrecognized arguments: --json
```

So, for `self-update` command to work, pipx 1.0.0 is required

refs:
- https://github.com/Taxel/PlexTraktSync/issues/730
- #717