### PR TITLE
Chore: Enable docker image layer cache in GHA

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -73,6 +73,8 @@ jobs:
           tags: ${{ env.TEST_IMAGE }}
           build-args: |
             APP_VERSION=${{ env.APP_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test Docker image
         run: |
@@ -90,5 +92,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ env.APP_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
 # vim:ts=2:sw=2:et


### PR DESCRIPTION
This could speed up Docker builds in GitHub Actions.

- https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache