### PR TITLE
Refactor: Lazy import commands

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import click
 
-from plextraktsync.commands.clear_collections import clear_collections
 from plextraktsync.commands.info import info
 from plextraktsync.commands.inspect import inspect
 from plextraktsync.commands.login import login
@@ -68,6 +67,17 @@ def cache():
     """
     Manage and analyze Requests Cache.
     """
+    pass
+
+
+@command()
+@click.option('--confirm', is_flag=True, help='Confirm the dangerous action')
+@click.option('--dry-run', is_flag=True, help='Do not perform delete actions')
+def clear_collections():
+    """
+    Clear Movies and Shows collections in Trakt
+    """
+
     pass
 
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -4,7 +4,6 @@ from os import environ
 import click
 
 from plextraktsync.commands.self_update import enable_self_update, self_update
-from plextraktsync.commands.unmatched import unmatched
 from plextraktsync.commands.watch import watch
 from plextraktsync.factory import factory
 
@@ -183,6 +182,30 @@ def trakt_login():
     """
     Log in to Trakt Account to obtain Access Token.
     """
+    pass
+
+
+@command()
+@click.option(
+    "--no-progress-bar", "no_progress_bar",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Don't output progress bars"
+)
+@click.option(
+    "--local",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Show only local files (no match in Plex)"
+)
+@click.command()
+def unmatched():
+    """
+    List media that has no match in Trakt or Plex
+    """
+
     pass
 
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import click
 
-from plextraktsync.commands.login import login
 from plextraktsync.commands.plex_login import plex_login
 from plextraktsync.commands.self_update import enable_self_update, self_update
 from plextraktsync.commands.sync import sync
@@ -102,6 +101,14 @@ def inspect():
     Inspect details of an object
     """
 
+    pass
+
+
+@command()
+def login():
+    """
+    Log in to Plex and Trakt if needed
+    """
     pass
 
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import click
 
 from plextraktsync.commands.cache import cache
@@ -11,6 +12,27 @@ from plextraktsync.commands.sync import sync
 from plextraktsync.commands.trakt_login import trakt_login
 from plextraktsync.commands.unmatched import unmatched
 from plextraktsync.commands.watch import watch
+
+
+def command():
+    """
+    Wrapper to lazy load commands when commands being executed only
+    """
+
+    def decorator(fn):
+        @click.command()
+        @wraps(fn)
+        def wrap(*args, **kwargs):
+            import importlib
+
+            name = fn.__name__
+            module = importlib.import_module(f'.commands.{name}', package=__package__)
+            cmd = getattr(module, name)
+            cmd(*args, **kwargs)
+
+        return wrap
+
+    return decorator
 
 
 @click.group(invoke_without_command=True)

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import click
 
-from plextraktsync.commands.info import info
 from plextraktsync.commands.inspect import inspect
 from plextraktsync.commands.login import login
 from plextraktsync.commands.plex_login import plex_login
@@ -76,6 +75,15 @@ def cache():
 def clear_collections():
     """
     Clear Movies and Shows collections in Trakt
+    """
+
+    pass
+
+
+@command()
+def info():
+    """
+    Print application and environment version info
     """
 
     pass

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,12 +1,16 @@
 from functools import wraps
+from os import environ
+
 import click
 
-from plextraktsync.commands.plex_login import plex_login
 from plextraktsync.commands.self_update import enable_self_update, self_update
 from plextraktsync.commands.sync import sync
 from plextraktsync.commands.trakt_login import trakt_login
 from plextraktsync.commands.unmatched import unmatched
 from plextraktsync.commands.watch import watch
+from plextraktsync.factory import factory
+
+CONFIG = factory.config()
 
 
 def command():
@@ -108,6 +112,16 @@ def inspect():
 def login():
     """
     Log in to Plex and Trakt if needed
+    """
+    pass
+
+
+@command()
+@click.option("--username", help="Plex login", default=lambda: environ.get("PLEX_USERNAME", CONFIG["PLEX_USERNAME"]))
+@click.option("--password", help="Plex password", default=lambda: environ.get("PLEX_PASSWORD", None))
+def plex_login():
+    """
+    Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.
     """
     pass
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import click
 
-from plextraktsync.commands.inspect import inspect
 from plextraktsync.commands.login import login
 from plextraktsync.commands.plex_login import plex_login
 from plextraktsync.commands.self_update import enable_self_update, self_update
@@ -84,6 +83,23 @@ def clear_collections():
 def info():
     """
     Print application and environment version info
+    """
+
+    pass
+
+
+@command()
+@click.argument('input', nargs=-1)
+@click.option(
+    "--watched-shows",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Print Trakt watched_shows and exit"
+)
+def inspect():
+    """
+    Inspect details of an object
     """
 
     pass

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -4,7 +4,6 @@ from os import environ
 import click
 
 from plextraktsync.commands.self_update import enable_self_update, self_update
-from plextraktsync.commands.sync import sync
 from plextraktsync.commands.trakt_login import trakt_login
 from plextraktsync.commands.unmatched import unmatched
 from plextraktsync.commands.watch import watch
@@ -122,6 +121,60 @@ def login():
 def plex_login():
     """
     Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.
+    """
+    pass
+
+
+@command()
+@click.option(
+    "--library",
+    help="Specify Library to use"
+)
+@click.option(
+    "--show", "show",
+    type=str,
+    show_default=True, help="Sync specific show only"
+)
+@click.option(
+    "--movie", "movie",
+    type=str,
+    show_default=True, help="Sync specific movie only"
+)
+@click.option(
+    "--id", "ids",
+    type=str,
+    multiple=True,
+    show_default=True, help="Sync specific item only"
+)
+@click.option(
+    "--sync", "sync_option",
+    type=click.Choice(["all", "movies", "tv", "shows"], case_sensitive=False),
+    default="all",
+    show_default=True, help="Specify what to sync"
+)
+@click.option(
+    "--batch-size", "batch_size",
+    type=int,
+    default=1, show_default=True,
+    help="Batch size for collection submit queue"
+)
+@click.option(
+    "--dry-run", "dry_run",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Dry run: Do not make changes"
+)
+@click.option(
+    "--no-progress-bar", "no_progress_bar",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Don't output progress bars"
+)
+def sync():
+    """
+    Perform sync between Plex and Trakt
     """
     pass
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -4,7 +4,6 @@ from os import environ
 import click
 
 from plextraktsync.commands.self_update import enable_self_update, self_update
-from plextraktsync.commands.watch import watch
 from plextraktsync.factory import factory
 
 CONFIG = factory.config()
@@ -206,6 +205,14 @@ def unmatched():
     List media that has no match in Trakt or Plex
     """
 
+    pass
+
+
+@command()
+def watch():
+    """
+    Listen to events from Plex
+    """
     pass
 
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -23,7 +23,13 @@ def command():
             name = fn.__name__
             module = importlib.import_module(f'.commands.{name}', package=__package__)
             cmd = getattr(module, name)
-            cmd(*args, **kwargs)
+
+            try:
+                cmd(*args, **kwargs)
+            except RuntimeError as e:
+                from click import ClickException
+
+                raise ClickException(f"Error running {name} command: {str(e)}")
 
         return wrap
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -4,7 +4,6 @@ from os import environ
 import click
 
 from plextraktsync.commands.self_update import enable_self_update, self_update
-from plextraktsync.commands.trakt_login import trakt_login
 from plextraktsync.commands.unmatched import unmatched
 from plextraktsync.commands.watch import watch
 from plextraktsync.factory import factory
@@ -175,6 +174,14 @@ def plex_login():
 def sync():
     """
     Perform sync between Plex and Trakt
+    """
+    pass
+
+
+@command()
+def trakt_login():
+    """
+    Log in to Trakt Account to obtain Access Token.
     """
     pass
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import click
 
-from plextraktsync.commands.cache import cache
 from plextraktsync.commands.clear_collections import clear_collections
 from plextraktsync.commands.info import info
 from plextraktsync.commands.inspect import inspect
@@ -43,6 +42,33 @@ def cli(ctx):
     """
     if not ctx.invoked_subcommand:
         sync()
+
+
+@command()
+@click.option(
+    "--sort",
+    type=click.Choice(["size", "date", "url"], case_sensitive=False),
+    default="size",
+    show_default=True, help="Sort mode"
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=20,
+    show_default=True, help="Limit entries to be printed"
+)
+@click.option(
+    "--reverse",
+    is_flag=True,
+    default=False,
+    help="Sort reverse"
+)
+@click.argument("url", required=False)
+def cache():
+    """
+    Manage and analyze Requests Cache.
+    """
+    pass
 
 
 cli.add_command(cache)

--- a/plextraktsync/commands/cache.py
+++ b/plextraktsync/commands/cache.py
@@ -70,31 +70,7 @@ def inspect_url(session: CachedSession, url: str):
             print(m.content)
 
 
-@click.command()
-@click.option(
-    "--sort",
-    type=click.Choice(["size", "date", "url"], case_sensitive=False),
-    default="size",
-    show_default=True, help="Sort mode"
-)
-@click.option(
-    "--limit",
-    type=int,
-    default=20,
-    show_default=True, help="Limit entries to be printed"
-)
-@click.option(
-    "--reverse",
-    is_flag=True,
-    default=False,
-    help="Sort reverse"
-)
-@click.argument("url", required=False)
 def cache(sort: str, limit: int, reverse: bool, url: str):
-    """
-    Manage and analyze Requests Cache.
-    """
-
     config = factory.config()
     trakt_cache = config["cache"]["path"]
     session = CachedSession(cache_name=trakt_cache, backend='sqlite')

--- a/plextraktsync/commands/clear_collections.py
+++ b/plextraktsync/commands/clear_collections.py
@@ -4,14 +4,7 @@ from plextraktsync.factory import factory
 from plextraktsync.logging import logger
 
 
-@click.command()
-@click.option('--confirm', is_flag=True, help='Confirm the dangerous action')
-@click.option('--dry-run', is_flag=True, help='Do not perform delete actions')
 def clear_collections(confirm, dry_run):
-    """
-    Clear Movies and Shows collections in Trakt
-    """
-
     if not confirm and not dry_run:
         click.echo('You need to pass --confirm or --dry-run option to proceed')
         return

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -1,6 +1,5 @@
 import sys
 
-import click
 from plexapi import VERSION as PLEX_API_VERSION
 from trakt import __version__ as TRAKT_API_VERSION
 
@@ -10,12 +9,7 @@ from plextraktsync.path import cache_dir, config_dir, log_dir
 from plextraktsync.version import version as get_version
 
 
-@click.command()
 def info():
-    """
-    Print application and environment version info
-    """
-
     print(f"PlexTraktSync Version: {get_version()}")
 
     py_version = sys.version.replace("\n", "")

--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -1,5 +1,3 @@
-import click
-
 from plextraktsync.factory import factory
 from plextraktsync.version import version
 
@@ -82,20 +80,7 @@ def inspect_media(id):
         print(f"- {h.viewedAt} by {h.account.name} on {h.device.name} with {h.device.platform}")
 
 
-@click.command()
-@click.argument('input', nargs=-1)
-@click.option(
-    "--watched-shows",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Print Trakt watched_shows and exit"
-)
 def inspect(input, watched_shows: bool):
-    """
-    Inspect details of an object
-    """
-
     print(f"PlexTraktSync [{version()}]")
 
     if watched_shows:

--- a/plextraktsync/commands/login.py
+++ b/plextraktsync/commands/login.py
@@ -4,7 +4,7 @@ from plextraktsync.commands.plex_login import (has_plex_token,
                                                plex_login_autoconfig)
 from plextraktsync.commands.trakt_login import (has_trakt_token,
                                                 trakt_login_autoconfig)
-from plextraktsync.style import comment, highlight, success
+from plextraktsync.style import highlight, success
 
 
 def ensure_login():
@@ -15,12 +15,7 @@ def ensure_login():
         trakt_login_autoconfig()
 
 
-@click.command()
 def login():
-    """
-    Log in to Plex and Trakt if needed
-    """
-
     click.echo(highlight("Checking Plex and Trakt logins"))
     ensure_login()
     click.echo(success("Success!"))

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -6,7 +6,8 @@ from subprocess import check_output
 from typing import List
 
 import click
-from click import Choice, ClickException
+from click import ClickException
+from InquirerPy import get_style, inquirer
 from plexapi.exceptions import NotFound, Unauthorized
 from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
 from plexapi.server import PlexServer
@@ -25,7 +26,6 @@ NOTICE_2FA_PASSWORD = comment(
 )
 CONFIG = factory.config()
 
-from InquirerPy import get_style, inquirer
 
 style = get_style({"questionmark": "hidden", "question": "ansiyellow", "pointer": "fg:ansiblack bg:ansiyellow", })
 
@@ -49,7 +49,8 @@ def choose_managed_user(account: MyPlexAccount):
     click.echo(success("Managed user(s) found:"))
     users = sorted(users)
     users.insert(0, account.username)
-    user = inquirer.select(message="Select the user you would like to use:", choices=users, default=None, style=style, qmark="", pointer=">",).execute()
+    user = inquirer.select(message="Select the user you would like to use:", choices=users, default=None, style=style,
+                           qmark="", pointer=">", ).execute()
 
     if user == account.username:
         return None
@@ -73,7 +74,8 @@ def prompt_server(servers: List[MyPlexResource]):
 
         product = decorator(f"{s.product}/{s.productVersion}")
         platform = decorator(f"{s.device}: {s.platform}/{s.platformVersion}")
-        click.echo(f"- {highlight(s.name)}: [Last seen: {decorator(str(s.lastSeenAt))}, Server: {product} on {platform}]")
+        click.echo(
+            f"- {highlight(s.name)}: [Last seen: {decorator(str(s.lastSeenAt))}, Server: {product} on {platform}]")
         c: ResourceConnection
         for c in s.connections:
             click.echo(f"    {c.uri}")
@@ -94,7 +96,9 @@ def prompt_server(servers: List[MyPlexResource]):
             fmt_server(s)
             server_names.append(s.name)
 
-    return inquirer.select(message="Select default server:", choices=sorted(server_names), default=None, style=style, qmark="", pointer=">",).execute()
+    return inquirer.select(message="Select default server:", choices=sorted(server_names), default=None, style=style,
+                           qmark="", pointer=">", ).execute()
+
 
 def pick_server(account: MyPlexAccount):
     servers = account.resources()
@@ -144,14 +148,7 @@ def plex_login_autoconfig():
     login(username, password)
 
 
-@click.command("plex-login")
-@click.option("--username", help="Plex login", default=lambda: environ.get("PLEX_USERNAME", CONFIG["PLEX_USERNAME"]))
-@click.option("--password", help="Plex password", default=lambda: environ.get("PLEX_PASSWORD", None))
 def plex_login(username, password):
-    """
-    Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.
-    """
-
     login(username, password)
 
 

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -11,53 +11,6 @@ from plextraktsync.logging import logger
 from plextraktsync.version import version
 
 
-@click.command()
-@click.option(
-    "--library",
-    help="Specify Library to use"
-)
-@click.option(
-    "--show", "show",
-    type=str,
-    show_default=True, help="Sync specific show only"
-)
-@click.option(
-    "--movie", "movie",
-    type=str,
-    show_default=True, help="Sync specific movie only"
-)
-@click.option(
-    "--id", "ids",
-    type=str,
-    multiple=True,
-    show_default=True, help="Sync specific item only"
-)
-@click.option(
-    "--sync", "sync_option",
-    type=click.Choice(["all", "movies", "tv", "shows"], case_sensitive=False),
-    default="all",
-    show_default=True, help="Specify what to sync"
-)
-@click.option(
-    "--batch-size", "batch_size",
-    type=int,
-    default=1, show_default=True,
-    help="Batch size for collection submit queue"
-)
-@click.option(
-    "--dry-run", "dry_run",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Dry run: Do not make changes"
-)
-@click.option(
-    "--no-progress-bar", "no_progress_bar",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Don't output progress bars"
-)
 def sync(
         sync_option: str,
         library: str,

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import click
-from click import ClickException
 from tqdm import tqdm
 
 from plextraktsync.commands.login import ensure_login
@@ -49,17 +48,11 @@ def sync(
         click.echo("Nothing to sync, this is likely due conflicting options given.")
         return
 
-    try:
-        w.print_plan(print=tqdm.write)
-    except RuntimeError as e:
-        raise ClickException(str(e))
+    w.print_plan(print=tqdm.write)
 
     if dry_run:
         print("Enabled dry-run mode: not making actual changes")
 
     with measure_time("Completed full sync"):
-        try:
-            runner = factory.sync()
-            runner.sync(walker=w, dry_run=config.dry_run)
-        except RuntimeError as e:
-            raise ClickException(str(e))
+        runner = factory.sync()
+        runner.sync(walker=w, dry_run=config.dry_run)

--- a/plextraktsync/commands/trakt_login.py
+++ b/plextraktsync/commands/trakt_login.py
@@ -52,7 +52,6 @@ def trakt_login_autoconfig():
     login()
 
 
-@click.command()
 def trakt_login():
     """
     Log in to Trakt Account to obtain Access Token.

--- a/plextraktsync/commands/unmatched.py
+++ b/plextraktsync/commands/unmatched.py
@@ -5,26 +5,7 @@ from plextraktsync.factory import factory
 from plextraktsync.walker import WalkConfig, Walker
 
 
-@click.option(
-    "--no-progress-bar", "no_progress_bar",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Don't output progress bars"
-)
-@click.option(
-    "--local",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Show only local files (no match in Plex)"
-)
-@click.command()
 def unmatched(no_progress_bar: bool, local: bool):
-    """
-    List media that has no match in Trakt or Plex
-    """
-
     config = factory.run_config().update(progressbar=not no_progress_bar)
     ensure_login()
     plex = factory.plex_api()

--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -1,5 +1,3 @@
-import click
-
 from plextraktsync.config import Config
 from plextraktsync.events import (ActivityNotification, Error,
                                   PlaySessionStateNotification, TimelineEntry)
@@ -85,7 +83,8 @@ class WatchStateUpdater:
         m = self.find_by_key(activity.key, reload=True)
         if not m:
             return
-        self.logger.info(f"Activity: {m}: Collected: {m.is_collected}, Watched: [Plex: {m.watched_on_plex}, Trakt: {m.watched_on_trakt}]")
+        self.logger.info(
+            f"Activity: {m}: Collected: {m.is_collected}, Watched: [Plex: {m.watched_on_plex}, Trakt: {m.watched_on_trakt}]")
 
         if self.add_collection and not m.is_collected:
             self.logger.info(f"Add to collection: {m}")
@@ -139,12 +138,7 @@ class WatchStateUpdater:
             del self.sessions[event.session_key]
 
 
-@click.command()
 def watch():
-    """
-    Listen to events from Plex
-    """
-
     server = factory.plex_server()
     trakt = factory.trakt_api()
     plex = factory.plex_api()


### PR DESCRIPTION
This prevents all commands being imported just to figure out their usage.

This has minor speedup for setting up the application due not importing commands that aren't executed in the current run.