### PR TITLE
Fix: Disable username filter if no permission

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -50,7 +50,11 @@ class WatchStateUpdater:
         self.remove_collection = config["watch"]["remove_collection"]
         self.add_collection = config["watch"]["add_collection"]
         if config["watch"]["username_filter"]:
-            self.username_filter = config["PLEX_USERNAME"]
+            if not self.plex.has_sessions():
+                self.logger.warning('No permission to access sessions, disabling username filter')
+                self.username_filter = None
+            else:
+                self.username_filter = config["PLEX_USERNAME"]
         else:
             self.username_filter = None
         self.sessions = SessionCollection(plex)

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -574,5 +574,13 @@ class PlexApi:
         m.markWatched()
 
     @nocache
+    def has_sessions(self):
+        try:
+            self.plex.sessions()
+            return True
+        except Unauthorized:
+            return False
+
+    @nocache
     def get_sessions(self):
         return self.plex.sessions()


### PR DESCRIPTION
If pulling server without admin access the `/sessions` request gives a forbidden error. This changes to detect such scenario and disabling username filter.