### PR TITLE
Add retry to plex.rate method to overcome timeout error

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -537,6 +537,7 @@ class PlexApi:
         return PlexRatingCollection(self)
 
     @nocache
+    @rate_limit()
     def rate(self, m, rating):
         m.rate(rating)
 


### PR DESCRIPTION
Some mitigation to https://github.com/Taxel/PlexTraktSync/issues/742

Closes #742