### PR TITLE
[watch] Mark as watched on Plex if above scrobble threshold

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -121,7 +121,7 @@ class WatchStateUpdater:
         movie = m.plex.item
         percent = m.plex.watch_progress(event.view_offset)
         
-        if percent >= self.scrobblers.threshold:
+        if percent >= self.threshold:
             m.mark_watched_plex()
 
         self.logger.info(f"{movie}: {percent:.6F}% Watched: {movie.isWatched}, LastViewed: {movie.lastViewedAt}")

--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -120,6 +120,9 @@ class WatchStateUpdater:
 
         movie = m.plex.item
         percent = m.plex.watch_progress(event.view_offset)
+        
+        if percent >= self.scrobblers.threshold:
+            m.mark_watched_plex()
 
         self.logger.info(f"{movie}: {percent:.6F}% Watched: {movie.isWatched}, LastViewed: {movie.lastViewedAt}")
         self.scrobble(m, percent, event)


### PR DESCRIPTION
Mark as watched on Plex when going over the percentage treshold.
This will also mark it as watched on Trakt automatically.

I think the default treshold should be higher than 80 though. 
Most of the episodes has short end credits, I think 90 or even 95 should be better for episodes.
80 should be helpfull for movies because of the long end credits.