### PR TITLE
Fix:  Use is_watched from plex item

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -93,7 +93,7 @@ class Media:
 
     @property
     def watched_on_plex(self):
-        return self.plex.item.isWatched
+        return self.plex.is_watched
 
     @property
     def watched_on_trakt(self):

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -200,6 +200,11 @@ class PlexLibraryItem:
         return self.date_value(self.item.lastViewedAt)
 
     @property
+    @nocache
+    def is_watched(self):
+        return self.item.isWatched
+
+    @property
     def collected_at(self):
         return self.date_value(self.item.addedAt)
 


### PR DESCRIPTION
The plex item is decorated with nocache, so the call won't be cached.