### PR TITLE
Feature:   Allow inspect to take full urls as input

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -1,5 +1,6 @@
 from plextraktsync.factory import factory
 from plextraktsync.version import version
+from urllib.parse import urlparse, parse_qs
 
 
 def print_watched_shows():
@@ -78,6 +79,21 @@ def inspect_media(id):
     print("Plex play history:")
     for h in m.plex_history(device=True, account=True):
         print(f"- {h.viewedAt} by {h.account.name} on {h.device.name} with {h.device.platform}")
+
+
+def id_from_url(url: str):
+    """
+    Extracts id from urls like:
+      https://app.plex.tv/desktop/#!/server/abcdefg/details?key=%2Flibrary%2Fmetadata%2F13202
+    """
+    result = urlparse(url)
+    if result.fragment[0] == '!':
+        parsed = parse_qs(urlparse(result.fragment).query)
+        key = ','.join(parsed['key'])
+        if key.startswith('/library/metadata/'):
+            return int(key[len('/library/metadata/'):])
+
+    return url
 
 
 def inspect(input, watched_shows: bool):

--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -106,4 +106,6 @@ def inspect(input, watched_shows: bool):
     for id in input:
         if id.isnumeric():
             id = int(id)
+        elif id.startswith('https:') or id.startswith('http:'):
+            id = id_from_url(id)
         inspect_media(id)


### PR DESCRIPTION
Allow to use full urls like this:

```sh
$ plextraktsync inspect https://app.plex.tv/desktop/#!/server/abcdefg/details?key=%2Flibrary%2Fmetadata%2F13202
```

Selecting just the numeric part after `%2F` is rather tricky as double click on the number selects also `2F` i.e: `2F13202`