### PR TITLE
Fix: pass progress from plex when calling scrobble api

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -132,7 +132,8 @@ class WatchStateUpdater:
         percent = m.plex.watch_progress(event.view_offset)
 
         self.logger.info(f"on_play: {movie}: {percent:.6F}% Watched: {movie.isWatched}, LastViewed: {movie.lastViewedAt}")
-        self.scrobble(m, percent, event)
+        scrobbled = self.scrobble(m, percent, event)
+        self.logger.debug(f"Scrobbled: {scrobbled}")
 
     def can_scrobble(self, event: PlaySessionStateNotification):
         if not self.username_filter:

--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -151,9 +151,10 @@ class WatchStateUpdater:
             return self.scrobblers[tm].pause(percent)
 
         if state == "stopped":
-            self.scrobblers[tm].stop(percent)
+            value = self.scrobblers[tm].stop(percent)
             del self.scrobblers[tm]
             del self.sessions[event.session_key]
+            return value
 
 
 def watch():

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -64,8 +64,13 @@ class ScrobblerProxy:
 
     # Copied method, until upstream is merged
     # https://github.com/moogar0880/PyTrakt/pull/196
+    @nocache
+    @rate_limit()
+    @time_limit()
     @post
-    def _post(self, uri):
+    def _post(self, method: str, progress: float):
+        self.scrobbler.progress = progress
+        uri = f'scrobble/{method}'
         payload = dict(
             progress=self.scrobbler.progress,
             app_version=self.scrobbler.version,

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -34,33 +34,21 @@ class ScrobblerProxy:
         self.threshold = threshold
         self.logger = logging.getLogger("PlexTraktSync.ScrobblerProxy")
 
-    @nocache
-    @rate_limit()
-    @time_limit()
     def update(self, progress: float):
         self.logger.debug(f'update({self.scrobbler.media}): {progress}')
-        return self.scrobbler.update(progress)
+        return self._post('start', progress)
 
-    @nocache
-    @rate_limit()
-    @time_limit()
     def pause(self, progress: float):
         self.logger.debug(f'pause({self.scrobbler.media}): {progress}')
-        self.scrobbler.progress = progress
-        return self.scrobbler.pause()
+        return self._post('pause', progress)
 
-    @nocache
-    @rate_limit()
-    @time_limit()
     def stop(self, progress: float):
         if progress >= self.threshold:
             self.logger.debug(f'stop({self.scrobbler.media}): {progress}')
-            self.scrobbler.progress = progress
-            return self.scrobbler.stop()
+            return self._post('stop', progress)
         else:
             self.logger.debug(f'pause({self.scrobbler.media}): {progress}')
-            self.scrobbler.progress = progress
-            return self.scrobbler.pause()
+            return self._post('pause', progress)
 
     # Copied method, until upstream is merged
     # https://github.com/moogar0880/PyTrakt/pull/196

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -38,7 +38,7 @@ class ScrobblerProxy:
     @time_limit()
     def update(self, progress: float):
         self.logger.debug(f'update({self.scrobbler.media}): {progress}')
-        self.scrobbler.update(progress)
+        return self.scrobbler.update(progress)
 
     @nocache
     @rate_limit()
@@ -46,7 +46,7 @@ class ScrobblerProxy:
     def pause(self, progress: float):
         self.logger.debug(f'pause({self.scrobbler.media}): {progress}')
         self.scrobbler.progress = progress
-        self.scrobbler.pause()
+        return self.scrobbler.pause()
 
     @nocache
     @rate_limit()
@@ -55,11 +55,11 @@ class ScrobblerProxy:
         if progress >= self.threshold:
             self.logger.debug(f'stop({self.scrobbler.media}): {progress}')
             self.scrobbler.progress = progress
-            self.scrobbler.stop()
+            return self.scrobbler.stop()
         else:
             self.logger.debug(f'pause({self.scrobbler.media}): {progress}')
             self.scrobbler.progress = progress
-            self.scrobbler.pause()
+            return self.scrobbler.pause()
 
 
 class TraktRatingCollection(dict):

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -6,6 +6,7 @@ import trakt
 import trakt.movies
 import trakt.sync
 import trakt.users
+from trakt import post
 from trakt.errors import ForbiddenException, OAuthException
 from trakt.movies import Movie
 from trakt.sync import Scrobbler
@@ -60,6 +61,19 @@ class ScrobblerProxy:
             self.logger.debug(f'pause({self.scrobbler.media}): {progress}')
             self.scrobbler.progress = progress
             return self.scrobbler.pause()
+
+    # Copied method, until upstream is merged
+    # https://github.com/moogar0880/PyTrakt/pull/196
+    @post
+    def _post(self, uri):
+        payload = dict(
+            progress=self.scrobbler.progress,
+            app_version=self.scrobbler.version,
+            date=self.scrobbler.date
+        )
+        payload.update(self.scrobbler.media.to_json_singular())
+        response = yield uri, payload
+        yield response
 
 
 class TraktRatingCollection(dict):


### PR DESCRIPTION
Pass fresh progress value before calling stop/pause instead of previous value from update.

Probably fixes https://github.com/Taxel/PlexTraktSync/issues/758 and https://github.com/Taxel/PlexTraktSync/issues/766

This also improves logging, example:

```
2022-01-31 00:09:10,540 DEBUG[PlexTraktSync.WatchStateUpdater]:Scrobbled: {'id': 0, 'action': 'start', 'progress': 0.0, 'sharing': {'facebook': False, 'twitter': False, 'tumblr': False}, 'episode': {'season': 2, 'number': 4, ...
2022-01-31 00:09:16,294 DEBUG[PlexTraktSync.WatchStateUpdater]:Scrobbled: {'id': 0, 'action': 'pause', 'progress': 0.0, 'sharing': {'facebook': False, 'twitter': False, 'tumblr': False}, 'episode': {'season': 2, 'number': 4, ...
```

Requires:
- https://github.com/moogar0880/PyTrakt/pull/196

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/758#issuecomment-1025189681