### PR TITLE
Cleanup: Drop Python 3.7 support (EOL)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   flake8-lint:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ on:
       - '*.*.*'
 
 env:
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   pypi:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   test:

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 
 [packages]
 attrs = "==23.1.0"
-"backports.cached-property" = {version="==1.0.2", python_version="<='3.7'"}
 cattrs = {version="==23.1.2", python_version=">='3.7'"}
 certifi = "==2023.7.22"
 charset-normalizer = "==3.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "532294a487c2992f0288a4b85dd5f38ef99efca6f6cbbe525f75d6ef7f7aabc4"
+            "sha256": "28d0d877b259798c9378094eb3002f9d8b1f7b9191c91ce5eee8402a8ba15735"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,14 +23,6 @@
             ],
             "index": "pypi",
             "version": "==23.1.0"
-        },
-        "backports.cached-property": {
-            "hashes": [
-                "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd",
-                "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"
-            ],
-            "markers": "python_version <= '3.7'",
-            "version": "==1.0.2"
         },
         "cattrs": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ have a file containing those on your harddrive, you can not use this project.
   - [Good practices](#good-practices)
   - [Troubleshooting](#troubleshooting)
 
-[python-versions-badge]: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue
+[python-versions-badge]: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue
 
 ## Features
 
@@ -69,7 +69,7 @@ have a file containing those on your harddrive, you can not use this project.
 
 ## Pre-requisites
 
-The script is known to work with Python 3.7-3.11 versions.
+The script is known to work with Python 3.8-3.11 versions.
 
 ## Installation
 

--- a/plextraktsync/commands/imdb_import.py
+++ b/plextraktsync/commands/imdb_import.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import factory
 
 if TYPE_CHECKING:

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
-
-from plextraktsync.decorators.cached_property import cached_property
 
 if TYPE_CHECKING:
     from plextraktsync.config.Config import Config

--- a/plextraktsync/decorators/cached_property.py
+++ b/plextraktsync/decorators/cached_property.py
@@ -1,4 +1,0 @@
-try:
-    from functools import cached_property
-except ImportError:
-    from backports.cached_property import cached_property  # noqa: F401

--- a/plextraktsync/logger/filter.py
+++ b/plextraktsync/logger/filter.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 from logging import Filter
 from typing import TYPE_CHECKING
-
-from plextraktsync.decorators.cached_property import cached_property
 
 if TYPE_CHECKING:
     from logging import Logger, LogRecord

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plexapi.exceptions import PlexApiException
 from requests import RequestException
 from trakt.errors import TraktException
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import logger
 from plextraktsync.trakt.TraktLookup import TraktLookup
 from rich.markup import escape

--- a/plextraktsync/mixin/SetWindowTitle.py
+++ b/plextraktsync/mixin/SetWindowTitle.py
@@ -1,4 +1,4 @@
-from plextraktsync.decorators.cached_property import cached_property
+from functools import cached_property
 
 
 class SetWindowTitle:

--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import plexapi
@@ -9,7 +10,6 @@ from plexapi.myplex import MyPlexAccount
 from plexapi.playlist import Playlist
 from plexapi.server import PlexServer, SystemAccount, SystemDevice
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_dict, flatten_list
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.retry import retry

--- a/plextraktsync/plex/PlexAudioCodec.py
+++ b/plextraktsync/plex/PlexAudioCodec.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import re
-
-from plextraktsync.decorators.cached_property import cached_property
+from functools import cached_property
 
 
 class PlexAudioCodec:

--- a/plextraktsync/plex/PlexGuid.py
+++ b/plextraktsync/plex/PlexGuid.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import factory
 
 if TYPE_CHECKING:

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import datetime
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from trakt.utils import timestamp
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.retry import retry
 from plextraktsync.factory import factory
 from plextraktsync.plex.PlexGuid import PlexGuid

--- a/plextraktsync/plex/PlexWatchList.py
+++ b/plextraktsync/plex/PlexWatchList.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_set
 
 if TYPE_CHECKING:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.factory import logger
 from plextraktsync.trakt.types import TraktMedia

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import trakt
@@ -10,7 +11,6 @@ from click import ClickException
 from trakt.errors import ForbiddenException, OAuthException
 
 from plextraktsync import pytrakt_extensions
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_list
 from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.decorators.retry import retry

--- a/plextraktsync/trakt/TraktItem.py
+++ b/plextraktsync/trakt/TraktItem.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
-
-from plextraktsync.decorators.cached_property import cached_property
 
 if TYPE_CHECKING:
     from plextraktsync.trakt.TraktApi import TraktApi

--- a/plextraktsync/trakt/TraktLookup.py
+++ b/plextraktsync/trakt/TraktLookup.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.retry import retry
 from plextraktsync.factory import logger
 

--- a/plextraktsync/trakt/TraktWatchlist.py
+++ b/plextraktsync/trakt/TraktWatchlist.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_dict
 
 if TYPE_CHECKING:

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from plextraktsync.decorators.cached_property import cached_property
+from functools import cached_property
 
 
 class Factory:

--- a/plextraktsync/util/Path.py
+++ b/plextraktsync/util/Path.py
@@ -1,7 +1,6 @@
+from functools import cached_property
 from os import getenv, makedirs
 from os.path import abspath, dirname, exists, join
-
-from plextraktsync.decorators.cached_property import cached_property
 
 
 class Path:

--- a/plextraktsync/util/Version.py
+++ b/plextraktsync/util/Version.py
@@ -1,4 +1,4 @@
-from plextraktsync.decorators.cached_property import cached_property
+from functools import cached_property
 
 
 class Version:

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from functools import cached_property
 from typing import TYPE_CHECKING, NamedTuple
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.mixin.SetWindowTitle import SetWindowTitle
 from plextraktsync.plex.PlexGuid import PlexGuid

--- a/plextraktsync/watch/ProgressBar.py
+++ b/plextraktsync/watch/ProgressBar.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import factory
 
 if TYPE_CHECKING:

--- a/plextraktsync/watch/WatchStateUpdater.py
+++ b/plextraktsync/watch/WatchStateUpdater.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import logging
 from plextraktsync.watch.events import (ActivityNotification, Error,
                                         PlaySessionStateNotification,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 
 -i https://pypi.org/simple
 attrs==23.1.0
-backports.cached-property==1.0.2; python_version <= '3.7'
 cattrs==23.1.2; python_version >= '3.7'
 certifi==2023.7.22
 charset-normalizer==3.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     # https://endoflife.date/python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ packages =
     plextraktsync.trakt
     plextraktsync.util
     plextraktsync.watch
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 
 [options.packages.find]


### PR DESCRIPTION
Not to be merged before 27 Jun 2023:
- https://endoflife.date/python



Version | Released | Security Support | Release
-- | -- | -- | --
3.7 | 3 years and 7 months ago(27 Jun 2018) | Ends in 1 year and 4 months(27 Jun 2023) | 3.7.12

