### PR TITLE
Fix: Do not cache ratings fetch

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -414,6 +414,7 @@ class PlexLibrarySection:
         except NotFound:
             return None
 
+    @nocache
     def find_with_rating(self):
         filters = {
             'and': [


### PR DESCRIPTION
Fixes #778, a bug from https://github.com/Taxel/PlexTraktSync/pull/668