### PR TITLE
Rename Plex variable fallbackurl to localurl

### DIFF
--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -228,9 +228,9 @@ def login(username: str, password: str):
                 )
             except Exception:
                 host_ip = "172.17.0.1"
-        CONFIG["PLEX_FALLBACKURL"] = f"http://{host_ip}:32400"
+        CONFIG["PLEX_LOCALURL"] = f"http://{host_ip}:32400"
     else:
-        CONFIG["PLEX_FALLBACKURL"] = "http://localhost:32400"
+        CONFIG["PLEX_LOCALURL"] = "http://localhost:32400"
     CONFIG.save()
 
     click.echo(SUCCESS_MESSAGE)

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -39,7 +39,8 @@ class RunConfig:
 class Config(dict):
     env_keys = [
         "PLEX_BASEURL",
-        "PLEX_FALLBACKURL",
+        "PLEX_FALLBACKURL",  # legacy, used before 0.18.21
+        "PLEX_LOCALURL",
         "PLEX_TOKEN",
         "PLEX_USERNAME",
         "TRAKT_USERNAME",
@@ -78,6 +79,10 @@ class Config(dict):
             self[key] = value
 
         self.initialized = True
+
+        if self["PLEX_LOCALURL"] is None:  # old .env file used before 0.18.21
+            self["PLEX_LOCALURL"] = self["PLEX_FALLBACKURL"]
+            self["PLEX_FALLBACKURL"] = None
 
         self["cache"]["path"] = self["cache"]["path"].replace(
             "$PTS_CACHE_DIR", cache_dir

--- a/plextraktsync/plex_server.py
+++ b/plextraktsync/plex_server.py
@@ -23,7 +23,7 @@ def _get_plex_server():
     CONFIG = factory.config()
     plex_token = CONFIG["PLEX_TOKEN"]
     plex_baseurl = CONFIG["PLEX_BASEURL"]
-    plex_fallbackurl = CONFIG["PLEX_FALLBACKURL"]
+    plex_localurl = CONFIG["PLEX_LOCALURL"]
     if plex_token == "-":
         plex_token = ""
     server = None
@@ -37,13 +37,13 @@ def _get_plex_server():
     # if connection fails, it will try :
     # 1. url expected by new ssl certificate
     # 2. url without ssl
-    # 3. fallback url (localhost)
+    # 3. local url (localhost)
 
     try:
         server = PlexServer(token=plex_token, baseurl=plex_baseurl)
     except plexapi.server.requests.exceptions.SSLError as e:
-        m = "Plex connection error: {}, fallback url {} didn't respond either.".format(
-            str(e), plex_fallbackurl
+        m = "Plex connection error: {}, local url {} didn't respond either.".format(
+            str(e), plex_localurl
         )
         excep_msg = str(e.__context__)
         if "doesn't match '*." in excep_msg:
@@ -58,7 +58,7 @@ def _get_plex_server():
                 # save new url to .env
                 CONFIG["PLEX_TOKEN"] = plex_token
                 CONFIG["PLEX_BASEURL"] = new_plex_baseurl
-                CONFIG["PLEX_FALLBACKURL"] = plex_fallbackurl
+                CONFIG["PLEX_LOCALURL"] = plex_localurl
                 CONFIG.save()
                 logger.info("Plex server url changed to {}".format(new_plex_baseurl))
             except Exception:
@@ -73,15 +73,15 @@ def _get_plex_server():
             except Exception:
                 pass
     except Exception as e:
-        m = "Plex connection error: {}, fallback url {} didn't respond either.".format(
-            str(e), plex_fallbackurl
+        m = "Plex connection error: {}, local url {} didn't respond either. Check PLEX_LOCALURL in .env file.".format(
+            str(e), plex_localurl
         )
     if server is None:
         try:  # 3
-            server = PlexServer(token=plex_token, baseurl=plex_fallbackurl)
+            server = PlexServer(token=plex_token, baseurl=plex_localurl)
             logger.warning(
-                "No response from {}, fallback to {}".format(
-                    plex_baseurl, plex_fallbackurl
+                "No response from {}, connection using local url {}".format(
+                    plex_baseurl, plex_localurl
                 )
             )
         except Exception:


### PR DESCRIPTION
In `.env` file, I suggest renaming the variable `PLEX_FALLBACKURL` to `PLEX_LOCALURL` so that **users understand and change this URL by themself** with a specific message in error logs.

______
After that, the local IP address auto-finding will have to be improved for docker users because 172.17.0.x doesn't look useful (see #775 and #816)