### PR TITLE
Feature: Add support to override .env keys from actual environment

### DIFF
--- a/plextraktsync/config.default.json
+++ b/plextraktsync/config.default.json
@@ -4,6 +4,9 @@
         "filename": "plextraktsync.log",
         "append": true
     },
+    "config": {
+        "dotenv_override": true
+    },
     "cache": {
         "path": "$PTS_CACHE_DIR/trakt_cache"
     },

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -70,8 +70,9 @@ class Config(dict):
 
         config = self.load_json(self.config_file)
         self.merge(config, self)
+        override = self["config"]["dotenv_override"]
 
-        load_dotenv(self.env_file)
+        load_dotenv(self.env_file, override=override)
         for key in self.env_keys:
             value = getenv(key)
             if value == "-" or value == "None" or value == "":


### PR DESCRIPTION
Useful when the same `.env` file is used to initialize docker-compose but
want to change the `.env` file value at runtime.

This changes so that values of `.env` are always read even if the environment with the same name is already present.

```json
    "config": {
        "dotenv_override": true
    },
```

See https://github.com/Taxel/PlexTraktSync/discussions/849