### PR TITLE
Reorganize watch command instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To run sync:
 ```
 docker-compose run --rm plextraktsync
 ```
+The container will stop after the sync is completed. Read Setup section to run it automatically at set intervals.
 
 ### Windows Setup (optional alternative)
 

--- a/README.md
+++ b/README.md
@@ -113,22 +113,6 @@ To run sync:
 docker-compose run --rm plextraktsync
 ```
 
-To run `watch` command:
-
-```
-docker-compose run --rm plextraktsync watch
-```
-or add `command: watch` to docker compose file, and `docker-compose up -d plextraktsync` to start the container detached:
-
-```yaml
-services:
-  plextraktsync:
-    image: ghcr.io/taxel/plextraktsync
-    volumes:
-      - ./config:/app/config
-    command: watch
-```
-
 ### Windows Setup (optional alternative)
 
 - Download the latest `.zip` release from https://github.com/Taxel/PlexTraktSync/tags
@@ -283,9 +267,7 @@ Server has 2 libraries: ['Movies', 'TV Shows']
 ### Watch
 
 You can use the `watch` command to listen to events from Plex Media Server
-and scrobble plays.
-
-`plextraktsync watch`
+and scrobble plays. It does NOT run a sync between Plex and Trakt.
 
 > What is scrobbling?
 >
@@ -305,6 +287,26 @@ To restrict scrobbling to your user **only** (recommended), set the following in
     }
 }
 ```
+
+To run `watch` command:
+
+`plextraktsync watch`
+
+or
+```
+docker-compose run --rm plextraktsync watch
+```
+or add `command: watch` to docker compose file, and `docker-compose up -d plextraktsync` to start the container detached:
+
+```yaml
+services:
+  plextraktsync:
+    image: ghcr.io/taxel/plextraktsync
+    volumes:
+      - ./config:/app/config
+    command: watch
+```
+
 
 #### Systemd setup
 


### PR DESCRIPTION
Reorganize instructions about `watch` command.
I move `watch` examples under the Watch section so the explanations of what it does are read first.

Some users run the `watch` command without fully understanding what it does.
Many docker users are concerned because they switch to `watch` to keep the container alive (a stopping container is not usual).

fixes #843 
fixes #860 

