### PR TITLE
Feature: Catch exceptions locally in watch to capture traceback

### DIFF
--- a/plextraktsync/listener.py
+++ b/plextraktsync/listener.py
@@ -36,7 +36,13 @@ class EventDispatcher:
             if not self.match_event(listener, event):
                 continue
 
-            listener["listener"](event)
+            try:
+                listener["listener"](event)
+            except Exception as e:
+                self.logger.error(e)
+
+                import traceback
+                self.logger.debug(traceback.format_tb(e.__traceback__))
 
     @staticmethod
     def match_filter(event, key, match):


### PR DESCRIPTION
Better logging for https://github.com/Taxel/PlexTraktSync/issues/866

The traceback will be logged to debug log:

```
2022-04-03 12:39:58,400 ERROR[PlexTraktSync.EventDispatcher]:'int' object does not support item assignment
2022-04-03 12:39:58,401 DEBUG[PlexTraktSync.EventDispatcher]:['  File "PlexTraktSync/plextraktsync/listener.py", line 41, in dispatch\n    f[2] = 3\n']
```