### PR TITLE
Improve logic of collected items batch (send to trakt every n seconds)

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -158,12 +158,12 @@ def plex_login():
     help="Specify what to sync",
 )
 @click.option(
-    "--batch-size",
-    "batch_size",
+    "--batch-delay",
+    "batch_delay",
     type=int,
-    default=1,
+    default=5,
     show_default=True,
-    help="Batch size for collection submit queue",
+    help="Time in seconds between each collection batch submit to trakt",
 )
 @click.option(
     "--dry-run",

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -16,7 +16,7 @@ def sync(
     show: str,
     movie: str,
     ids: List[str],
-    batch_size: int,
+    batch_delay: int,
     dry_run: bool,
     no_progress_bar: bool,
 ):
@@ -31,7 +31,7 @@ def sync(
     shows = sync_option in ["all", "tv", "shows"]
 
     config = factory.run_config().update(
-        batch_size=batch_size, dry_run=dry_run, progressbar=not no_progress_bar
+        batch_delay=batch_delay, dry_run=dry_run, progressbar=not no_progress_bar
     )
     wc = factory.walk_config().update(movies=movies, shows=shows)
     w = factory.walker()

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -27,7 +27,7 @@ class RunConfig:
     """
 
     dry_run: bool = False
-    batch_size: int = 1
+    batch_delay: int = 5
     progressbar: bool = True
 
     def update(self, **kwargs):

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -10,7 +10,7 @@ class Factory:
         from plextraktsync.trakt_api import TraktApi
 
         config = self.run_config()
-        trakt = TraktApi(batch_size=config.batch_size)
+        trakt = TraktApi(batch_delay=config.batch_delay)
 
         return trakt
 

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -98,7 +98,7 @@ class Sync:
         if m.is_collected:
             return
 
-        logger.info(f"To be added to collection: {m}")
+        logger.info(f"Adding to collection: {m}")
         if not dry_run:
             m.add_to_collection(batch=True)
 

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -68,6 +68,7 @@ class Sync:
             self.sync_ratings(movie, dry_run=dry_run)
             self.sync_watched(movie, dry_run=dry_run)
             listutil.addPlexItemToLists(movie)
+        walker.trakt.batch.flush(force=True)
 
         shows = set()
         for episode in walker.find_episodes():
@@ -78,6 +79,7 @@ class Sync:
             if self.config.sync_ratings:
                 # collect shows for later ratings sync
                 shows.add(episode.show)
+        walker.trakt.batch.flush(force=True)
 
         for show in walker.walk_shows(shows, title="Syncing show ratings"):
             self.sync_ratings(show, dry_run=dry_run)

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -325,7 +325,7 @@ class TraktBatch:
             result = self.trakt_sync_collection(self.collection)
             result = self.remove_empty_values(result.copy())
             if result:
-                logger.info(f"Updated Trakt collection: {result}")
+                logger.debug(f"Updated Trakt collection: {result}")
         finally:
             self.collection.clear()
             self.last_sent_time = time()

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Union
+from time import time
 
 import trakt
 import trakt.movies
@@ -92,8 +93,8 @@ class TraktApi:
     Trakt API class abstracting common data access and dealing with requests cache.
     """
 
-    def __init__(self, batch_size=None):
-        self.batch_size = batch_size
+    def __init__(self, batch_delay=None):
+        self.batch_delay = batch_delay
         trakt.core.CONFIG_PATH = pytrakt_file
         trakt.core.session = factory.session()
 
@@ -105,7 +106,7 @@ class TraktApi:
 
     @cached_property
     def batch(self):
-        return TraktBatch(self, batch_size=self.batch_size)
+        return TraktBatch(self, batch_delay=self.batch_delay)
 
     @cached_property
     @nocache
@@ -307,10 +308,11 @@ class TraktApi:
 
 
 class TraktBatch:
-    def __init__(self, trakt: TraktApi, batch_size=None):
+    def __init__(self, trakt: TraktApi, batch_delay=None):
         self.trakt = trakt
-        self.batch_size = batch_size
+        self.batch_delay = batch_delay
         self.collection = {}
+        self.last_sent_time = 0
 
     @nocache
     @rate_limit()
@@ -334,15 +336,16 @@ class TraktBatch:
 
         return size
 
-    def flush(self):
+    def flush(self, force=False):
         """
-        Flush the queue if it's bigger than batch_size
+        Flush the queue every batch_delay seconds
         """
-        if not self.batch_size:
+        if not self.batch_delay and force is False:
             return
-
-        if self.queue_size() >= self.batch_size:
+        elapsed = time() - self.last_sent_time
+        if elapsed >= self.batch_delay or force is True:
             self.submit_collection()
+            self.last_sent_time = time()
 
     def add_to_collection(self, media_type: str, item):
         """

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -328,6 +328,7 @@ class TraktBatch:
                 logger.info(f"Updated Trakt collection: {result}")
         finally:
             self.collection.clear()
+            self.last_sent_time = time()
 
     def queue_size(self):
         size = 0
@@ -345,7 +346,6 @@ class TraktBatch:
         elapsed = time() - self.last_sent_time
         if elapsed >= self.batch_delay or force is True:
             self.submit_collection()
-            self.last_sent_time = time()
 
     def add_to_collection(self, media_type: str, item):
         """

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -27,7 +27,7 @@ def test_batch_size_none():
 
 def test_batch_size_1():
     response = load_mock("trakt_sync_collection_response.json")
-    b = TraktBatch(trakt, batch_size=1)
+    b = TraktBatch(trakt, batch_delay=1)
     b.trakt_sync_collection = Mock(return_value=response)
 
     assert b.queue_size() == 0


### PR DESCRIPTION
This PR changes the logic of batch sending of Plex collected items. The script now sends collected items to trakt based on **time interval** instead of **batch size**.
`--batch-delay`  (in seconds) is used instead of `--batch-size` option. Default is 5 seconds.


Logic is that collected items are sent every n seconds.
It reduces trakt number of requests for huge Plex libraries having many new items. Sync time should be reduced too.

⚠️ Only tested on a small library, please anyone test on big library and give feedback.

One annoying detail is the last `flush(force=True)` is displayed _after_ the message `INFO: Section processed in x seconds`
I don't understand why this last `flush()` was not implemented with the batch-size version because it is needed to finish the job if the last batch is not sent.

```
INFO: Rating <tmdb:749673:<Episode:4352:Detective-Conan-s01e04>> with 4 on Plex
INFO: To be added to collection: <tmdb:749674:<Episode:4353:Detective-Conan-s01e05>>
INFO: Rating <tmdb:749674:<Episode:4353:Detective-Conan-s01e05>> with 8 on Plex
INFO: To be added to collection: <tmdb:749675:<Episode:4354:Detective-Conan-s01e06>>
INFO: To be added to collection: <tmdb:749676:<Episode:4355:Detective-Conan-s01e07>>
INFO: To be added to collection: <tmdb:749677:<Episode:4356:Detective-Conan-s01e08>>
INFO: To be added to collection: <tmdb:749678:<Episode:4357:Detective-Conan-s01e09>>
INFO: To be added to collection: <tmdb:749679:<Episode:4358:Detective-Conan-s01e10>>
INFO: Updated Trakt collection: {'added': {'episodes': 9}}
INFO: To be added to collection: <tmdb:749680:<Episode:4359:Detective-Conan-s01e11>>
INFO: To be added to collection: <tmdb:749681:<Episode:4360:Detective-Conan-s01e12>>
INFO: To be added to collection: <tmdb:749682:<Episode:4361:Detective-Conan-s01e13>>
INFO: To be added to collection: <tmdb:749683:<Episode:4362:Detective-Conan-s01e14>>
INFO: To be added to collection: <tmdb:749684:<Episode:4363:Detective-Conan-s01e15>>
INFO: To be added to collection: <tmdb:749685:<Episode:4364:Detective-Conan-s01e16>>
INFO: To be added to collection: <tmdb:749686:<Episode:4365:Detective-Conan-s01e17>>
INFO: To be added to collection: <tmdb:749687:<Episode:4366:Detective-Conan-s01e18>>
INFO: To be added to collection: <tmdb:749688:<Episode:4367:Detective-Conan-s01e19>>
INFO: To be added to collection: <tmdb:749689:<Episode:4368:Detective-Conan-s01e20>>
INFO: To be added to collection: <tmdb:749690:<Episode:4369:Detective-Conan-s01e21>>
INFO: To be added to collection: <tmdb:749691:<Episode:4370:Detective-Conan-s01e22>>
INFO: To be added to collection: <tmdb:749692:<Episode:4371:Detective-Conan-s01e23>>
INFO: To be added to collection: <tmdb:749693:<Episode:4372:Detective-Conan-s01e24>>
INFO: To be added to collection: <tmdb:749694:<Episode:4373:Detective-Conan-s01e25>>
INFO: To be added to collection: <tmdb:749695:<Episode:4374:Detective-Conan-s01e26>>
INFO: To be added to collection: <tmdb:749696:<Episode:4375:Detective-Conan-s01e27>>
INFO: To be added to collection: <tmdb:749697:<Episode:4376:Detective-Conan-s01e28>>
INFO: To be added to collection: <tmdb:1257985:<Episode:4625:Ozark-s01e01>>
INFO: Updated Trakt collection: {'added': {'episodes': 19}}
INFO: To be added to collection: <tmdb:1339580:<Episode:4626:Ozark-s01e02>>
INFO: To be added to collection: <tmdb:1339581:<Episode:4627:Ozark-s01e03>>
INFO: To be added to collection: <tmdb:1339582:<Episode:4628:Ozark-s01e04>>
INFO: To be added to collection: <tmdb:1339583:<Episode:4629:Ozark-s01e05>>
INFO: To be added to collection: <tmdb:1339584:<Episode:4630:Ozark-s01e06>>
INFO: To be added to collection: <tmdb:1339585:<Episode:4631:Ozark-s01e07>>
INFO: To be added to collection: <tmdb:1339586:<Episode:4632:Ozark-s01e08>>
INFO: To be added to collection: <tmdb:1339587:<Episode:4633:Ozark-s01e09>>
INFO: To be added to collection: <tmdb:1339588:<Episode:4634:Ozark-s01e10>>
Processing TV Shows 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 19/19  [ 0:00:32 < 0:00:00 , 1 it/s ]
INFO: TV Shows processed in 32.6 seconds
INFO: Updated Trakt collection: {'added': {'episodes': 9}}
Syncing show ratings   5% ━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1/19  [ 0:00:01 < -:--:-- , ? it/s ]
INFO: Updated plex watchlist in 0.2 seconds
INFO: Completed full sync in 40.0 seconds
```

As a reminder, the first implementation of batch :
- https://github.com/Taxel/PlexTraktSync/pull/232

fixes #855