### PR TITLE
Fix: Reload item when accessing parts for media

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -227,7 +227,8 @@ class PlexLibraryItem:
 
     @property
     def parts(self) -> List[MediaPart]:
-        for media in self.item.media:
+        item = self.plex.fetch_item(self.item.ratingKey)
+        for media in item.item.media:
             yield from media.parts
 
     @flatten_list


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/572

There's no major performance gain, as the parts are only accessed when the item is submitted to collection.