### PR TITLE
Replace appdirs with platformdirs dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-appdirs = "==1.4.4"
 attrs = "==22.2.0"
 "backports.cached-property" = {version="==1.0.2", python_version="<='3.7'"}
 cattrs = {version="==22.2.0", python_version=">='3.7'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b7d212ee832fcbc573dba049a53b7d60259d23870bdc18e7da496578e044dee0"
+            "sha256": "346e20c2940bac84f48eb66bcc265e694e284cb7b0d82a85475f55d47c7f24d5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,14 +16,6 @@
         ]
     },
     "default": {
-        "appdirs": {
-            "hashes": [
-                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
-                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
-            ],
-            "index": "pypi",
-            "version": "==1.4.4"
-        },
         "attrs": {
             "hashes": [
                 "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ plextraktsync sync
 ```
 
 NOTE: `pipx` install will use OS specific paths for Config, Logs, Cache, see
-[appdirs] documentation for details or check output of [info command](#info-command).
+[platformdirs] documentation for details or check output of [info command](#info-command).
 
-[appdirs]: https://pypi.org/project/appdirs
+[platformdirs]: https://pypi.org/project/platformdirs
 [install-pipx]: https://github.com/pypa/pipx#install-pipx
 
 ### Docker Compose

--- a/plextraktsync/util/Path.py
+++ b/plextraktsync/util/Path.py
@@ -39,9 +39,9 @@ class Path:
 
     @cached_property
     def app_dir(self):
-        from appdirs import AppDirs
+        from platformdirs import PlatformDirs
 
-        return AppDirs(self.app_name)
+        return PlatformDirs(self.app_name)
 
     @cached_property
     def installed(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 
 -i https://pypi.org/simple/
-appdirs==1.4.4
 attrs==22.2.0
 backports.cached-property==1.0.2; python_version <= '3.7'
 cattrs==22.2.0; python_version >= '3.7'


### PR DESCRIPTION
It seems that the community is moving past `appdirs` and that a more maintained fork has appeared: `platformdirs`.

This becomes relevant when requests cache is updated to <del>0.10</del> 1.0.0:
- https://github.com/reclosedev/requests-cache/issues/563

Currently `appdirs` dependency is still in `Pipfile.lock` because of `requests-cache`.

Ref:
- https://github.com/ActiveState/appdirs/issues/79
- https://github.com/ActiveState/appdirs/issues/170
- https://platformdirs.readthedocs.io/en/latest/changelog.html
