### PR TITLE
Fix: Open config.json as utf-8

### DIFF
--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -40,7 +40,7 @@ class RunConfig:
 class ConfigLoader:
     @staticmethod
     def load_json(path):
-        with open(path, "r") as fp:
+        with open(path, "r", encoding="utf-8") as fp:
             try:
                 config = json.load(fp)
             except JSONDecodeError as e:


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/878

Avoid opening config with OS native encoding, always use utf-8.