### PR TITLE
Feature: Add ability to extract media id from playHistory plex url

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -89,13 +89,19 @@ def id_from_url(url: str):
     """
     Extracts id from urls like:
       https://app.plex.tv/desktop/#!/server/abcdefg/details?key=%2Flibrary%2Fmetadata%2F13202
+      https://app.plex.tv/desktop/#!/server/abcdefg/playHistory?filters=metadataItemID%3D6041&filterTitle=&isParentType=false
     """
     result = urlparse(url)
     if result.fragment[0] == "!":
         parsed = parse_qs(urlparse(result.fragment).query)
-        key = ",".join(parsed["key"])
-        if key.startswith("/library/metadata/"):
-            return int(key[len("/library/metadata/"):])
+        if "key" in parsed:
+            key = ",".join(parsed["key"])
+            if key.startswith("/library/metadata/"):
+                return int(key[len("/library/metadata/"):])
+        if "filters" in parsed:
+            filters = parse_qs(parsed["filters"][0])
+            if "metadataItemID" in filters:
+                return int(filters["metadataItemID"][0])
 
     return url
 


### PR DESCRIPTION
Extracts id from urls like:
```
$ plextraktsync inspect https://app.plex.tv/desktop/#!/server/abcdefg/details?key=%2Flibrary%2Fmetadata%2F13202
$ plextraktsync inspect https://app.plex.tv/desktop/#!/server/abcdefg/playHistory?filters=metadataItemID%3D6041&filterTitle=&isParentType=false
```