### PR TITLE
Get trakt shows collection through sync/collection/shows request

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -73,8 +73,9 @@ class Media:
                 f"is_collected: Unsupported media type: {self.media_type}"
             )
 
-        collected = self.show.collected
-        return collected.get_completed(self.season_number, self.episode_number)
+        collected = self.trakt_api.collected_shows
+        return collected.is_collected(
+            self.show_trakt_id, self.season_number, self.episode_number)
 
     @cached_property
     def collected(self):

--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -49,9 +49,16 @@ class LazyEpisode:
 
 @get
 def allwatched():
-    # returns a ShowProgress object containing all watched episodes
+    # returns a AllShowProgress object containing all watched shows
     data = yield "sync/watched/shows"
-    yield AllWatchedShows(data)
+    yield AllShowsProgress(data)
+
+
+@get
+def allcollected():
+    # returns a AllShowProgress object containing all collected shows
+    data = yield "sync/collection/shows"
+    yield AllShowsProgress(data)
 
 
 @get
@@ -63,7 +70,7 @@ def watched(show_id):
 
 @get
 def collected(show_id):
-    # returns a ShowProgress object containing the watched states of the passed show
+    # returns a ShowProgress object containing the collected states of the passed show
     data = yield "shows/{}/progress/collection?specials=true".format(show_id)
     yield ShowProgress(**data)
 
@@ -152,7 +159,7 @@ class ShowProgress:
         return self.seasons[season].get_completed(episode)
 
 
-class AllWatchedShows:
+class AllShowsProgress:
     def __init__(self, shows=None):
         self.shows = {}
         for show in shows:
@@ -165,6 +172,13 @@ class AllWatchedShows:
         elif season not in self.shows[trakt_id].seasons.keys():
             return False
         return self.shows[trakt_id].seasons[season].get_completed(episode)
+
+    def is_collected(self, trakt_id, season, episode):
+        if trakt_id not in self.shows.keys():
+            return False
+        elif season not in self.shows[trakt_id].seasons.keys():
+            return False
+        return episode in self.shows[trakt_id].seasons[season].episodes.keys()
 
     def add(self, trakt_id, season, episode):
         episode_prog = {"number": episode, "completed": True}

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -163,6 +163,12 @@ class TraktApi:
     @cached_property
     @nocache
     @rate_limit()
+    def collected_shows(self):
+        return pytrakt_extensions.allcollected()
+
+    @cached_property
+    @nocache
+    @rate_limit()
     def watchlist_movies(self):
         return self.me.watchlist_movies
 


### PR DESCRIPTION
...instead of [/shows/id/progress/collection](https://trakt.docs.apiary.io/#reference/shows/collection-progress/get-show-collection-progress) request which returns only aired episodes. Trakt doc states:
> Note: Only aired episodes are used to calculate progress. Episodes in the future or without an air date are ignored.

The [sync/collection/shows](https://trakt.docs.apiary.io/#reference/sync/get-collection/get-collection) trakt request is better because it returns all collected episodes **even if not aired**.


There was a problem with episodes without airdate (typically specials episodes of season 0) being sent over and over to trakt, polluting log file.
Problem similar to PR https://github.com/Taxel/PlexTraktSync/pull/31

fixes #936