### PR TITLE
Use progress reset trakt VIP feature for shows

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -160,10 +160,11 @@ class Media:
                 self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
         elif self.is_episode:
             if self.show_reset_at and self.plex.seen_date.replace(tzinfo=None) < self.show_reset_at:
-                logger.info(f"Show {self.plex.item.show().title} has been reset in trakt at {self.show_reset_at}.")
-                logger.info(f"Marking {self.plex.item.show().title} as unwatched in Plex.")
-                self.plex_api.reset_show(show=self.plex.item.show(), reset_date=self.show_reset_at)
-            if not dry_run:
+                if not dry_run:
+                    logger.info(f"Show {self.plex.item.show().title} has been reset in trakt at {self.show_reset_at}.")
+                    logger.info(f"Marking {self.plex.item.show().title} as unwatched in Plex.")
+                    self.plex_api.reset_show(show=self.plex.item.show(), reset_date=self.show_reset_at)
+            elif not dry_run:
                 logger.info(f"Marking as watched in Trakt: {self}")
                 self.trakt_api.mark_watched(
                     self.trakt, self.plex.seen_date, self.show_trakt_id

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -160,7 +160,9 @@ class Media:
                 self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
         elif self.is_episode:
             if self.show_reset_at and self.plex.seen_date < self.show_reset_at:
-                return
+                logger.info(f"Show {self.plex.item.show().title} has been reset in trakt at {self.show_reset_at}.")
+                logger.info(f"Marking {self.plex.item.show().title} as unwatched in Plex.")
+                self.plex_api.reset_show(show=self.plex.item.show(), reset_date=self.show_reset_at)
             if not dry_run:
                 logger.info(f"Marking as watched in Trakt: {self}")
                 self.trakt_api.mark_watched(

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -159,7 +159,7 @@ class Media:
                 logger.info(f"Marking as watched in Trakt: {self}")
                 self.trakt_api.mark_watched(self.trakt, self.plex.seen_date)
         elif self.is_episode:
-            if self.show_reset_at and self.plex.seen_date < self.show_reset_at:
+            if self.show_reset_at and self.plex.seen_date.replace(tzinfo=None) < self.show_reset_at:
                 logger.info(f"Show {self.plex.item.show().title} has been reset in trakt at {self.show_reset_at}.")
                 logger.info(f"Marking {self.plex.item.show().title} as unwatched in Plex.")
                 self.plex_api.reset_show(show=self.plex.item.show(), reset_date=self.show_reset_at)

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -640,6 +640,11 @@ class PlexApi:
         m.markPlayed()
 
     @nocache
+    @retry()
+    def mark_unwatched(self, m):
+        m.markUnplayed()
+
+    @nocache
     def has_sessions(self):
         try:
             self.plex.sessions()
@@ -710,3 +715,14 @@ class PlexApi:
         except NotFound:
             return None
         return map(PlexLibraryItem, result)
+
+    @nocache
+    def reset_show(self, show, reset_date):
+        reset_count = 0
+        for ep in show.watched():
+            if ep.lastViewedAt < reset_date:
+                self.mark_unwatched(ep)
+                reset_count += 1
+            else:
+                logger.debug(f"{show.title} {ep.seasonEpisode} watched at {ep.lastViewedAt} after reset date {reset_date}")
+        logger.debug(f"{show.title}: {reset_count} Plex episode(s) marked as unwatched.")

--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -124,6 +124,12 @@ class AllShowsProgress:
             return False
         return episode in self.shows[trakt_id].seasons[season].episodes.keys()
 
+    def reset_at(self, trakt_id):
+        if trakt_id not in self.shows.keys():
+            return False
+        else:
+            return airs_date(self.shows[trakt_id].reset_at)
+
     def add(self, trakt_id, season, episode):
         episode_prog = {"number": episode, "completed": True}
         season_prog = {"number": season, "episodes": [episode_prog]}

--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -1,4 +1,5 @@
 from trakt.core import get
+from trakt.utils import airs_date
 
 
 @get
@@ -48,10 +49,13 @@ class SeasonProgress:
 
         self.completed = completed == len(episodes)
 
-    def get_completed(self, episode):
+    def get_completed(self, episode, reset_at):
         if self.completed:
             return True
         elif episode not in self.episodes.keys():
+            return False
+        last_watched_at = airs_date(self.episodes[episode].last_watched_at)
+        if reset_at and reset_at > last_watched_at:
             return False
         return self.episodes[episode].get_completed()
 
@@ -96,7 +100,8 @@ class ShowProgress:
             return True
         elif season not in self.seasons.keys():
             return False
-        return self.seasons[season].get_completed(episode)
+        reset_at = airs_date(self.reset_at)
+        return self.seasons[season].get_completed(episode, reset_at)
 
 
 class AllShowsProgress:
@@ -109,9 +114,8 @@ class AllShowsProgress:
     def get_completed(self, trakt_id, season, episode):
         if trakt_id not in self.shows.keys():
             return False
-        elif season not in self.shows[trakt_id].seasons.keys():
-            return False
-        return self.shows[trakt_id].seasons[season].get_completed(episode)
+        else:
+            return self.shows[trakt_id].get_completed(season, episode)
 
     def is_collected(self, trakt_id, season, episode):
         if trakt_id not in self.shows.keys():

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -157,9 +157,7 @@ class Sync:
         if m.watched_on_plex:
             if not self.config.plex_to_trakt["watched_status"]:
                 return
-            logger.info(f"Marking as watched in Trakt: {m}")
-            if not dry_run:
-                m.mark_watched_trakt()
+            m.mark_watched_trakt(dry_run)
         elif m.watched_on_trakt:
             if not self.config.trakt_to_plex["watched_status"]:
                 return


### PR DESCRIPTION
Trakt VIP members can [reset a show watched progress](https://support.trakt.tv/support/solutions/articles/70000628748-how-to-reset-watched-progress).
To make it work with PlexTraktSync, the script should take this `reset_at` date into consideration when reading the watched status of trakt episodes.

After being reset, a show [watched progress](https://trakt.docs.apiary.io/#reference/shows/watched-progress) should be defined as unwatched :

> If not null, the reset_at date is when the user started re-watching the show. Your app can adjust the progress by ignoring episodes with a last_watched_at prior to the reset_at.

This PR adds the `reset_at < last_watched_at` check before returning any trakt episode watched status.
It also marks as unwatched in Plex a show that's been reset in Trakt (only episodes watched before reset date).

This PR doesn't change anything for non-VIP trakt users.

closes #966