### PR TITLE
docs: add steps to configure the credentials in the docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,32 @@ or check output of [info command](#info-command).
 [appdirs]: https://pypi.org/project/appdirs
 [install-pipx]: https://github.com/pypa/pipx#install-pipx
 
-### Docker Compose
+### Docker
 
-You can setup docker compose file like this:
+#### Initial setup of the Docker container
+
+Before running the container with Docker compose, you need to set it up with credentials (see #setup). To do so run the following command to create and start the container with an interactive console, then answer the question as described in [the setup section](#setup)
+
+```
+docker run --rm --name plextraktsync -it -v .config:/app/config ghcr.io/taxel/plextraktsync
+```
+
+#### Docker Compose
+
+Once your initial container is configured, you can setup docker compose file like this:
 
 ```yaml
 services:
   plextraktsync:
     image: ghcr.io/taxel/plextraktsync
+    container_name: plextraktsync
+    restart: on-failure:2
     volumes:
       - ./config:/app/config
 ```
+
+> **Note**  
+> The `container_name` should match the value you set for `--name` in the previous step 
 
 To run sync:
 
@@ -174,7 +189,10 @@ Installing from GitHub is considered developer mode and it's documented in
   - Enter `urn:ietf:wg:oauth:2.0:oob` as the redirect url
   - You can leave Javascript origins and the Permissions checkboxes blank
 
-- Run `plextraktsync`, the script will ask for missing credentials
+- Run `plextraktsync`, the script will ask for missing credentials  
+> **Note**  
+> To setup the credentials in the Docker Container, refer to the [Initial setup of the Docker container](#initial-setup-of-the-docker-container) section
+
 
 - At first run you will be asked to setup Trakt and Plex access.
 


### PR DESCRIPTION
Credentials cannot be configured when running the docker compose. The container has to be created with an interactive console first
https://github.com/Taxel/PlexTraktSync/discussions/970