### PR TITLE
Use trakt from git repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,13 @@ pipenv run plextraktsync
 
 [pipenv]: https://pipenv.pypa.io/
 
+## Updating trakt dependency
+
+1. Update version in `trakt/__init__py`, commit, push it
+1. Add git tag, push it
+1. Run `pipenv install "trakt@https://github.com/glensc/python-trakt/archive/refs/tags/3.4.1.zip#egg=trakt"`
+1. Update trakt version manually in `requirements.txt`, `pipenv lock --requirements` loses the `trakt@` prefix
+
 ## Testing
 
 We use [pytest] for testing.

--- a/Pipfile
+++ b/Pipfile
@@ -20,9 +20,9 @@ requests = ">=2.25.1"
 requests-cache = "==0.9.6"
 rich = "==12.6.0"
 tqdm = "==4.64.1"
-trakt = {ref = "3.4.0", git = "https://github.com/glensc/python-trakt"}
 urllib3 = ">=1.26.6"
 websocket-client = "==1.4.1"
+trakt = {file = "https://github.com/glensc/python-trakt/archive/refs/tags/3.4.0.zip"}
 
 [requires]
 python_version = "3"

--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ requests = ">=2.25.1"
 requests-cache = "==0.9.6"
 rich = "==12.6.0"
 tqdm = "==4.64.1"
-trakt = "==3.4.0"
+trakt = {ref = "3.4.0", git = "https://github.com/glensc/python-trakt"}
 urllib3 = ">=1.26.6"
 websocket-client = "==1.4.1"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0db3457f8af6d05dda5515e43fb1f715b4bbda008f068aa8c085477ef67e7eb8"
+            "sha256": "fcb075b2517afb0196bd8dae72905c7f8aec06d05d2321cb472a19064f49bfb8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -254,12 +254,12 @@
             "version": "==4.64.1"
         },
         "trakt": {
+            "git": "https://github.com/glensc/python-trakt",
             "hashes": [
                 "sha256:1efd909378a09dd0abc3f056e12b2c18cad20cc699bfd211d1807414ba77d90d",
                 "sha256:a5f54258102c747ff50f3ffecc8ed52f20706938f620da4dd016d47ee4fd75ae"
             ],
-            "index": "pypi",
-            "version": "==3.4.0"
+            "ref": "8a6d4f168a858447014fb4c2c0efceb47b30ebb7"
         },
         "url-normalize": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fcb075b2517afb0196bd8dae72905c7f8aec06d05d2321cb472a19064f49bfb8"
+            "sha256": "d879198c5226ee72ac817e91d805550e857f484485b1085d345408765377c318"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -254,12 +254,8 @@
             "version": "==4.64.1"
         },
         "trakt": {
-            "git": "https://github.com/glensc/python-trakt",
-            "hashes": [
-                "sha256:1efd909378a09dd0abc3f056e12b2c18cad20cc699bfd211d1807414ba77d90d",
-                "sha256:a5f54258102c747ff50f3ffecc8ed52f20706938f620da4dd016d47ee4fd75ae"
-            ],
-            "ref": "8a6d4f168a858447014fb4c2c0efceb47b30ebb7"
+            "file": "https://github.com/glensc/python-trakt/archive/refs/tags/3.4.0.zip",
+            "version": "==3.4.0"
         },
         "url-normalize": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==8.1.3
 commonmark==0.9.1
 deprecated==1.2.13
 exceptiongroup==1.0.0rc9; python_version < '3.11'
-git+https://github.com/glensc/python-trakt@3.4.0#egg=trakt
+https://github.com/glensc/python-trakt/archive/refs/tags/3.4.0.zip#egg=trakt
 idna==3.4; python_version >= '3.5'
 inquirerpy==0.3.4
 oauthlib==3.2.2; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==8.1.3
 commonmark==0.9.1
 deprecated==1.2.13
 exceptiongroup==1.0.0rc9; python_version < '3.11'
-https://github.com/glensc/python-trakt/archive/refs/tags/3.4.0.zip#egg=trakt
+trakt @ https://github.com/glensc/python-trakt/archive/refs/tags/3.4.0.zip#egg=trakt
 idna==3.4; python_version >= '3.5'
 inquirerpy==0.3.4
 oauthlib==3.2.2; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ click==8.1.3
 commonmark==0.9.1
 deprecated==1.2.13
 exceptiongroup==1.0.0rc9; python_version < '3.11'
+git+https://github.com/glensc/python-trakt@3.4.0#egg=trakt
 idna==3.4; python_version >= '3.5'
 inquirerpy==0.3.4
 oauthlib==3.2.2; python_version >= '3.6'
@@ -31,7 +32,6 @@ requests==2.28.1
 rich==12.6.0
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tqdm==4.64.1
-trakt==3.4.0
 url-normalize==1.4.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 urllib3==1.26.12
 wcwidth==0.2.5


### PR DESCRIPTION
Testing to use trakt as git repository because current trakt maintainer is unavailable:
- https://github.com/moogar0880/PyTrakt/issues/199

Test for:
- https://github.com/Taxel/PlexTraktSync/issues/994

uses repo from:
- https://github.com/glensc/python-trakt

commands:
```
pipenv install "git+https://github.com/glensc/python-trakt@3.4.0#egg=trakt"
pipenv lock --requirements > requirements.txt
```