### PR TITLE
Fix: Catch invalid ratingKey property fetch from watch

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -511,8 +511,15 @@ class PlexApi:
         return PlexLibraryItem(media, plex=self)
 
     def reload_item(self, pm: PlexLibraryItem):
+        try:
+            key = pm.item.ratingKey
+        except AttributeError as e:
+            logger.debug(f"Invalid object: {e}")
+            return None
+
         self.fetch_item.cache_clear()
-        return self.fetch_item(pm.item.ratingKey)
+
+        return self.fetch_item(key)
 
     def media_url(self, m: PlexLibraryItem):
         return f"{self.plex_base_url}/details?key={m.item.key}"


### PR DESCRIPTION
```
ERROR    'Tag' object has no attribute 'ratingKey'
DEBUG
  File "PlexTraktSync/plextraktsync/listener.py", line 40, in dispatch
         listener["listener"](event)
  File "PlexTraktSync/plextraktsync/commands/watch.py", line 101, in on_activity
         m = self.find_by_key(activity.key, reload=True)
  File "PlexTraktSync/plextraktsync/commands/watch.py", line 79, in find_by_key
         pm = self.plex.reload_item(pm)
  File "PlexTraktSync/plextraktsync/plex_api.py", line 513, in reload_item
    return self.fetch_item(pm.item.ratingKey)
```