### PR TITLE
Plex Watchlist sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ or to improve documentation [docs-needed], thank you.**
 - Watched status are synced (dates are not reported from Trakt to Plex)
 - Liked lists in Trakt are downloaded and all movies in Plex belonging to that
   list are added
+- Watchlists are synced
 - You can edit the config file to choose what to sync
 - None of the above requires a Plex Pass or Trakt VIP membership.
   Downside: Needs to be executed manually or via cronjob,

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -202,6 +202,7 @@ def login(username: str, password: str):
         managed_user = choose_managed_user(account)
         if managed_user:
             user = managed_user
+            CONFIG["PLEX_OWNER_TOKEN"] = token
             token = account.user(managed_user).get_token(plex.machineIdentifier)
 
     CONFIG["PLEX_USERNAME"] = user

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -21,11 +21,13 @@ sync:
     collection: true
     ratings: true
     watched_status: true
+    watchlist: true
   trakt_to_plex:
     liked_lists: true
     ratings: true
     watched_status: true
     watchlist: true
+    watchlist_as_playlist: false
 
 watch:
   add_collection: false

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -107,6 +107,7 @@ class Config(dict):
         "PLEX_FALLBACKURL",  # legacy, used before 0.18.21
         "PLEX_LOCALURL",
         "PLEX_TOKEN",
+        "PLEX_OWNER_TOKEN",
         "PLEX_USERNAME",
         "TRAKT_USERNAME",
     ]

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -189,9 +189,7 @@ class Sync:
 
     def sync_watchlist(self, walker: Walker, dry_run=False):
         """After plex library processing, sync watchlist items not in the plex library"""
-        if self.update_trakt_wl:
-            for m in walker.media_from_plexlist(list(self.plex_wl.values())):
-                self.watchlist_sync_item(m, dry_run)
-        if self.update_plex_wl:
-            for m in walker.media_from_traktlist(list(self.trakt_wl_movies.values()) + list(self.trakt_wl_shows.values())):
-                self.watchlist_sync_item(m, dry_run)
+        for m in walker.media_from_plexlist(list(self.plex_wl.values())):
+            self.watchlist_sync_item(m, dry_run)
+        for m in walker.media_from_traktlist(list(self.trakt_wl_movies.values()) + list(self.trakt_wl_shows.values())):
+            self.watchlist_sync_item(m, dry_run)

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -24,6 +24,7 @@ class SyncConfig:
             "ratings": self.get("trakt_to_plex", "ratings"),
             "liked_lists": self.get("trakt_to_plex", "liked_lists"),
             "watchlist": self.get("trakt_to_plex", "watchlist"),
+            "watchlist_as_playlist": self.get("trakt_to_plex", "watchlist_as_playlist"),
         }
 
     @cached_property
@@ -32,6 +33,7 @@ class SyncConfig:
             "watched_status": self.get("plex_to_trakt", "watched_status"),
             "ratings": self.get("plex_to_trakt", "ratings"),
             "collection": self.get("plex_to_trakt", "collection"),
+            "watchlist": self.get("plex_to_trakt", "watchlist"),
         }
 
     @cached_property
@@ -55,8 +57,17 @@ class Sync:
     def sync(self, walker: Walker, dry_run=False):
         listutil = TraktListUtil()
         trakt = walker.trakt
+        plex = walker.plex
+        self.update_plex_wl = self.config.trakt_to_plex["watchlist"] and not self.config.trakt_to_plex["watchlist_as_playlist"]
+        self.update_plex_wl_as_pl = self.config.trakt_to_plex["watchlist"] and self.config.trakt_to_plex["watchlist_as_playlist"]
+        self.update_trakt_wl = self.config.plex_to_trakt["watchlist"]
+        self.sync_wl = self.config.trakt_to_plex["watchlist"] or self.config.plex_to_trakt["watchlist"]
+        if self.sync_wl:
+            self.trakt_wl_movies = {tm.trakt: tm for tm in trakt.watchlist_movies} or {}
+            self.trakt_wl_shows = {tm.trakt: tm for tm in trakt.watchlist_shows} or {}
+            self.plex_wl = {pm.guid: pm for pm in plex.watchlist()} or {}
 
-        if self.config.trakt_to_plex["watchlist"] and trakt.watchlist_movies:
+        if self.update_plex_wl_as_pl:
             listutil.addList(None, "Trakt Watchlist", trakt_list=trakt.watchlist_movies)
 
         if self.config.trakt_to_plex["liked_lists"]:
@@ -68,7 +79,8 @@ class Sync:
             self.sync_ratings(movie, dry_run=dry_run)
             self.sync_watched(movie, dry_run=dry_run)
             listutil.addPlexItemToLists(movie)
-        walker.trakt.batch.flush(force=True)
+            self.watchlist_sync_item(movie, dry_run=dry_run)
+        trakt.flush()
 
         shows = set()
         for episode in walker.find_episodes():
@@ -76,17 +88,22 @@ class Sync:
             self.sync_ratings(episode, dry_run=dry_run)
             self.sync_watched(episode, dry_run=dry_run)
             listutil.addPlexItemToLists(episode)
-            if self.config.sync_ratings:
-                # collect shows for later ratings sync
+            if self.config.sync_ratings or self.sync_wl:
+                # collect shows for later ratings and watchlists sync
                 shows.add(episode.show)
-        walker.trakt.batch.flush(force=True)
+        walker.trakt.flush()
 
         for show in walker.walk_shows(shows, title="Syncing show ratings"):
             self.sync_ratings(show, dry_run=dry_run)
 
-        if not dry_run:
-            with measure_time("Updated plex watchlist"):
-                listutil.updatePlexLists(walker.plex)
+        if not dry_run and self.sync_wl:
+            with measure_time("Updated watchlist"):
+                if self.update_plex_wl_as_pl:
+                    listutil.updatePlexLists(walker.plex)
+                else:
+                    for show in walker.walk_shows(shows, title="Syncing watchlist shows"):
+                        self.watchlist_sync_item(show, dry_run=dry_run)
+                    self.sync_watchlist(walker)
 
         if not dry_run:
             trakt.flush()
@@ -142,3 +159,41 @@ class Sync:
             logger.info(f"Marking as watched in Plex: {m}")
             if not dry_run:
                 m.mark_watched_plex()
+
+    def watchlist_sync_item(self, m: Media, dry_run=False):
+        if self.sync_wl:
+            if m.is_movie:
+                trakt_wl = self.trakt_wl_movies
+            else:
+                trakt_wl = self.trakt_wl_shows
+            if m.plex.item.guid in self.plex_wl:
+                if m.trakt.trakt not in trakt_wl:
+                    if self.update_trakt_wl:
+                        if not dry_run:
+                            logger.info(f"Adding {m.plex.item.title} to Trakt watchlist")
+                            m.add_to_trakt_watchlist(batch=True)
+                    else:
+                        logger.info(f"Removing {m.trakt.title} from Plex watchlist")
+                        m.remove_from_plex_watchlist()
+                else:
+                    trakt_wl.pop(m.trakt.trakt)
+                self.plex_wl.pop(m.plex.item.guid)
+            else:
+                if m.trakt.trakt in trakt_wl:
+                    if self.update_plex_wl:
+                        if not dry_run:
+                            logger.info(f"Adding {m.trakt.title} to Plex watchlist")
+                            m.add_to_plex_watchlist()
+                    else:
+                        logger.info(f"Removing {m.trakt.title} from Trakt watchlist")
+                        m.remove_from_trakt_watchlist()
+                    trakt_wl.pop(m.trakt.trakt)
+
+    def sync_watchlist(self, walker: Walker, dry_run=False):
+        """After plex library processing, sync watchlist items not in the plex library"""
+        if self.update_trakt_wl:
+            for m in walker.media_from_plexlist(list(self.plex_wl.values())):
+                self.watchlist_sync_item(m, dry_run)
+        if self.update_plex_wl:
+            for m in walker.media_from_traktlist(list(self.trakt_wl_movies.values()) + list(self.trakt_wl_shows.values())):
+                self.watchlist_sync_item(m, dry_run)

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -169,24 +169,26 @@ class Sync:
             if m.plex.item.guid in self.plex_wl:
                 if m.trakt.trakt not in trakt_wl:
                     if self.update_trakt_wl:
+                        logger.info(f"Adding {m.plex.item.title} to Trakt watchlist")
                         if not dry_run:
-                            logger.info(f"Adding {m.plex.item.title} to Trakt watchlist")
                             m.add_to_trakt_watchlist(batch=True)
                     else:
                         logger.info(f"Removing {m.trakt.title} from Plex watchlist")
-                        m.remove_from_plex_watchlist()
+                        if not dry_run:
+                            m.remove_from_plex_watchlist()
                 else:
                     trakt_wl.pop(m.trakt.trakt)
                 self.plex_wl.pop(m.plex.item.guid)
             else:
                 if m.trakt.trakt in trakt_wl:
                     if self.update_plex_wl:
+                        logger.info(f"Adding {m.trakt.title} to Plex watchlist")
                         if not dry_run:
-                            logger.info(f"Adding {m.trakt.title} to Plex watchlist")
                             m.add_to_plex_watchlist()
                     else:
                         logger.info(f"Removing {m.trakt.title} from Trakt watchlist")
-                        m.remove_from_trakt_watchlist()
+                        if not dry_run:
+                            m.remove_from_trakt_watchlist()
                     trakt_wl.pop(m.trakt.trakt)
 
     def sync_watchlist(self, walker: Walker, dry_run=False):

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -8,7 +8,7 @@ from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.media import Media, MediaFactory
 from plextraktsync.plex_api import (PlexApi, PlexGuid, PlexLibraryItem,
                                     PlexLibrarySection)
-from plextraktsync.trakt_api import TraktApi
+from plextraktsync.trakt_api import TraktApi, TraktItem
 
 
 class WalkConfig:
@@ -320,3 +320,21 @@ class Walker:
                 yield from it
         else:
             yield from iterable
+
+    def media_from_traktlist(self, items: List):
+        it = self.progressbar(items, desc="Processing Trakt watchlist")
+        for media in it:
+            tm = TraktItem(media, trakt=self.trakt)
+            m = self.mf.resolve_trakt(tm)
+            if not m:
+                continue
+            yield m
+
+    def media_from_plexlist(self, items: List):
+        it = self.progressbar(items, desc="Processing Plex watchlist")
+        for media in it:
+            pm = PlexLibraryItem(media, plex=self.plex)
+            m = self.mf.resolve_any(pm)
+            if not m:
+                continue
+            yield m


### PR DESCRIPTION
Adds sync between [Plex Universal Watchlist](https://support.plex.tv/articles/universal-watchlist/) (feature added april-2022) and Trakt Watchlist.

```yaml
sync:
  plex_to_trakt:
    watchlist: true
  trakt_to_plex:
    watchlist: true
    watchlist_as_playlist: false
```
- If you want to sync watchlist only `one-way` (plex_to_trakt **or** trakt_to_plex), it will remove items on destination watchlist that are not on source watchlist (kind of overwrite to keep it perfectly identical).

- If you sync watchlist `two-way` (plex_to_trakt **and** trakt_to_plex), no items are removed.

Before this PR, the Trakt watchlist was synced as a standard playlist because Plex didn't have a Watchlist.
To keep this old behavior, edit config file to sync trakt_to_plex only and use `watchlist_as_playlist` :
```yaml
sync:
  plex_to_trakt:
    watchlist: false
  trakt_to_plex:
    watchlist: true
    watchlist_as_playlist: true
```
To sync a managed user (home user) watchlist, you will need to re-run the login process to plex (only one time) because a new token is stored.

Many futur movies (not released yet) are already in Trakt database but not yet in Plex database. You can add them in your Trakt watchlist but not in your Plex watchlist. You'll see this in logs, it's normal :
```
INFO     Skipping Avatar: The Way of Water from Trakt watchlist because not found in Plex Discover
INFO     Skipping Dune: Part Two from Trakt watchlist because not found in Plex Discover
INFO     Skipping John Wick: Chapter 4 from Trakt watchlist because not found in Plex Discover
```

TODO:
- Remove item from Plex watchlist after being watched (seems to [not be automatic](https://support.plex.tv/articles/universal-watchlist/#toc-4))

closes #876 