### PR TITLE
Check episodes id if ordering is different between Plex and Trakt

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -7,7 +7,7 @@ from trakt.errors import TraktException
 from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.logging import logger
 from plextraktsync.plex_api import PlexApi, PlexGuid, PlexLibraryItem
-from plextraktsync.trakt_api import TraktApi
+from plextraktsync.trakt_api import TraktApi, TraktLookup
 
 
 class Media:
@@ -97,7 +97,7 @@ class Media:
         if self.media_type != "shows":
             raise RuntimeError(f"seasons: Unsupported media type: {self.media_type}")
 
-        return self.trakt_api.lookup(self.trakt)
+        return TraktLookup(self.trakt)
 
     @property
     def watched_on_plex(self):

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -32,11 +32,11 @@ class Media:
 
     @property
     def season_number(self):
-        return self.plex.season_number
+        return self.trakt.season
 
     @property
     def episode_number(self):
-        return self.plex.episode_number
+        return self.trakt.number
 
     @cached_property
     def trakt_id(self):


### PR DESCRIPTION
Some TV Shows have different episodes ordering across source databases (tvdb, tmdb,...) and layout (aired, DVD, absolute).

- Trakt uses tmdb as primary source.
- Plex uses tmdb order as [default](https://support.plex.tv/articles/naming-and-organizing-your-tv-show-files/) but let users choose episodes ordering among sources (tvdb, tmdb) and layout order (aired, DVD, absolute).

Tmdb is the recommended source but sometimes another one has to be used.

What this PR adds :
Checks episodes id to correctly map episodes number between Plex (order chosen by user) and Trakt (tmdb order).

fixes #914
fixes #996