### PR TITLE
plexapi isWatched markWatched are deprecated

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -221,7 +221,7 @@ class PlexLibraryItem:
     @property
     @nocache
     def is_watched(self):
-        return self.item.isWatched
+        return self.item.isPlayed
 
     @property
     def collected_at(self):
@@ -611,7 +611,7 @@ class PlexApi:
     @nocache
     @retry()
     def mark_watched(self, m):
-        m.markWatched()
+        m.markPlayed()
 
     @nocache
     def has_sessions(self):


### PR DESCRIPTION
Use of new **Plexapi** property `isPlayed` and method `markPlayed()` instead of deprecated `isWatched` and `markWatched()`

Ref :
- https://github.com/pkkid/python-plexapi/pull/984

fixes #1016