### PR TITLE
batch=True for remove_from_trakt_watchlist

### DIFF
--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -185,7 +185,7 @@ class Sync:
                     else:
                         logger.info(f"Removing {m.trakt.title} from Trakt watchlist")
                         if not dry_run:
-                            m.remove_from_trakt_watchlist()
+                            m.remove_from_trakt_watchlist(batch=True)
 
     def sync_watchlist(self, walker: Walker, dry_run=False):
         """After plex library processing, sync watchlist items not in the plex library"""


### PR DESCRIPTION
`batch=True` was missing in `m.remove_from_trakt_watchlist()`

TODO: add @nocache decorator when batch is not used, namely for :
- trakt.sync.add_to_collection(item)
- trakt.sync.add_to_watchlist(item)
- trakt.sync.remove_from_watchlist(item)

fixes #1026