### PR TITLE
Refactor: Use logger to print walk plan

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import click
-from tqdm import tqdm
 
 from plextraktsync.commands.login import ensure_login
 from plextraktsync.decorators.measure_time import measure_time
@@ -50,7 +49,7 @@ def sync(
         click.echo("Nothing to sync, this is likely due conflicting options given.")
         return
 
-    w.print_plan(print=tqdm.write)
+    w.print_plan(print=logger.info)
 
     if dry_run:
         print("Enabled dry-run mode: not making actual changes")

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -52,7 +52,7 @@ def sync(
     w.print_plan(print=logger.info)
 
     if dry_run:
-        print("Enabled dry-run mode: not making actual changes")
+        logger.info("Enabled dry-run mode: not making actual changes")
 
     with measure_time("Completed full sync"):
         runner = factory.sync()

--- a/plextraktsync/rich_addons.py
+++ b/plextraktsync/rich_addons.py
@@ -9,7 +9,7 @@ class RichHighlighter(RegexHighlighter):
         r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[\-\+]?\d+?)?\b|0x[0-9a-fA-F]*)",
         r"(?P<attrib_name>[\w_]{1,50})=(?P<attrib_value>\"?[\w_]+\"?)?",
         r"(?P<tag_start>\<)(?P<tag_name>(?:Movie|Episode|Show):\d+:[^>]+)(?P<tag_end>\>)",
-        r"(?P<tag_start>\<)(?P<tag_name>(?:PlexGuid|Guid):[^>]+)(?P<tag_end>\>)",
+        r"(?P<tag_start>\<)(?P<tag_name>(?:PlexGuid|Guid|PlexLibrarySection):[^>]+)(?P<tag_end>\>)",
         r"(?P<tag_start>\<)(?P<tag_name>(?:imdb|tmdb|tvdb|local):(?:\d+:)[^>]+)(?P<tag_end>\>)",
         r"\b(?P<bool_true>True)\b|\b(?P<bool_false>False)\b|\b(?P<none>None)\b",
         r"(?<![\\\w])(?P<str>b?\'\'\'.*?(?<!\\)\'\'\'|b?\'.*?(?<!\\)\'|b?\"\"\".*?(?<!\\)\"\"\"|b?\".*?(?<!\\)\")",


### PR DESCRIPTION
The side-effect is that this makes output colored and thus easier to read perhaps.

```
➜ plextraktsync
INFO     PlexTraktSync [0.21.0dev0]
INFO     Sync Movie sections: [<PlexLibrarySection:movie:Movies>]
INFO     Sync Show sections: [<PlexLibrarySection:show:TV Shows>]
```