### PR TITLE
Feature: Use logger to print messages in info command

### DIFF
--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -5,11 +5,12 @@ from trakt import __version__ as TRAKT_API_VERSION
 
 from plextraktsync.commands.plex_login import has_plex_token
 from plextraktsync.factory import factory
+from plextraktsync.logging import logger
 from plextraktsync.path import cache_dir, config_dir, log_dir
 from plextraktsync.version import version as get_version
 
 
-def info():
+def info(print=logger.info):
     print(f"PlexTraktSync Version: {get_version()}")
 
     py_version = sys.version.replace("\n", "")

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -21,6 +21,8 @@ def info():
     print(f"Log Dir: {log_dir}")
 
     config = factory.config()
+    print(f"Log File: {config.log_file}")
+
     print(f"Plex username: {config['PLEX_USERNAME']}")
     print(f"Trakt username: {config['TRAKT_USERNAME']}")
 

--- a/plextraktsync/commands/info.py
+++ b/plextraktsync/commands/info.py
@@ -22,6 +22,7 @@ def info():
 
     config = factory.config()
     print(f"Log File: {config.log_file}")
+    print(f"Cache File: {config.cache_path}.sqlite")
 
     print(f"Plex username: {config['PLEX_USERNAME']}")
     print(f"Trakt username: {config['TRAKT_USERNAME']}")

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -127,6 +127,14 @@ class Config(dict):
             self.initialize()
         return dict.__contains__(self, item)
 
+    @property
+    def log_file(self):
+        from os.path import join
+
+        from .path import log_dir
+
+        return join(log_dir, self["logging"]["filename"])
+
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -139,6 +139,10 @@ class Config(dict):
     def log_debug(self):
         return ("log_debug_messages" in self and self["log_debug_messages"]) or self["logging"]["debug"]
 
+    @property
+    def log_append(self):
+        return self["logging"]["append"]
+
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -143,6 +143,10 @@ class Config(dict):
     def log_append(self):
         return self["logging"]["append"]
 
+    @property
+    def cache_path(self):
+        return self["cache"]["path"]
+
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -135,6 +135,10 @@ class Config(dict):
 
         return join(log_dir, self["logging"]["filename"])
 
+    @property
+    def log_debug(self):
+        return ("log_debug_messages" in self and self["log_debug_messages"]) or self["logging"]["debug"]
+
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -42,8 +42,7 @@ class Factory:
         from requests_cache import CachedSession
 
         config = self.config()
-        trakt_cache = config["cache"]["path"]
-        session = CachedSession(trakt_cache)
+        session = CachedSession(config.cache_path)
 
         return session
 

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -1,5 +1,3 @@
-from deprecated import deprecated
-
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.rich_addons import RichHighlighter
 
@@ -48,18 +46,6 @@ class Factory:
         session = CachedSession(trakt_cache)
 
         return session
-
-    @memoize
-    @deprecated("Use session instead")
-    def requests_cache(self):
-        import requests_cache
-
-        config = self.config()
-        trakt_cache = config["cache"]["path"]
-
-        requests_cache.install_cache(trakt_cache)
-
-        return requests_cache
 
     @memoize
     def sync(self):

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -6,10 +6,7 @@ from .factory import factory
 def initialize():
     CONFIG = factory.config()
     # global log level for all messages
-    if ("log_debug_messages" in CONFIG and CONFIG["log_debug_messages"]) or CONFIG["logging"]["debug"]:
-        log_level = logging.DEBUG
-    else:
-        log_level = logging.INFO
+    log_level = logging.DEBUG if CONFIG.log_debug else logging.INFO
 
     # messages with info and above are printed to stdout
     console_handler = factory.console_logger()

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -1,8 +1,6 @@
 import logging
-from os.path import join
 
 from .factory import factory
-from .path import log_dir
 
 
 def initialize():
@@ -12,7 +10,6 @@ def initialize():
         log_level = logging.DEBUG
     else:
         log_level = logging.INFO
-    log_file = join(log_dir, CONFIG["logging"]["filename"])
 
     # messages with info and above are printed to stdout
     console_handler = factory.console_logger()
@@ -22,7 +19,7 @@ def initialize():
 
     # file handler can log down to debug messages
     mode = "a" if CONFIG["logging"]["append"] else "w"
-    file_handler = logging.FileHandler(log_file, mode, "utf-8")
+    file_handler = logging.FileHandler(CONFIG.log_file, mode, "utf-8")
     file_handler.setFormatter(
         logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s")
     )

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -15,7 +15,7 @@ def initialize():
     console_handler.setLevel(logging.INFO)
 
     # file handler can log down to debug messages
-    mode = "a" if CONFIG["logging"]["append"] else "w"
+    mode = "a" if CONFIG.log_append else "w"
     file_handler = logging.FileHandler(CONFIG.log_file, mode, "utf-8")
     file_handler.setFormatter(
         logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s")

--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -4,9 +4,9 @@ from .factory import factory
 
 
 def initialize():
-    CONFIG = factory.config()
+    config = factory.config()
     # global log level for all messages
-    log_level = logging.DEBUG if CONFIG.log_debug else logging.INFO
+    log_level = logging.DEBUG if config.log_debug else logging.INFO
 
     # messages with info and above are printed to stdout
     console_handler = factory.console_logger()
@@ -15,8 +15,8 @@ def initialize():
     console_handler.setLevel(logging.INFO)
 
     # file handler can log down to debug messages
-    mode = "a" if CONFIG.log_append else "w"
-    file_handler = logging.FileHandler(CONFIG.log_file, mode, "utf-8")
+    mode = "a" if config.log_append else "w"
+    file_handler = logging.FileHandler(config.log_file, mode, "utf-8")
     file_handler.setFormatter(
         logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s")
     )

--- a/plextraktsync/path.py
+++ b/plextraktsync/path.py
@@ -20,7 +20,6 @@ class Path:
         self.config_yml = join(self.config_dir, "config.yml")
         self.pytrakt_file = join(self.config_dir, ".pytrakt.json")
         self.env_file = join(self.config_dir, ".env")
-        self.log_file = join(self.log_dir, "last_update.log")
 
     @cached_property
     def config_dir(self):
@@ -70,4 +69,3 @@ config_file = p.config_file
 config_yml = p.config_yml
 pytrakt_file = p.pytrakt_file
 env_file = p.env_file
-log_file = p.log_file


### PR DESCRIPTION
This makes info command be colored via rich package.

Also add log filename and cache filename to command output, as they can be reconfigured via config file. Internally it moves those path values building to Config class to avoid duplication.