### PR TITLE
Add plex account token for shared resource

### DIFF
--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -61,7 +61,7 @@ def myplex_login(username, password):
 
 
 def choose_managed_user(account: MyPlexAccount):
-    users = [u.title for u in account.users()]
+    users = [u.title for u in account.users() if u.home]
     if not users:
         return None
 

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -201,6 +201,8 @@ def login(username: str, password: str):
 
     token = server.accessToken
     user = account.username
+    CONFIG["PLEX_OWNER_TOKEN"] = ""
+    CONFIG["PLEX_ACCOUNT_TOKEN"] = ""
     if server.owned:
         managed_user = choose_managed_user(account)
         if managed_user:

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -207,6 +207,8 @@ def login(username: str, password: str):
             user = managed_user
             CONFIG["PLEX_OWNER_TOKEN"] = token
             token = account.user(managed_user).get_token(plex.machineIdentifier)
+    else:
+        CONFIG["PLEX_ACCOUNT_TOKEN"] = account._token
 
     CONFIG["PLEX_USERNAME"] = user
     CONFIG["PLEX_TOKEN"] = token

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -108,6 +108,7 @@ class Config(dict):
         "PLEX_LOCALURL",
         "PLEX_TOKEN",
         "PLEX_OWNER_TOKEN",
+        "PLEX_ACCOUNT_TOKEN",
         "PLEX_USERNAME",
         "TRAKT_USERNAME",
     ]

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -629,11 +629,17 @@ class PlexApi:
     def _plex_account(self):
         CONFIG = factory.config()
         plex_owner_token = CONFIG.get("PLEX_OWNER_TOKEN")
+        plex_account_token = CONFIG.get("PLEX_ACCOUNT_TOKEN")
         plex_username = CONFIG.get("PLEX_USERNAME")
         if plex_owner_token:
             try:
                 plex_owner_account = MyPlexAccount(token=plex_owner_token)
                 return plex_owner_account.switchHomeUser(plex_username)
+            except BadRequest as e:
+                logger.error(f"Error during {plex_username} account access: {e}")
+        elif plex_account_token:
+            try:
+                return MyPlexAccount(token=plex_account_token)
             except BadRequest as e:
                 logger.error(f"Error during {plex_username} account access: {e}")
         else:


### PR DESCRIPTION
Account token ≠ Resource access token for users with shared library

This PR adds the **plex_account_token** to `.env` file for Plex account users using a shared resource.
