### PR TITLE
Fix: Setup PlexAccount only when needed

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -477,7 +477,10 @@ class PlexApi:
 
     def __init__(self, plex: PlexServer):
         self.plex = plex
-        self.account = self._plex_account()
+
+    @cached_property
+    def account(self):
+        return self._plex_account()
 
     @cached_property
     def plex_base_url(self):


### PR DESCRIPTION
This avoids warning when using watch
where plex account token is not yet available.