### PR TITLE
Feature: Add multiple servers support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /docker-compose.override.yml
 /last_update.log
 /plextraktsync.log
+/servers.yml
 /tests/.env
 /tests/config.json
 /trakt_cache.sqlite

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -10,6 +10,8 @@ from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
 from plexapi.server import PlexServer
 
+from plextraktsync.config.PlexServerConfig import PlexServerConfig
+from plextraktsync.config.ServerConfig import ServerConfig
 from plextraktsync.factory import factory
 from plextraktsync.style import (comment, disabled, error, highlight, prompt,
                                  success, title)
@@ -213,9 +215,19 @@ def login(username: str, password: str):
     CONFIG["PLEX_OWNER_TOKEN"] = plex_owner_token
     CONFIG["PLEX_ACCOUNT_TOKEN"] = plex_account_token
     CONFIG["PLEX_USERNAME"] = user
-    CONFIG["PLEX_TOKEN"] = token
-    CONFIG["PLEX_BASEURL"] = plex._baseurl
-    CONFIG["PLEX_LOCALURL"] = local_url()
+    CONFIG["PLEX_SERVER"] = server.name
     CONFIG.save()
+
+    psc = PlexServerConfig(
+        name=server.name,
+        token=token,
+        urls=[
+            plex._baseurl,
+            local_url(),
+        ],
+    )
+    sc = ServerConfig()
+    sc.add_server(psc)
+    sc.save()
 
     click.echo(SUCCESS_MESSAGE)

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -23,7 +23,7 @@ PROMPT_PLEX_RELOGIN = prompt(
     "You already have Plex Access Token, do you want to log in again?"
 )
 SUCCESS_MESSAGE = success(
-    "Plex Media Server Authentication Token and base URL have been added to .env file"
+    "Plex Media Server Authentication Token and base URL have been added to servers.yml"
 )
 NOTICE_2FA_PASSWORD = comment(
     "If you have 2 Factor Authentication enabled on Plex "

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -10,7 +10,6 @@ from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
 from plexapi.server import PlexServer
 
-from plextraktsync.config.PlexServerConfig import PlexServerConfig
 from plextraktsync.config.ServerConfig import ServerConfig
 from plextraktsync.factory import factory
 from plextraktsync.style import (comment, disabled, error, highlight, prompt,
@@ -218,7 +217,8 @@ def login(username: str, password: str):
     CONFIG["PLEX_SERVER"] = server.name
     CONFIG.save()
 
-    psc = PlexServerConfig(
+    sc = ServerConfig()
+    sc.add_server(
         name=server.name,
         token=token,
         urls=[
@@ -226,8 +226,6 @@ def login(username: str, password: str):
             local_url(),
         ],
     )
-    sc = ServerConfig()
-    sc.add_server(psc)
     sc.save()
 
     click.echo(SUCCESS_MESSAGE)

--- a/plextraktsync/config/Config.py
+++ b/plextraktsync/config/Config.py
@@ -18,6 +18,7 @@ class Config(dict, ConfigMergeMixin):
         "PLEX_OWNER_TOKEN",
         "PLEX_ACCOUNT_TOKEN",
         "PLEX_USERNAME",
+        "PLEX_SERVER",  # new in 0.24.0
         "TRAKT_USERNAME",
     ]
 

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import List
 
 
@@ -11,3 +11,9 @@ class PlexServerConfig:
     name: str = ""
     token: str = ""
     urls: List[str] = None
+
+    def asdict(self):
+        data = asdict(self)
+        del data["name"]
+
+        return data

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class PlexServerConfig:
+    """
+    Class to hold single server config
+    """
+
+    name: str = ""
+    token: str = ""
+    urls: List[str] = None

--- a/plextraktsync/config/ServerConfig.py
+++ b/plextraktsync/config/ServerConfig.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from os.path import exists
 
 from plextraktsync.config.ConfigLoader import ConfigLoader

--- a/plextraktsync/config/ServerConfig.py
+++ b/plextraktsync/config/ServerConfig.py
@@ -1,0 +1,69 @@
+from os.path import exists
+
+from plextraktsync.config.ConfigLoader import ConfigLoader
+from plextraktsync.config.ConfigMergeMixin import ConfigMergeMixin
+from plextraktsync.config.PlexServerConfig import PlexServerConfig
+from plextraktsync.path import default_servers_file, servers_config
+
+
+class ServerConfig(ConfigMergeMixin):
+    config_path = servers_config
+    loaded = False
+
+    def __init__(self):
+        self.servers = {}
+
+    def get_server(self, name: str):
+        self.load()
+        try:
+            return PlexServerConfig(**self.servers[name])
+        except KeyError:
+            raise RuntimeError(f"Server with name {name} is not defined")
+
+    def load(self):
+        if self.loaded:
+            return self
+        self.loaded = True
+        loader = ConfigLoader()
+
+        defaults = loader.load(default_servers_file)
+        self.servers.update(defaults["servers"])
+
+        if exists(self.config_path):
+            servers = loader.load(self.config_path)
+            self.merge(servers["servers"], self.servers)
+        else:
+            self.migrate()
+        return self
+
+    def migrate(self):
+        from plextraktsync.factory import factory
+        config = factory.config()
+        self.add_server(PlexServerConfig(
+            name="default",
+            urls=[
+                config["PLEX_BASEURL"],
+                config["PLEX_LOCALURL"],
+            ],
+            token=config["PLEX_TOKEN"],
+        ))
+        self.save()
+        config["PLEX_SERVER"] = "default"
+        config.save()
+        logger = factory.logger
+        logger.warning(f"Added default server to {self.config_path}")
+
+    def save(self):
+        loader = ConfigLoader()
+        loader.write(self.config_path, {
+            "servers": self.servers,
+        })
+
+    def add_server(self, config: PlexServerConfig):
+        self.load()
+        data = asdict(config)
+        del data["name"]
+        servers = {
+            config.name: data,
+        }
+        self.merge(servers, self.servers)

--- a/plextraktsync/config/ServerConfig.py
+++ b/plextraktsync/config/ServerConfig.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from os.path import exists
 
 from plextraktsync.config.ConfigLoader import ConfigLoader
@@ -40,14 +39,14 @@ class ServerConfig(ConfigMergeMixin):
     def migrate(self):
         from plextraktsync.factory import factory
         config = factory.config()
-        self.add_server(PlexServerConfig(
+        self.add_server(
             name="default",
             urls=[
                 config["PLEX_BASEURL"],
                 config["PLEX_LOCALURL"],
             ],
             token=config["PLEX_TOKEN"],
-        ))
+        )
         self.save()
         config["PLEX_SERVER"] = "default"
         config.save()
@@ -60,11 +59,10 @@ class ServerConfig(ConfigMergeMixin):
             "servers": self.servers,
         })
 
-    def add_server(self, config: PlexServerConfig):
+    def add_server(self, **kwargs):
         self.load()
-        data = asdict(config)
-        del data["name"]
+        config = PlexServerConfig(**kwargs)
         servers = {
-            config.name: data,
+            config.name: config.asdict(),
         }
         self.merge(servers, self.servers)

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -33,19 +33,23 @@ class Factory:
 
     @memoize
     def plex_server(self):
+        from plextraktsync.plex_server import PlexServerConnection
+
+        server = self.server_config()
+
+        return PlexServerConnection(factory).connect(
+            urls=server.urls,
+            token=server.token,
+        )
+
+    @memoize
+    def server_config(self):
         config = self.config()
 
         from plextraktsync.config.ServerConfig import ServerConfig
-        from plextraktsync.plex_server import PlexServerConnection
 
-        server_name = config["PLEX_SERVER"]
-        sc = ServerConfig()
-        sn = sc.get_server(server_name)
-
-        return PlexServerConnection(factory).connect(
-            urls=sn.urls,
-            token=sn.token,
-        )
+        # NOTE: the load() is needed because config["PLEX_SERVER"] may change during migrate() there.
+        return ServerConfig().load().get_server(config["PLEX_SERVER"])
 
     @memoize
     def session(self):

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -35,13 +35,16 @@ class Factory:
     def plex_server(self):
         config = self.config()
 
+        from plextraktsync.config.ServerConfig import ServerConfig
         from plextraktsync.plex_server import PlexServerConnection
+
+        server_name = config["PLEX_SERVER"]
+        sc = ServerConfig()
+        sn = sc.get_server(server_name)
+
         return PlexServerConnection(factory).connect(
-            urls=[
-                config["PLEX_BASEURL"],
-                config["PLEX_LOCALURL"],
-            ],
-            token=config["PLEX_TOKEN"]
+            urls=sn.urls,
+            token=sn.token,
         )
 
     @memoize

--- a/plextraktsync/path.py
+++ b/plextraktsync/path.py
@@ -15,8 +15,10 @@ class Path:
         self.ensure_dir(self.cache_dir)
 
         self.default_config_file = join(self.module_path, "config.default.yml")
+        self.default_servers_file = join(self.module_path, "servers.default.yml")
         self.config_file = join(self.config_dir, "config.json")
         self.config_yml = join(self.config_dir, "config.yml")
+        self.servers_config = join(self.config_dir, "servers.yml")
         self.pytrakt_file = join(self.config_dir, ".pytrakt.json")
         self.env_file = join(self.config_dir, ".env")
 
@@ -60,7 +62,9 @@ config_dir = p.config_dir
 log_dir = p.log_dir
 
 default_config_file = p.default_config_file
+default_servers_file = p.default_servers_file
 config_file = p.config_file
 config_yml = p.config_yml
+servers_config = p.servers_config
 pytrakt_file = p.pytrakt_file
 env_file = p.env_file

--- a/plextraktsync/plex_server.py
+++ b/plextraktsync/plex_server.py
@@ -56,7 +56,6 @@ class PlexServerConnection:
                 if "doesn't match '*." in message and ".plex.direct" in url:
                     url = self.extract_plex_direct(url, message)
                     self.logger.warning(f"Trying with url: {url}")
-                    self.save_new_url(url, urls[-1])
                     urls.append(url)
                     continue
 
@@ -87,12 +86,3 @@ class PlexServerConnection:
         end_pos = url.find(".plex.direct")
 
         return url[: end_pos - 32] + hash_value + url[end_pos:]
-
-    def save_new_url(self, base_url: str, local_url: str):
-        config = self.config
-
-        # save new url to .env
-        config["PLEX_BASEURL"] = base_url
-        config["PLEX_LOCALURL"] = local_url
-        config.save()
-        self.logger.info(f"Plex server url changed to {base_url}")

--- a/plextraktsync/servers.default.yml
+++ b/plextraktsync/servers.default.yml
@@ -1,0 +1,8 @@
+servers:
+  # servers definition
+  default:
+    token: ~
+    urls:
+      - http://localhost:32400
+
+# vim:ts=2:sw=2:et


### PR DESCRIPTION
Allow easy switching between multiple Plex servers.

This moves servers definition to `servers.yml` file:

```yml
servers:
  default:
    token: ~
    urls:
      - http://localhost:32400
```

in `.env`:
```sh
# Name of active server from servers.yml
PLEX_SERVER=default
```

`urls` can be an unlimited amount of urls to try.

`plex-login` command can be used to add new servers, it will add/update servers.yml and update `PLEX_SERVER` in `.env`.

Future ideas:
- allow specify server via commandline by name
- walk multiple servers
- per server config overrides