### PR TITLE
Fix rating being property again

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -217,6 +217,7 @@ class PlexLibraryItem:
 
         return value
 
+    @cached_property
     @nocache
     @retry(retries=1)
     def rating(self):


### PR DESCRIPTION
Mistakenly removed in eda493b6fc9a78e4645aa30c028a6b2400a3335c

Fixes https://github.com/Taxel/PlexTraktSync/issues/1090