### PR TITLE
Fix: Add support to detect pipx install from a pr

### DIFF
--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -1,36 +1,11 @@
-import json
-from json import JSONDecodeError
 from os import system
 
 import click
 
-from plextraktsync.util.execx import execx
-
-
-def pipx_installed(package: str):
-    try:
-        output = execx("pipx list --json")
-    except FileNotFoundError:
-        return None
-    if not output:
-        return None
-
-    try:
-        install_data = json.loads(output)
-    except JSONDecodeError:
-        return None
-    if install_data is None:
-        return None
-
-    try:
-        package = install_data["venvs"][package]["metadata"]["main_package"]
-    except KeyError:
-        return None
-
-    return package
-
 
 def enable_self_update():
+    from plextraktsync.util.packaging import pipx_installed
+
     package = pipx_installed("plextraktsync")
 
     return package is not None

--- a/plextraktsync/path.py
+++ b/plextraktsync/path.py
@@ -1,4 +1,3 @@
-import site
 from os import getenv, makedirs
 from os.path import abspath, dirname, exists, join
 
@@ -44,13 +43,9 @@ class Path:
 
     @cached_property
     def installed(self):
-        """
-        Return true if this package is installed to site-packages
-        """
-        absdir = dirname(dirname(__file__))
-        paths = site.getsitepackages()
+        from plextraktsync.util.packaging import installed
 
-        return absdir in paths
+        return installed()
 
     @staticmethod
     def ensure_dir(directory):

--- a/plextraktsync/util/packaging.py
+++ b/plextraktsync/util/packaging.py
@@ -16,6 +16,26 @@ def installed():
     return absdir in paths
 
 
+def pip_installed(name: str):
+    import sys
+    try:
+        output = execx(f"{sys.executable} -m pip inspect")
+    except FileNotFoundError:
+        return None
+
+    try:
+        inspect = json.loads(output)
+    except JSONDecodeError:
+        return None
+
+    for package in inspect["installed"]:
+        if package["metadata"]["name"] != name:
+            continue
+        return package
+
+    return None
+
+
 def pipx_installed(package: str):
     try:
         output = execx("pipx list --json")

--- a/plextraktsync/util/packaging.py
+++ b/plextraktsync/util/packaging.py
@@ -57,3 +57,21 @@ def pipx_installed(package: str):
         return None
 
     return package
+
+
+def vcs_info(package: str):
+    """
+    Return vcs_info from direct_url.json of a .dist-info for the package
+    """
+    data = pip_installed(package)
+    if not data:
+        return None
+    try:
+        v = data["direct_url"]["vcs_info"]
+    except KeyError:
+        return None
+
+    v["pr"] = v["requested_revision"][10:-5]
+    v["short_commit_id"] = v["commit_id"][:8]
+
+    return v

--- a/plextraktsync/util/packaging.py
+++ b/plextraktsync/util/packaging.py
@@ -1,5 +1,9 @@
+import json
 import site
+from json import JSONDecodeError
 from os.path import dirname
+
+from plextraktsync.util.execx import execx
 
 
 def installed():
@@ -10,3 +14,26 @@ def installed():
     paths = site.getsitepackages()
 
     return absdir in paths
+
+
+def pipx_installed(package: str):
+    try:
+        output = execx("pipx list --json")
+    except FileNotFoundError:
+        return None
+    if not output:
+        return None
+
+    try:
+        install_data = json.loads(output)
+    except JSONDecodeError:
+        return None
+    if install_data is None:
+        return None
+
+    try:
+        package = install_data["venvs"][package]["metadata"]["main_package"]
+    except KeyError:
+        return None
+
+    return package

--- a/plextraktsync/util/packaging.py
+++ b/plextraktsync/util/packaging.py
@@ -1,0 +1,12 @@
+import site
+from os.path import dirname
+
+
+def installed():
+    """
+    Return true if this package is installed to site-packages
+    """
+    absdir = dirname(dirname(dirname(__file__)))
+    paths = site.getsitepackages()
+
+    return absdir in paths

--- a/plextraktsync/version.py
+++ b/plextraktsync/version.py
@@ -10,11 +10,40 @@ class Version:
         if not __version__.endswith(".0dev0"):
             return __version__
 
+        # Print version from pip
+        if self.pipx_installed:
+            v = self.vcs_info
+            return f'{__version__[0:-4]}@pr/{v["pr"]}#{v["short_commit_id"]}'
+
+        # If installed with Git
         gv = git_version_info()
         if gv:
             return f"{__version__}: {gv}"
 
         return __version__
+
+    @property
+    def vcs_info(self):
+        from plextraktsync.util.packaging import vcs_info
+
+        return vcs_info("PlexTraktSync")
+
+    @property
+    def pipx_installed(self):
+        if not self.installed:
+            return False
+
+        from plextraktsync.util.packaging import pipx_installed
+
+        package = pipx_installed("plextraktsync")
+
+        return package is not None
+
+    @property
+    def installed(self):
+        from plextraktsync.util.packaging import installed
+
+        return installed()
 
 
 def git_version_info():

--- a/plextraktsync/version.py
+++ b/plextraktsync/version.py
@@ -1,3 +1,22 @@
+from plextraktsync.decorators.cached_property import cached_property
+
+
+class Version:
+    @cached_property
+    def version(self):
+        from plextraktsync import __version__
+
+        # Released in PyPI
+        if not __version__.endswith(".0dev0"):
+            return __version__
+
+        gv = git_version_info()
+        if gv:
+            return f"{__version__}: {gv}"
+
+        return __version__
+
+
 def git_version_info():
     try:
         from gitinfo import get_git_info
@@ -13,15 +32,8 @@ def git_version_info():
     return f"{commit['commit'][0:8]}: {message} @{commit['author_date']}"
 
 
+VERSION = Version()
+
+
 def version():
-    from plextraktsync import __version__
-
-    # Released in PyPI
-    if not __version__.endswith(".0dev0"):
-        return __version__
-
-    gv = git_version_info()
-    if gv:
-        return f"{__version__}: {gv}"
-
-    return __version__
+    return VERSION.version


### PR DESCRIPTION
Prints something like:
```
$ plextraktsync@1100 info
INFO     PlexTraktSync Version: 0.22.0@pr1100#1a9c2ed6
```

Refs:
- https://github.com/Taxel/PlexTraktSync/pull/1100#issuecomment-1279705151