### PR TITLE
Fix: Uninstall previous plextraktsync pr if already installed

### DIFF
--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -36,8 +36,24 @@ def enable_self_update():
     return package is not None
 
 
+def has_previous_pr(pr: int):
+    try:
+        from plextraktsync.util.execx import execx
+        execx(f"plextraktsync@{pr} --help")
+    except FileNotFoundError:
+        return False
+
+    return True
+
+
 def self_update(pr: int):
     if pr:
+        if has_previous_pr(pr):
+            # Uninstall because pipx doesn't update otherwise:
+            # - https://github.com/pypa/pipx/issues/902
+            click.echo(f"Uninstalling previous plextraktsync@{pr}")
+            system(f"pipx uninstall plextraktsync@{pr}")
+
         click.echo(f"Updating PlexTraktSync to the pull request #{pr} version using pipx")
         system(f"pipx install --suffix=@{pr} --force git+https://github.com/Taxel/PlexTraktSync@refs/pull/{pr}/head")
         return


### PR DESCRIPTION
Workaround for pipx shortcoming:
- https://github.com/pypa/pipx/issues/902