### PR TITLE
Feature: Add --version global option

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -37,11 +37,18 @@ def command():
 
 
 @click.group(invoke_without_command=True)
+@click.option("--version", is_flag=True, help="Print version and exit")
 @click.pass_context
-def cli(ctx):
+def cli(ctx, version: bool):
     """
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
+
+    if version:
+        from .version import version
+        print(f"PlexTraktSync {version()}")
+        return
+
     if not ctx.invoked_subcommand:
         sync()
 


### PR DESCRIPTION
Just have `plextraktsync --version` around.

```
$ plextraktsync self-update --pr 1109
Updating PlexTraktSync to the pull request #1109 version using pipx
  installed package PlexTraktSync 0.22.0.dev0 (PlexTraktSync@1109), installed using Python 3.10.8
  These apps are now globally available
    - plextraktsync@1109
done! ✨ 🌟 ✨
$ plextraktsync@1109 --version
PlexTraktSync 0.22.0@pr/1109#0c045225
```