### PR TITLE
Fix: Update self-update command to understand installed from pr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,12 @@ You can also use a convenience wrapper (this requires you install `plextraktsync
 $ plextraktsync self-update --pr 838
 ```
 
+You can also use the PR version of the program to pull in the latest changes with:
+
+```
+plextraktsync@1110 self-update
+```
+
 To remove the versions:
 
 ```

--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -13,13 +13,11 @@ def enable_self_update():
 
 
 def has_previous_pr(pr: int):
-    try:
-        from plextraktsync.util.execx import execx
-        execx(f"plextraktsync@{pr} --help")
-    except FileNotFoundError:
-        return False
+    from plextraktsync.util.packaging import pipx_installed
 
-    return True
+    package = pipx_installed(f"plextraktsync@{pr}")
+
+    return package is not None
 
 
 def pr_number() -> Optional[int]:

--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -39,6 +39,11 @@ def pr_number() -> Optional[int]:
 
 
 def self_update(pr: int):
+    if not pr:
+        pr = pr_number()
+        if pr:
+            click.echo(f"Installed as pr #{pr}, enabling pr mode")
+
     if pr:
         if has_previous_pr(pr):
             # Uninstall because pipx doesn't update otherwise:

--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -1,4 +1,5 @@
 from os import system
+from typing import Optional
 
 import click
 
@@ -19,6 +20,22 @@ def has_previous_pr(pr: int):
         return False
 
     return True
+
+
+def pr_number() -> Optional[int]:
+    """
+    Check if current executable is named plextraktsync@<pr>
+    """
+
+    import sys
+    try:
+        pr = sys.argv[0].split('@')[1]
+    except IndexError:
+        return None
+
+    if pr.isnumeric():
+        return int(pr)
+    return None
 
 
 def self_update(pr: int):

--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -5,9 +5,9 @@ import click
 
 
 def enable_self_update():
-    from plextraktsync.util.packaging import pipx_installed
+    from plextraktsync.util.packaging import pipx_installed, program_name
 
-    package = pipx_installed("plextraktsync")
+    package = pipx_installed(program_name())
 
     return package is not None
 

--- a/plextraktsync/util/packaging.py
+++ b/plextraktsync/util/packaging.py
@@ -59,6 +59,19 @@ def pipx_installed(package: str):
     return package
 
 
+def program_name():
+    """
+    Return current program name:
+    - pipx: plextraktsync
+    - pipx for pr 1000: plextraktsync@1000
+    """
+
+    import sys
+    from os.path import basename
+
+    return basename(sys.argv[0])
+
+
 def vcs_info(package: str):
     """
     Return vcs_info from direct_url.json of a .dist-info for the package

--- a/plextraktsync/version.py
+++ b/plextraktsync/version.py
@@ -33,9 +33,9 @@ class Version:
         if not self.installed:
             return False
 
-        from plextraktsync.util.packaging import pipx_installed
+        from plextraktsync.util.packaging import pipx_installed, program_name
 
-        package = pipx_installed("plextraktsync")
+        package = pipx_installed(program_name())
 
         return package is not None
 


### PR DESCRIPTION
this will update pr version of the command to latest pr changes of #1110:

```
$ plextraktsync@1110 self-update
```