### PR TITLE
Fix GitHub Actions set-output deprecation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,7 +43,7 @@ jobs:
             git fetch --tags --unshallow
             APP_VERSION=$(git describe --tags)_${GITHUB_REF#refs/heads/}
           fi
-          echo ::set-output name=version::$APP_VERSION
+          echo "version=$APP_VERSION" >> $GITHUB_OUTPUT
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/