### PR TITLE
Use trakt.show_id for episodes

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -133,12 +133,6 @@ class WatchStateUpdater:
         if not m:
             return None
 
-        # setup show property for trakt watched status
-        if m.is_episode:
-            ps = self.plex.fetch_item(m.plex.item.grandparentRatingKey)
-            ms = self.mf.resolve_any(ps)
-            m.show = ms
-
         return m
 
     def on_error(self, error: Error):

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -23,14 +23,11 @@ class Media:
             trakt,
             plex_api: PlexApi = None,
             trakt_api: TraktApi = None,
-            mf: MediaFactory = None,
     ):
         self.plex_api = plex_api
         self.trakt_api = trakt_api
-        self.mf = mf
         self.plex = plex
         self.trakt = trakt
-        self._show = None
 
     @cached_property
     def media_type(self):
@@ -57,23 +54,8 @@ class Media:
         return f"https://trakt.tv/{self.media_type}/{self.trakt_id}"
 
     @property
-    def show(self) -> Optional[Media]:
-        if self._show is None and self.mf:
-            ps = self.plex_api.fetch_item(self.plex.item.grandparentRatingKey)
-            ms = self.mf.resolve_any(ps)
-            self._show = ms
-
-        return self._show
-
-    @show.setter
-    def show(self, show):
-        self._show = show
-
-    @property
     def show_trakt_id(self):
-        if not self.show:
-            raise RuntimeError("Unexpected call: episode without show property")
-        return self.show.trakt_id
+        return getattr(self.trakt, "show_id", None)
 
     @cached_property
     def is_movie(self):
@@ -241,7 +223,7 @@ class MediaFactory:
         return self.make_media(pm, tm.item)
 
     def make_media(self, plex, trakt):
-        return Media(plex, trakt, plex_api=self.plex, trakt_api=self.trakt, mf=self)
+        return Media(plex, trakt, plex_api=self.plex, trakt_api=self.trakt)
 
     def _guid_match(self, candidates: List[PlexLibraryItem], tm: TraktItem) -> Optional[PlexLibraryItem]:
         if candidates:

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -386,7 +386,7 @@ class TraktApi:
         if te:
             return te
 
-        logger.warning(f"Retry using search for specific Plex Episode {guid.guid}")
+        logger.debug(f"Retry using search for specific Plex Episode {guid.guid}")
         if not guid.is_episode:
             return self.find_by_guid(guid)
         return None

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -284,7 +284,6 @@ class Walker:
             if not me:
                 continue
 
-            me.show = show
             yield me
 
     def media_from_sections(self, sections: List[PlexLibrarySection]):
@@ -309,7 +308,6 @@ class Walker:
             if not me:
                 continue
 
-            me.show = show
             yield me
 
     def progressbar(self, iterable, **kwargs):


### PR DESCRIPTION
requires :
- ~~https://github.com/moogar0880/PyTrakt/pull/208~~
- https://github.com/glensc/python-pytrakt/pull/6 (v3.4.9)
- #1143

Uses the newly added `show_id` attribute of trakt **TVEpisode** instead of TVShow id found from Plex show guid.
Usefull when a Plex show is split in many Trakt shows.

closes #1111