### PR TITLE
Fix super() call for python3

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -16,7 +16,7 @@ from plextraktsync.trakt_api import TraktApi
 
 class ScrobblerCollection(dict):
     def __init__(self, trakt: TraktApi, threshold=80):
-        super(dict, self).__init__()
+        super().__init__()
         self.trakt = trakt
         self.threshold = threshold
 
@@ -27,7 +27,7 @@ class ScrobblerCollection(dict):
 
 class SessionCollection(dict):
     def __init__(self, plex: PlexApi):
-        super(dict, self).__init__()
+        super().__init__()
         self.plex = plex
 
     def __missing__(self, key: str):

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -93,7 +93,7 @@ class PlexGuid:
 
 class PlexRatingCollection(dict):
     def __init__(self, plex: PlexApi):
-        super(dict, self).__init__()
+        super().__init__()
         self.plex = plex
 
     def __missing__(self, section_id: int):

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -74,7 +74,7 @@ class ScrobblerProxy:
 
 class TraktRatingCollection(dict):
     def __init__(self, trakt: TraktApi):
-        super(dict, self).__init__()
+        super().__init__()
         self.trakt = trakt
 
     def __missing__(self, media_type: str):


### PR DESCRIPTION
Use simplified super for python3:
- https://docs.quantifiedcode.com/python-anti-patterns/correctness/bad_first_argument_given_to_super.html

Refs:
- https://github.com/glensc/python-pytrakt/pull/4