### PR TITLE
plex ep localtime date changed to utc date before comparison with trakt date

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -720,7 +720,8 @@ class PlexApi:
     def reset_show(self, show, reset_date):
         reset_count = 0
         for ep in show.watched():
-            if ep.lastViewedAt < reset_date:
+            ep_seen_date = PlexLibraryItem(ep).seen_date.replace(tzinfo=None)
+            if ep_seen_date < reset_date:
                 self.mark_unwatched(ep)
                 reset_count += 1
             else:


### PR DESCRIPTION
Remove timezone offset for episode seen_date before comparing to trakt reset_at show date.

https://github.com/Taxel/PlexTraktSync/pull/1140#issuecomment-1292433963