### PR TITLE
Docs: Make clearer note about unsupported install methods

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -81,11 +81,11 @@ body:
       label: Install method
       description: How did you install PlexTraktSync
       options:
-        - pipx (Recommended)
-        - pip
+        - pipx
         - docker-compose
-        - git clone
-        - zip download
+        - pip (not supported)
+        - git clone (not supported)
+        - zip download (not supported)
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ label or to improve documentation [docs-needed], thank you.**
   - [Installation](#installation)
     - [pipx](#pipx)
     - [Docker Compose](#docker-compose)
-    - [Windows Setup (optional alternative)](#windows-setup-optional-alternative)
-    - [Unraid setup](#unraid-setup)
-    - [GitHub](#github)
+    - [Windows Setup (optional alternative)](#windows-setup-optional-alternative), unsupported
+    - [Unraid setup](#unraid-setup), unsupported
+    - [GitHub](#github), unsupported
   - [Setup](#setup)
   - [Sync settings](#sync-settings)
     - [Logging](#logging)

--- a/README.md
+++ b/README.md
@@ -129,11 +129,15 @@ it automatically at set intervals.
 
 ### Windows Setup (optional alternative)
 
+NOTE: _This installation method is not supported. It's documented solely by user contribution._
+
 - Download the latest `.zip` release from https://github.com/Taxel/PlexTraktSync/tags
 - Run `setup.bat` to install requirements and create optional shortcuts and
   routines _(requires Windows 7sp1 - 11)_.
 
 ### Unraid setup
+
+NOTE: _This installation method is not supported. It's documented solely by user contribution._
 
 Option 1 for container creation:
 Create a manual Unraid container of PlexTraktSync:
@@ -174,6 +178,8 @@ Once installed (or if already installed):
 - Set the schedule accordingly using the dropdown menu next to the "Run in Background" button
 
 ### GitHub
+
+NOTE: _This installation method is not supported._ You will not get support if you use this installation method.
 
 Installing from GitHub is considered developer mode, and it's documented in
 [CONTRIBUTING.md](CONTRIBUTING.md#checking-out-code).

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ The script is known to work with Python 3.7-3.10 versions.
 
 ## Installation
 
-- [pipx](#pipx) - _This is the recommended installation method_
-- [Docker Compose](#docker-compose)
-- [Windows Setup (optional alternative)](#windows-setup-optional-alternative)
-- [GitHub](#github)
-
 ### pipx
 
 Installation with [pipx][install-pipx].

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Once installed (or if already installed):
 
 ### GitHub
 
-Installing from GitHub is considered developer mode and it's documented in
+Installing from GitHub is considered developer mode, and it's documented in
 [CONTRIBUTING.md](CONTRIBUTING.md#checking-out-code).
 
 ## Setup


### PR DESCRIPTION
There has been an increasing volume of people making reports of installation failure, while they have not fully followed the installation documentation.

This makes it clear that only pipx and docker image are supported. other install methods are just documented as a convience, but without support.

- https://github.com/Taxel/PlexTraktSync/issues/1157
- https://github.com/Taxel/PlexTraktSync/issues/1154
- https://github.com/Taxel/PlexTraktSync/issues/1144