### PR TITLE
Add trakt official lists support

### DIFF
--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -131,7 +131,7 @@ class Sync:
 
         if self.config.sync_liked_lists:
             for lst in self.trakt.liked_lists:
-                listutil.addList(lst["username"], lst["listname"])
+                listutil.addList(lst["listid"], lst["listname"])
 
         if self.config.need_library_walk:
             for movie in walker.find_movies():

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -135,7 +135,7 @@ class TraktApi:
         for item in self.me.get_liked_lists("lists", limit=1000):
             yield {
                 'listname': item['list']['name'],
-                'username': item['list']['user']['ids']['slug'],
+                'listid': item['list']['ids']['trakt'],
             }
 
     @cached_property


### PR DESCRIPTION
With this PR, the script handles trakt lists with their id instead of there creator name.
This allows to use user lists and official lists with the same function.
Official lists are not identical to user lists because they are not created bu users and cannot be called with `/users/(user)/lists/(list)`

Ideally, the pytrakt module would add official lists support.