### PR TITLE
Refactor to use SyncConfig

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -50,7 +50,7 @@ def sync(
 
     with measure_time("Completed full sync"):
         runner = factory.sync()
-        if runner.need_library_walk:
+        if runner.config.need_library_walk:
             w.print_plan(print=logger.info)
         if dry_run:
             logger.info("Enabled dry-run mode: not making actual changes")

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -58,8 +58,10 @@ class Factory:
         from plextraktsync.sync import Sync
 
         config = self.config()
+        plex = self.plex_api()
+        trakt = self.trakt_api()
 
-        return Sync(config)
+        return Sync(config, plex, trakt)
 
     @memoize
     def progressbar(self, enabled=True):

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -121,13 +121,12 @@ class Sync:
 
     def sync(self, walker: Walker, dry_run=False):
         listutil = TraktListUtil()
-        trakt = walker.trakt
 
         if self.config.update_plex_wl_as_pl:
-            listutil.addList(None, "Trakt Watchlist", trakt_list=trakt.watchlist_movies)
+            listutil.addList(None, "Trakt Watchlist", trakt_list=self.trakt.watchlist_movies)
 
         if self.config.trakt_to_plex["liked_lists"]:
-            for lst in trakt.liked_lists:
+            for lst in self.trakt.liked_lists:
                 listutil.addList(lst["username"], lst["listname"])
 
         if self.config.need_library_walk:
@@ -136,7 +135,7 @@ class Sync:
                 self.sync_ratings(movie, dry_run=dry_run)
                 self.sync_watched(movie, dry_run=dry_run)
                 listutil.addPlexItemToLists(movie)
-            trakt.flush()
+            self.trakt.flush()
 
             shows = set()
             for episode in walker.find_episodes():
@@ -147,7 +146,7 @@ class Sync:
                 if self.config.sync_ratings:
                     # collect shows for later ratings sync
                     shows.add(episode.show)
-            trakt.flush()
+            self.trakt.flush()
 
             for show in walker.walk_shows(shows, title="Syncing show ratings"):
                 self.sync_ratings(show, dry_run=dry_run)
@@ -161,7 +160,7 @@ class Sync:
                     self.sync_watchlist(walker, dry_run=dry_run)
 
         if not dry_run:
-            trakt.flush()
+            self.trakt.flush()
 
     def sync_collection(self, m: Media, dry_run=False):
         if not self.config.plex_to_trakt["collection"]:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -46,10 +46,40 @@ class SyncConfig:
         return self.trakt_to_plex["ratings"] or self.plex_to_trakt["ratings"]
 
     @cached_property
+    def sync_watchlists(self):
+        return self.trakt_to_plex["watchlist"] or self.plex_to_trakt["watchlist"]
+
+    @cached_property
     def sync_watched_status(self):
         return (
             self.trakt_to_plex["watched_status"] or self.plex_to_trakt["watched_status"]
         )
+
+    @cached_property
+    def update_plex_wl(self):
+        return self.trakt_to_plex["watchlist"] and not self.trakt_to_plex["watchlist_as_playlist"]
+
+    @cached_property
+    def update_plex_wl_as_pl(self):
+        return self.trakt_to_plex["watchlist"] and self.trakt_to_plex["watchlist_as_playlist"]
+
+    @cached_property
+    def update_trakt_wl(self):
+        return self.plex_to_trakt["watchlist"]
+
+    @cached_property
+    def sync_wl(self):
+        return self.trakt_to_plex["watchlist"] or self.plex_to_trakt["watchlist"]
+
+    @cached_property
+    def need_library_walk(self):
+        return any([
+            self.update_plex_wl_as_pl,
+            self.sync_watched_status,
+            self.sync_ratings,
+            self.plex_to_trakt["collection"],
+            self.trakt_to_plex["liked_lists"],
+        ])
 
 
 class Sync:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 
 from plexapi.video import Movie, Show
+from trakt.tv import TVShow
 
 from plextraktsync.config import Config
 from plextraktsync.decorators.cached_property import cached_property
@@ -108,13 +109,13 @@ class Sync:
 
     @cached_property
     @flatten_dict
-    def trakt_wl_movies(self):
+    def trakt_wl_movies(self) -> Dict[int, Movie]:
         for tm in self.trakt.watchlist_movies:
             yield tm.trakt, tm
 
     @cached_property
     @flatten_dict
-    def trakt_wl_shows(self):
+    def trakt_wl_shows(self) -> Dict[int, TVShow]:
         for tm in self.trakt.watchlist_shows:
             yield tm.trakt, tm
 

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -3,6 +3,8 @@ from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.measure_time import measure_time
 from plextraktsync.factory import logger
 from plextraktsync.media import Media
+from plextraktsync.plex_api import PlexApi
+from plextraktsync.trakt_api import TraktApi
 from plextraktsync.trakt_list_util import TraktListUtil
 from plextraktsync.walker import Walker
 
@@ -51,8 +53,10 @@ class SyncConfig:
 
 
 class Sync:
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, plex: PlexApi, trakt: TraktApi):
         self.config = SyncConfig(config)
+        self.plex = plex
+        self.trakt = trakt
         self.update_plex_wl = self.config.trakt_to_plex["watchlist"] and not self.config.trakt_to_plex["watchlist_as_playlist"]
         self.update_plex_wl_as_pl = self.config.trakt_to_plex["watchlist"] and self.config.trakt_to_plex["watchlist_as_playlist"]
         self.update_trakt_wl = self.config.plex_to_trakt["watchlist"]

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from time import time
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import trakt
 import trakt.movies
@@ -190,14 +190,14 @@ class TraktApi:
     @nocache
     @rate_limit()
     @retry()
-    def watchlist_movies(self):
+    def watchlist_movies(self) -> List[Movie]:
         return self.me.watchlist_movies
 
     @cached_property
     @nocache
     @rate_limit()
     @retry()
-    def watchlist_shows(self):
+    def watchlist_shows(self) -> List[TVShow]:
         return self.me.watchlist_shows
 
     @cached_property


### PR DESCRIPTION
Increases readability (at least for me), lazy access for building lists. It's still a mess of responsibilities of classes, but at least properties aren't initialized inconsistent way. i.e need to run the `sync() method to gain access to some class properties.

For example this is still a mess:

```py
        runner: Sync = factory.sync()
        if runner.config.need_library_walk:
            w.print_plan(print=logger.info)
```