### PR TITLE
Fix: Disallow creating issues without templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,3 +2,4 @@ contact_links:
   - name: 💬 Discussions
     url: https://github.com/Taxel/PlexTraktSync/discussions/new?category=support
     about: Please use Discussions to ask for support. Bugs (application crashes, errors) needs to be reported as issues.
+blank_issues_enabled: false


### PR DESCRIPTION
Docs:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser