### PR TITLE
Feature: Pass config yaml to bugreport command

### DIFF
--- a/plextraktsync/commands/bug_report.py
+++ b/plextraktsync/commands/bug_report.py
@@ -6,13 +6,16 @@ URL_TEMPLATE = 'https://github.com/Taxel/PlexTraktSync/issues/new?template=bug.y
 
 
 def bug_url():
+    from plextraktsync.factory import factory
     from plextraktsync.util.versions import (pts_version, py_platform,
                                              py_version)
+    config = factory.config()
 
     q = urlencode({
         'os': py_platform(),
         'python': py_version(),
         'version': pts_version(),
+        'config': config.dump(),
     })
 
     return URL_TEMPLATE.format(q)

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -217,6 +217,19 @@ class Config(dict):
 
         return destination
 
+    def dump(self, print=None):
+        """
+        Print config serialized as yaml.
+        If print is None, return the produced string instead.
+        """
+        data = dict(self)
+        for key in self.env_keys:
+            del data[key]
+        dump = ConfigLoader.dump_yaml(None, data)
+        if print is None:
+            return dump
+        print(dump)
+
     def save(self):
         with open(self.env_file, "w") as txt:
             txt.write("# This is .env file for PlexTraktSync\n")

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -36,20 +36,20 @@ class RunConfig:
 
 
 class ConfigLoader:
-    @staticmethod
-    def load(path: str):
+    @classmethod
+    def load(cls, path: str):
         if path.endswith('.yml'):
-            return ConfigLoader.load_yaml(path)
+            return cls.load_yaml(path)
         if path.endswith('.json'):
-            return ConfigLoader.load_json(path)
+            return cls.load_json(path)
         raise RuntimeError(f'Unknown file type: {path}')
 
-    @staticmethod
-    def write(path: str, config):
+    @classmethod
+    def write(cls, path: str, config):
         if path.endswith('.yml'):
-            return ConfigLoader.write_yaml(path, config)
+            return cls.write_yaml(path, config)
         if path.endswith('.json'):
-            return ConfigLoader.write_json(path, config)
+            return cls.write_json(path, config)
         raise RuntimeError(f'Unknown file type: {path}')
 
     @staticmethod

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -93,12 +93,10 @@ class ConfigLoader:
         with open(path, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(config, indent=4))
 
-    @staticmethod
-    def write_yaml(path: str, config):
-        import yaml
-
+    @classmethod
+    def write_yaml(cls, path: str, config):
         with open(path, "w", encoding="utf-8") as fp:
-            yaml.dump(config, fp, allow_unicode=True, indent=2)
+            cls.dump_yaml(fp, config)
 
     @staticmethod
     def dump_yaml(fp, config):

--- a/plextraktsync/config.py
+++ b/plextraktsync/config.py
@@ -100,6 +100,12 @@ class ConfigLoader:
         with open(path, "w", encoding="utf-8") as fp:
             yaml.dump(config, fp, allow_unicode=True, indent=2)
 
+    @staticmethod
+    def dump_yaml(fp, config):
+        import yaml
+
+        return yaml.dump(config, fp, allow_unicode=True, indent=2)
+
 
 class Config(dict):
     env_keys = [


### PR DESCRIPTION
The bug-report command now also passes users' `config.yml`:

```
plextraktsync bug-report
```

Requires:
- https://github.com/Taxel/PlexTraktSync/pull/1164