### PR TITLE
Fix bug-report subcommand on linux

### DIFF
--- a/plextraktsync/util/openurl.py
+++ b/plextraktsync/util/openurl.py
@@ -11,7 +11,7 @@ def openurl(url: str):
             'darwin': 'open',
             'win32': 'start',
         }[sys.platform]
-    except IndexError:
+    except KeyError:
         opener = 'xdg-open'
 
     try:


### PR DESCRIPTION
```
✖  docker-compose run --rm plextraktsync bug-report
Opening bug report URL in browser, if that doesn't work open the link manually:

https://github.com/Taxel/PlexTraktSync/issues/new?template=bug.yml*redacted*
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/app/plextraktsync/__main__.py", line 18, in <module>
    cli()
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/app/plextraktsync/cli.py", line 28, in wrap
    cmd(*args, **kwargs)
  File "/app/plextraktsync/commands/bug_report.py", line 30, in bug_report
    openurl(url)
  File "/app/plextraktsync/util/openurl.py", line 10, in openurl
    opener = {
KeyError: 'linux'
```