### PR TITLE
Refactor: Update Plex playlists not delete+create

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -10,6 +10,7 @@ from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.library import LibrarySection
 from plexapi.media import AudioStream, MediaPart, SubtitleStream, VideoStream
 from plexapi.myplex import MyPlexAccount
+from plexapi.playlist import Playlist
 from plexapi.server import PlexServer, SystemAccount, SystemDevice
 from plexapi.video import Episode, Movie, Show
 from trakt.utils import timestamp
@@ -607,12 +608,12 @@ class PlexApi:
         m.rate(rating)
 
     @nocache
-    def update_playlist(self, name: str, items: List):
+    def update_playlist(self, name: str, items: List[Union[Movie, Show, Episode]]) -> None:
         """
         Updates playlist (creates if name missing) replacing contents with items[]
         """
         try:
-            playlist = self.plex.playlist(name)
+            playlist: Playlist = self.plex.playlist(name)
         except NotFound:
             playlist = self.plex.createPlaylist(name)
 

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -620,18 +620,6 @@ class PlexApi:
         playlist.addItems(items)
 
     @nocache
-    def create_playlist(self, name: str, items):
-        _, plex_items_sorted = zip(*sorted(dict(reversed(items)).items()))
-        self.plex.createPlaylist(name, items=plex_items_sorted)
-
-    @nocache
-    def delete_playlist(self, name: str):
-        try:
-            self.plex.playlist(name).delete()
-        except (NotFound, BadRequest):
-            logger.debug(f"Playlist '{name}' not found, so it could not be deleted")
-
-    @nocache
     @flatten_list
     def history(self, m, device=False, account=False):
         try:

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -607,6 +607,19 @@ class PlexApi:
         m.rate(rating)
 
     @nocache
+    def update_playlist(self, name: str, items: List):
+        """
+        Updates playlist (creates if name missing) replacing contents with items[]
+        """
+        try:
+            playlist = self.plex.playlist(name)
+        except NotFound:
+            playlist = self.plex.createPlaylist(name)
+
+        playlist.removeItems(playlist.items())
+        playlist.addItems(items)
+
+    @nocache
     def create_playlist(self, name: str, items):
         _, plex_items_sorted = zip(*sorted(dict(reversed(items)).items()))
         self.plex.createPlaylist(name, items=plex_items_sorted)

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -154,13 +154,21 @@ class Sync:
         if self.sync_wl:
             with measure_time("Updated watchlist"):
                 if self.config.update_plex_wl_as_pl:
-                    if not dry_run:
-                        listutil.updatePlexLists(walker.plex)
+                    self.update_playlists(listutil, dry_run=dry_run)
                 else:
                     self.sync_watchlist(walker, dry_run=dry_run)
 
         if not dry_run:
             self.trakt.flush()
+
+    def update_playlists(self, listutil: TraktListUtil, dry_run=False):
+        if dry_run:
+            return
+
+        for tl in listutil.lists:
+            logger.info(f"Updating Plex List: {tl.name} ({len(tl.plex_items)} items)")
+            _, plex_items_sorted = zip(*sorted(dict(reversed(tl.plex_items)).items()))
+            self.plex.update_playlist(tl.name, plex_items_sorted)
 
     def sync_collection(self, m: Media, dry_run=False):
         if not self.config.plex_to_trakt["collection"]:

--- a/plextraktsync/trakt_list_util.py
+++ b/plextraktsync/trakt_list_util.py
@@ -91,7 +91,3 @@ class TraktListUtil:
     def addPlexItemToLists(self, m):
         for tl in self.lists:
             tl.addPlexItem(m.trakt, m.plex.item)
-
-    def updatePlexLists(self, plex: PlexApi):
-        for tl in self.lists:
-            tl.updatePlexList(plex)

--- a/plextraktsync/trakt_list_util.py
+++ b/plextraktsync/trakt_list_util.py
@@ -7,7 +7,6 @@ from trakt.users import UserList
 from trakt.utils import extract_ids, slugify
 
 from plextraktsync.factory import logger
-from plextraktsync.plex_api import PlexApi
 
 
 class LazyUserList(UserList):
@@ -63,12 +62,6 @@ class TraktList:
                 )
             else:
                 logger.info(f"Added to list {self.name}: {plex_item}")
-
-    def updatePlexList(self, plex: PlexApi):
-        plex.delete_playlist(self.name)
-
-        if len(self.plex_items) > 0:
-            plex.create_playlist(self.name, self.plex_items)
 
 
 class TraktListUtil:


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/124

This allows you edit Plex lists, add them description:
- https://github.com/pkkid/python-plexapi/issues/1054

and it will be preserved as long as you keep the name intact.

Playlist contents is still cleared with each update to supply order by PTS.
it would be overly complicated to do compare and run only three available methods:
- addItems
- deleteItems
- reorderItems

besides, reorder items can take only one item a time, so lots of api calls