### PR TITLE
Fix: Remove setup-cfg-fmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,6 @@ repos:
     hooks:
       - id: rm-unneeded-f-str
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.2.0
-    hooks:
-      - id: setup-cfg-fmt
-
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:


### PR DESCRIPTION
It can't preserve comments,
so very annoying to revert the changes all the time..

refs:
- https://github.com/Taxel/PlexTraktSync/commit/271a993a0d8489eebc86f6fa5380eb5ec0c85230 (added here)

discussions:
- https://github.com/asottile/setup-cfg-fmt/issues/44
- https://github.com/asottile/setup-cfg-fmt/pull/21
- https://github.com/asottile/setup-cfg-fmt/issues/25