### PR TITLE
Handle syncing empty watchlist or playlist

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -629,10 +629,16 @@ class PlexApi:
         """
         Updates playlist (creates if name missing) replacing contents with items[]
         """
+        playlist: Playlist = None
         try:
-            playlist: Playlist = self.plex.playlist(name)
+            playlist = self.plex.playlist(name)
         except NotFound:
-            playlist = self.plex.createPlaylist(name)
+            if len(items) > 0:
+                playlist = self.plex.createPlaylist(name, items=items)
+
+        # Skip if playlist could not be made/retrieved
+        if playlist is None:
+            return False
 
         # Skip if nothing to update
         if self.same_list(items, playlist.items()):

--- a/plextraktsync/trakt_list_util.py
+++ b/plextraktsync/trakt_list_util.py
@@ -51,6 +51,9 @@ class TraktList:
 
         https://github.com/Taxel/PlexTraktSync/pull/58
         """
+        if len(self.plex_items) == 0:
+            return []
+
         _, items = zip(*sorted(dict(reversed(self.plex_items)).items()))
         return items
 


### PR DESCRIPTION
Enables handling of a watchlist which has no items in common with the Plex library.
Also fixes an issue where [creating a new playlist would give a BadRequest exception.](https://github.com/Taxel/PlexTraktSync/pull/1183#discussion_r1018872371) 