### PR TITLE
allow None as date value

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -411,8 +411,10 @@ class PlexLibraryItem:
             return f"<{self.item}>"
 
     def to_json(self):
+        collected_at = None if not self.collected_at else timestamp(
+            self.collected_at)
         metadata = {
-            "collected_at": timestamp(self.collected_at),
+            "collected_at": collected_at,
             "media_type": "digital",
             "resolution": self.resolution,
             "hdr": self.hdr,

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -399,7 +399,7 @@ class PlexLibraryItem:
     @staticmethod
     def date_value(date):
         if not date:
-            raise ValueError("Value can't be None")
+            return None
 
         return date.astimezone(datetime.timezone.utc)
 


### PR DESCRIPTION
Plex uses file date to set the `addedAt` value of a media.
Some media managers (such as Radarr/Sonarr) have an option to automatically set file date to release date.
But some OS cannot handle very old dates (eg. [Windows](https://www.reddit.com/r/radarr/comments/qr3jbj/trigger_write_release_dates_to_files_many_have/) dates before 1970) so the file date cannot be written on file system by such media manager.
Therefore Plex cannot populate the `addedAt` value.

This PR allows None value for `addedAt` instead of crashing.
None value is accepted by trakt, it is understood as current datetime.

closes #1189
closes #949