### PR TITLE
Fix 10x 1.1s second delay end of the sync

### DIFF
--- a/plextraktsync/timer.py
+++ b/plextraktsync/timer.py
@@ -1,6 +1,6 @@
 from time import monotonic, sleep
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
 
 
 class Timer:
@@ -13,6 +13,7 @@ class Timer:
             raise ValueError(f"Delay must be a positive number: {delay}")
         self.delay = delay
         self.last_time = None
+        self.logger = logging.getLogger("PlexTraktSync.Timer")
 
     @property
     def time_remaining(self):
@@ -34,6 +35,6 @@ class Timer:
 
         wait = self.time_remaining
         if wait:
-            logger.debug(f"Sleeping for {wait:.3f} seconds")
+            self.logger.debug(f"Sleeping for {wait:.3f} seconds")
             sleep(wait)
         self.update()

--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -397,9 +397,6 @@ class TraktBatch:
     @time_limit()
     @retry()
     def submit(self):
-        if self.queue_size() == 0:
-            return
-
         try:
             result = self.trakt_sync(self.items)
             result = self.remove_empty_values(result.copy())
@@ -422,10 +419,11 @@ class TraktBatch:
         """
         if not self.batch_delay and force is False:
             return
+        if self.queue_size() == 0:
+            return
+
         elapsed = time() - self.last_sent_time
-        if elapsed >= self.batch_delay:
-            self.submit()
-        elif force is True:
+        if elapsed >= self.batch_delay or force is True:
             self.submit()
 
     def add_to_items(self, media_type: str, item):


### PR DESCRIPTION
Remove a call to `submit()` if there's nothing to submit.

```
➜ grep -F 'Sleeping for' plextraktsync.log
2022-11-14 19:52:31,535 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:32,639 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:33,742 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:34,845 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:35,949 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:37,053 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:38,156 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:40,892 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:41,993 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
2022-11-14 19:52:43,097 DEBUG[PlexTraktSync]:Sleeping for 1.100 seconds
```