### PR TITLE
Fix: Skip attempting to detect protocol if url is None

### DIFF
--- a/plextraktsync/plex_server.py
+++ b/plextraktsync/plex_server.py
@@ -38,6 +38,7 @@ class PlexServerConnection:
         # 2. url without ssl
         # 3. local url (localhost)
         for url in urls:
+            self.logger.debug(f"Trying url: {url}")
             try:
                 return PlexServer(baseurl=url, token=token, session=self.session)
             except SSLError as e:

--- a/plextraktsync/plex_server.py
+++ b/plextraktsync/plex_server.py
@@ -66,7 +66,7 @@ class PlexServerConnection:
             except ConnectionError as e:
                 self.logger.error(e)
                 # 2.
-                if url[:5] == "https":
+                if url and url[:5] == "https":
                     url = url.replace("https", "http")
                     self.logger.warning(f"Trying with url: {url}")
                     urls.append(url)


### PR DESCRIPTION
Fixes exception from https://github.com/Taxel/PlexTraktSync/issues/1198, https://github.com/Taxel/PlexTraktSync/issues/1202