### PR TITLE
Feature: Save all urls to config from plex-login

### DIFF
--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -46,6 +46,7 @@ def server_urls(server: MyPlexResource):
     """
 
     yield from [c.uri for c in server.connections]
+    yield from [c.httpuri for c in server.connections]
     yield local_url()
 
 

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -225,10 +225,7 @@ def login(username: str, password: str):
     sc.add_server(
         name=server.name,
         token=token,
-        urls=[
-            plex._baseurl,
-            local_url(),
-        ],
+        urls=server_urls(server),
     )
     sc.save()
 

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -8,7 +8,6 @@ from click import ClickException
 from InquirerPy import get_style, inquirer
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
-from plexapi.server import PlexServer
 
 from plextraktsync.config.ServerConfig import ServerConfig
 from plextraktsync.decorators.flatten import flatten_list
@@ -177,8 +176,6 @@ def choose_server(account: MyPlexAccount):
             for c in server.connections:
                 click.echo(f"    {c.uri}")
             plex = server.connect()
-            # Validate connection again, the way we connect
-            plex = PlexServer(token=server.accessToken, baseurl=plex._baseurl)
             return [server, plex]
         except NotFound as e:
             click.secho(f"{e}, Try another server, {type(e)}")

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -45,8 +45,13 @@ def server_urls(server: MyPlexResource):
     Return urls to connect to specific server
     """
 
-    yield from [c.uri for c in server.connections]
-    yield from [c.httpuri for c in server.connections]
+    # https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/myplex.py#L1309-L1314
+    connections = server.preferred_connections(
+        None,
+        locations=server.DEFAULT_LOCATION_ORDER,
+        schemes=server.DEFAULT_SCHEME_ORDER
+    )
+    yield from connections
     yield local_url()
 
 

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -11,6 +11,7 @@ from plexapi.myplex import MyPlexAccount, MyPlexResource, ResourceConnection
 from plexapi.server import PlexServer
 
 from plextraktsync.config.ServerConfig import ServerConfig
+from plextraktsync.decorators.flatten import flatten_list
 from plextraktsync.factory import factory
 from plextraktsync.style import (comment, disabled, error, highlight, prompt,
                                  success, title)
@@ -37,6 +38,16 @@ style = get_style(
         "pointer": "fg:ansiblack bg:ansiyellow",
     }
 )
+
+
+@flatten_list
+def server_urls(server: MyPlexResource):
+    """
+    Return urls to connect to specific server
+    """
+
+    yield from [c.uri for c in server.connections]
+    yield local_url()
 
 
 def myplex_login(username, password):


### PR DESCRIPTION
Uses [`preferred_connections`](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/myplex.py#L1309-L1314) which describes as:
> Returns a sorted list of the available connection addresses for this resource.
> Often times there is more than one address specified for a server or client.
> Default behavior will prioritize local connections before remote or relay and HTTPS before HTTP.
> 

Writes all urls in order like:

```yml
servers:
  default:
    urls:
    - https://192-168-0-1.5eaf640a56769cf3a72fd93ac9711e40.plex.direct:32400
    - http://192.168.0.1:32400
    - https://8-8-8-8.5eaf640a56769cf3a72fd93ac9711e40.plex.direct:12521
    - http://8.8.8.8:12521
    - http://localhost:32400
```