### PR TITLE
Refactor: Setup url cache for trakt.tv by patterns

### DIFF
--- a/plextraktsync/commands/config.py
+++ b/plextraktsync/commands/config.py
@@ -7,3 +7,6 @@ def config(print=print):
 
     print(f"# Config File: {config.config_yml}")
     config.dump(print=print)
+
+    print("# HTTP Cache")
+    config.http_cache.dump(print=print)

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -61,14 +61,14 @@ xbmc-providers:
   shows: tvdb
 
 ##### Advanced settings below this line, don't edit unless you know what you're doing #####
-http_cache:
+#http_cache:
   # Value "0" means never cache, value "-1" means never expires
   # anything else means how long to cache
   #
   # https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#url-patterns
   #
   # NOTE: If there is more than one match, the first match will be used in the order they are defined
-  policy:
+#  policy:
 #    "*.trakt.tv/users/me": 1 day
 #    "*.trakt.tv/users/likes/lists": 0
 

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -1,21 +1,6 @@
 cache:
   path: $PTS_CACHE_DIR/trakt_cache
 
-http_cache:
-  never_cache:
-    # Requests matching these patterns will not be cached
-    - "*.trakt.tv/shows/*/seasons"
-    - "*.trakt.tv/sync/collection/shows"
-    - "*.trakt.tv/sync/watched/shows"
-    - "*.trakt.tv/users/*/collection/movies"
-    - "*.trakt.tv/users/*/collection/shows"
-    - "*.trakt.tv/users/*/ratings/*"
-    - "*.trakt.tv/users/*/watched/movies"
-    - "*.trakt.tv/users/*/watchlist/movies"
-    - "*.trakt.tv/users/*/watchlist/shows"
-    - "*.trakt.tv/users/likes/lists"
-    - "*.trakt.tv/users/me"
-
 excluded-libraries:
   - Private
   - Family Holidays
@@ -74,5 +59,24 @@ watch:
 xbmc-providers:
   movies: imdb
   shows: tvdb
+
+##### Advanced settings below this line, don't edit unless you know what you're doing #####
+http_cache:
+  # Value "0" means never cache, value "-1" means never expires
+  # anything else means how long to cache
+  #
+  # NOTE: If there is more than one match, the first match will be used in the order they are defined
+  policy:
+    "*.trakt.tv/shows/*/seasons": 0
+    "*.trakt.tv/sync/collection/shows": 0
+    "*.trakt.tv/sync/watched/shows": 0
+    "*.trakt.tv/users/*/collection/movies": 0
+    "*.trakt.tv/users/*/collection/shows": 0
+    "*.trakt.tv/users/*/ratings/*": 0
+    "*.trakt.tv/users/*/watched/movies": 0
+    "*.trakt.tv/users/*/watchlist/movies": 0
+    "*.trakt.tv/users/*/watchlist/shows": 0
+    "*.trakt.tv/users/likes/lists": 0
+    "*.trakt.tv/users/me": 0
 
 # vim:ts=2:sw=2:et

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -65,18 +65,11 @@ http_cache:
   # Value "0" means never cache, value "-1" means never expires
   # anything else means how long to cache
   #
+  # https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#url-patterns
+  #
   # NOTE: If there is more than one match, the first match will be used in the order they are defined
   policy:
-    "*.trakt.tv/shows/*/seasons": 0
-    "*.trakt.tv/sync/collection/shows": 0
-    "*.trakt.tv/sync/watched/shows": 0
-    "*.trakt.tv/users/*/collection/movies": 0
-    "*.trakt.tv/users/*/collection/shows": 0
-    "*.trakt.tv/users/*/ratings/*": 0
-    "*.trakt.tv/users/*/watched/movies": 0
-    "*.trakt.tv/users/*/watchlist/movies": 0
-    "*.trakt.tv/users/*/watchlist/shows": 0
-    "*.trakt.tv/users/likes/lists": 0
-    "*.trakt.tv/users/me": 0
+#    "*.trakt.tv/users/me": 1 day
+#    "*.trakt.tv/users/likes/lists": 0
 
 # vim:ts=2:sw=2:et

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -1,6 +1,21 @@
 cache:
   path: $PTS_CACHE_DIR/trakt_cache
 
+http_cache:
+  never_cache:
+    # Requests matching these patterns will not be cached
+    - "*.trakt.tv/shows/*/seasons"
+    - "*.trakt.tv/sync/collection/shows"
+    - "*.trakt.tv/sync/watched/shows"
+    - "*.trakt.tv/users/*/collection/movies"
+    - "*.trakt.tv/users/*/collection/shows"
+    - "*.trakt.tv/users/*/ratings/*"
+    - "*.trakt.tv/users/*/watched/movies"
+    - "*.trakt.tv/users/*/watchlist/movies"
+    - "*.trakt.tv/users/*/watchlist/shows"
+    - "*.trakt.tv/users/likes/lists"
+    - "*.trakt.tv/users/me"
+
 excluded-libraries:
   - Private
   - Family Holidays

--- a/plextraktsync/config/Config.py
+++ b/plextraktsync/config/Config.py
@@ -62,6 +62,12 @@ class Config(ChangeNotifier, ConfigMergeMixin, dict):
     def cache_path(self):
         return self["cache"]["path"]
 
+    @property
+    def http_cache(self):
+        from plextraktsync.config.HttpCacheConfig import HttpCacheConfig
+
+        return HttpCacheConfig(**self["http_cache"])
+
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -42,9 +42,15 @@ class HttpCacheConfig:
         NOTE: If there is more than one match, the first match will be used in the order they are defined
         """
 
-        policy = dict(self.default_policy)
-        if self.policy:
-            policy.update(self.policy)
+        # We need to build the dict manually, so users can have overrides for builtin patterns
+        policy = {}
+        for k, v in self.default_policy.items():
+            # Use user value if present
+            if k in self.policy:
+                v = self.policy[k]
+            policy[k] = v
+
+        policy.update(self.policy)
 
         return policy
 

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from requests_cache import DO_NOT_CACHE
-
 if TYPE_CHECKING:
-    from typing import List
+    from typing import Dict
 
     from requests_cache import ExpirationPatterns
 
@@ -17,7 +15,7 @@ class HttpCacheConfig:
     Main config dataclass
     """
 
-    never_cache: List[str]
+    policy: Dict[str]
 
     @property
     def urls_expire_after(self) -> ExpirationPatterns:
@@ -28,7 +26,4 @@ class HttpCacheConfig:
 
         NOTE: If there is more than one match, the first match will be used in the order they are defined
         """
-        result = {}
-        result.update({url: DO_NOT_CACHE for url in self.never_cache})
-
-        return result
+        return self.policy

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import List
+
+from requests_cache import DO_NOT_CACHE, ExpirationPatterns
+
+
+@dataclass(frozen=True)
+class HttpCacheConfig:
+    """
+    Main config dataclass
+    """
+
+    never_cache: List[str]
+
+    @property
+    def urls_expire_after(self) -> ExpirationPatterns:
+        """
+        Create url patterns:
+        - https://requests-cache.readthedocs.io/en/stable/examples.html#url-patterns
+        - https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#url-patterns
+
+        NOTE: If there is more than one match, the first match will be used in the order they are defined
+        """
+        result = {}
+        result.update({url: DO_NOT_CACHE for url in self.never_cache})
+
+        return result

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -47,3 +47,19 @@ class HttpCacheConfig:
             policy.update(self.policy)
 
         return policy
+
+    def dump(self, print=None):
+        """
+        Print config serialized as yaml.
+        If print is None, return the produced string instead.
+        """
+        from plextraktsync.config.ConfigLoader import ConfigLoader
+        data = {
+            "http_cache": {
+                "policy": self.urls_expire_after,
+            },
+        }
+        dump = ConfigLoader.dump_yaml(None, data)
+        if print is None:
+            return dump
+        print(dump)

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -1,7 +1,14 @@
-from dataclasses import dataclass
-from typing import List
+from __future__ import annotations
 
-from requests_cache import DO_NOT_CACHE, ExpirationPatterns
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from requests_cache import DO_NOT_CACHE
+
+if TYPE_CHECKING:
+    from typing import List
+
+    from requests_cache import ExpirationPatterns
 
 
 @dataclass(frozen=True)

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -17,6 +17,21 @@ class HttpCacheConfig:
 
     policy: Dict[str]
 
+    default_policy = {
+        # Requests matching these patterns will not be cached
+        "*.trakt.tv/shows/*/seasons": 0,
+        "*.trakt.tv/sync/collection/shows": 0,
+        "*.trakt.tv/sync/watched/shows": 0,
+        "*.trakt.tv/users/*/collection/movies": 0,
+        "*.trakt.tv/users/*/collection/shows": 0,
+        "*.trakt.tv/users/*/ratings/*": 0,
+        "*.trakt.tv/users/*/watched/movies": 0,
+        "*.trakt.tv/users/*/watchlist/movies": 0,
+        "*.trakt.tv/users/*/watchlist/shows": 0,
+        "*.trakt.tv/users/likes/lists": 0,
+        "*.trakt.tv/users/me": 0,
+    }
+
     @property
     def urls_expire_after(self) -> ExpirationPatterns:
         """
@@ -26,4 +41,5 @@ class HttpCacheConfig:
 
         NOTE: If there is more than one match, the first match will be used in the order they are defined
         """
-        return self.policy
+
+        return {**self.default_policy, **self.policy}

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -42,4 +42,8 @@ class HttpCacheConfig:
         NOTE: If there is more than one match, the first match will be used in the order they are defined
         """
 
-        return {**self.default_policy, **self.policy}
+        policy = dict(self.default_policy)
+        if self.policy:
+            policy.update(self.policy)
+
+        return policy

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -79,10 +79,10 @@ class Factory:
     def session(self):
         from requests_cache import CachedSession
 
-        config = self.config
-        session = CachedSession(config.cache_path)
-
-        return session
+        return CachedSession(
+            cache_name=self.config.cache_path,
+            urls_expire_after=self.config.http_cache.urls_expire_after,
+        )
 
     @cached_property
     def sync(self):

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -12,7 +12,6 @@ from trakt.errors import ForbiddenException, OAuthException
 from plextraktsync import pytrakt_extensions
 from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.decorators.flatten import flatten_list
-from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.decorators.retry import retry
 from plextraktsync.decorators.time_limit import time_limit
@@ -66,7 +65,6 @@ class TraktApi:
         return self.trakt_batch("watchlist", add=False)
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def me(self):
@@ -77,7 +75,6 @@ class TraktApi:
             raise e
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     @flatten_list
@@ -89,27 +86,23 @@ class TraktApi:
             }
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def watched_movies(self):
         return set(map(lambda m: m.trakt, self.me.watched_movies))
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def movie_collection(self):
         return self.me.movie_collection
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def show_collection(self):
         return self.me.show_collection
 
-    @nocache
     @rate_limit()
     @time_limit()
     @retry()
@@ -121,28 +114,24 @@ class TraktApi:
         return set(map(lambda m: m.trakt, self.movie_collection))
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def watched_shows(self):
         return pytrakt_extensions.allwatched()
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def collected_shows(self):
         return pytrakt_extensions.allcollected()
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def watchlist_movies(self) -> List[Movie]:
         return self.me.watchlist_movies
 
     @cached_property
-    @nocache
     @rate_limit()
     @retry()
     def watchlist_shows(self) -> List[TVShow]:
@@ -165,13 +154,11 @@ class TraktApi:
         else:
             raise ValueError(f"Unsupported type: {m.media_type}")
 
-    @nocache
     @rate_limit()
     @retry()
     def get_ratings(self, media_type: str):
         return self.me.get_ratings(media_type)
 
-    @nocache
     @rate_limit()
     @time_limit()
     @retry()
@@ -183,7 +170,6 @@ class TraktApi:
         scrobbler = media.scrobble(0, None, None)
         return ScrobblerProxy(scrobbler, threshold)
 
-    @nocache
     @rate_limit()
     @time_limit()
     @retry()

--- a/plextraktsync/trakt/TraktBatch.py
+++ b/plextraktsync/trakt/TraktBatch.py
@@ -8,7 +8,6 @@ import trakt.movies
 import trakt.sync
 import trakt.users
 
-from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.decorators.retry import retry
 from plextraktsync.decorators.time_limit import time_limit
@@ -31,7 +30,6 @@ class TraktBatch:
         if cleanup:
             cleanup.add(self.flush)
 
-    @nocache
     @rate_limit()
     @time_limit()
     @retry()

--- a/plextraktsync/trakt/TraktLookup.py
+++ b/plextraktsync/trakt/TraktLookup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.cached_property import cached_property
-from plextraktsync.decorators.nocache import nocache
 from plextraktsync.decorators.retry import retry
 from plextraktsync.factory import logger
 
@@ -29,7 +28,6 @@ class TraktLookup:
         self.same_order = True
 
     @cached_property
-    @nocache
     @retry()
     def table(self):
         """


### PR DESCRIPTION
Replaces https://github.com/Taxel/PlexTraktSync/pull/1220

Removes `@nocache` annotation and moves them to be setup via rules:

```yml
##### Advanced settings below this line, don't edit unless you know what you're doing #####
http_cache:
  # Value "0" means never cache, value "-1" means never expires
  # anything else means how long to cache
  #
  # NOTE: If there is more than one match, the first match will be used in the order they are defined
  policy:
    "*.trakt.tv/shows/*/seasons": 0
    "*.trakt.tv/sync/collection/shows": 0
    "*.trakt.tv/sync/watched/shows": 0
    "*.trakt.tv/users/*/collection/movies": 0
    "*.trakt.tv/users/*/collection/shows": 0
    "*.trakt.tv/users/*/ratings/*": 0
    "*.trakt.tv/users/*/watched/movies": 0
    "*.trakt.tv/users/*/watchlist/movies": 0
    "*.trakt.tv/users/*/watchlist/shows": 0
    "*.trakt.tv/users/likes/lists": 0
    "*.trakt.tv/users/me": 0
```

This allows to setup rule to cache some watchlist forever.

In the future could add default cache key (removed from this branch for now):

```yml
http_cache:
  # By default, cached responses expire in an hour
  default_expire_after: 1 hour
```
