### PR TITLE
Fix: Make /root path accessible for pipx find

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,5 @@ VOLUME /app/config
 COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=compile /app ./
 RUN ln -s /app/plextraktsync.sh /usr/bin/plextraktsync
+# https://github.com/python/cpython/issues/69667
+RUN chmod a+x /root


### PR DESCRIPTION
Workaround for python bug:
- https://github.com/python/cpython/issues/69667

Details:
- https://github.com/Taxel/PlexTraktSync/issues/1223#issuecomment-1326278510

Regression from:
- https://github.com/Taxel/PlexTraktSync/pull/1194