### PR TITLE
Feature: Add PUID/PGID support to docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /*
 !/Pipfile
 !/Pipfile.lock
+!/entrypoint.sh
 !/plextraktsync.sh
 !/plextraktsync/*.py
 !/plextraktsync/commands/*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN python -m compileall .
 RUN chmod -R a+rX,g-w .
 
 FROM base
-ENTRYPOINT ["python", "-m", "plextraktsync"]
+ENTRYPOINT ["/init"]
 
 ENV \
 	PATH=/root/.local/bin:$PATH \
@@ -69,6 +69,7 @@ eot
 COPY --from=tools /dist /
 COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=compile /app ./
+COPY entrypoint.sh /init
 RUN ln -s /app/plextraktsync.sh /usr/bin/plextraktsync
 # https://github.com/python/cpython/issues/69667
 RUN chmod a+x /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,23 @@ ENV \
 
 VOLUME /app/config
 
+# Add user/group
+ENV PUID=1000
+ENV PGID=1000
+
+RUN <<eot
+	set -x
+	addgroup --gid $PGID --system plextraktsync
+	adduser \
+		--disabled-password \
+		--gecos "Plex Trakt Sync" \
+		--home "$(pwd)" \
+		--ingroup plextraktsync \
+		--no-create-home \
+		--uid "$PUID" \
+		plextraktsync
+eot
+
 # Copy things together
 COPY --from=build /root/.local/share/virtualenvs/app-*/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=compile /app ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,19 +49,16 @@ ENV \
 VOLUME /app/config
 
 # Add user/group
-ENV PUID=1000
-ENV PGID=1000
-
 RUN <<eot
 	set -x
-	addgroup --gid $PGID --system plextraktsync
+	addgroup --gid 1000 --system plextraktsync
 	adduser \
 		--disabled-password \
 		--gecos "Plex Trakt Sync" \
 		--home "$(pwd)" \
 		--ingroup plextraktsync \
 		--no-create-home \
-		--uid "$PUID" \
+		--uid 1000 \
 		plextraktsync
 eot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3-labs
 FROM python:3.11-alpine3.16 AS base
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ services:
     volumes:
       - ./config:/app/config
     environment:
+      - PUID=1000
+      - PGID=1000
       - TZ=Europe/Tallinn
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+: ${TRACE:=}
+: ${APP_USER:=plextraktsync}
+: ${APP_GROUP:=plextraktsync}
+
+ensure_dir() {
+	install -o "$APP_USER" -g "$APP_GROUP" -d "$@"
+}
+
+ensure_owner() {
+	chown "$APP_USER:$APP_GROUP" "$@"
+}
+
+# change uid/gid of app user if requested
+setup_user() {
+	local uid=${PUID:-}
+	local gid=${PGID:-}
+
+	if [ -n "$uid" ] && [ "$(id -u $APP_USER)" != "$uid" ]; then
+		usermod -u "$uid" "$APP_USER"
+	fi
+	if [ -n "$gid" ] && [ "$(id -g $APP_GROUP)" != "$gid" ]; then
+		groupmod -g "$gid" "$APP_GROUP"
+	fi
+}
+
+# Run command as app user
+# https://github.com/karelzak/util-linux/issues/325
+switch_user() {
+	local uid=$(id -u "$APP_USER")
+	local gid=$(id -g "$APP_GROUP")
+
+	exec setpriv --euid "$uid" --ruid "$uid" --clear-groups --egid "$gid" --rgid "$gid" -- "$@"
+}
+
+fix_permissions() {
+	ensure_dir /app/config
+	ensure_owner /app/config -R
+}
+
+set -eu
+test -n "$TRACE" && set -x
+
+# prepend default command
+set -- python -m plextraktsync "$@"
+
+if [ "$(id -u)" = "0" ]; then
+	setup_user
+	fix_permissions
+	switch_user "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Match the LinuxServer images behavior:
- https://github.com/linuxserver-labs/docker-plextraktsync


```yaml
services:
  plextraktsync:
    image: ghcr.io/taxel/plextraktsync
    container_name: plextraktsync
    restart: on-failure:2
    volumes:
      - ./config:/app/config
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=Europe/Tallinn
```

- If `PUID`/`PGID` are specified, in container uid/gid is changed, files are changed to plextraktsync user recursively in config dir and script is continuing with plextraktsync user.
- Without specifying `PUID`/`PGID`, container continues to run as `root`. no file permissions are changed
- if `--user` is specified, no permissions are changed and process continues to run as that user.