### PR TITLE
Fix: Package servers.default.yml to pip package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ console_scripts =
 . =
     requirements.txt
     plextraktsync/config.default.yml
+    plextraktsync/servers.default.yml
 
 [requirements-files]
 # setuptools does not support "file:", so use a extra package for this:


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/1228