### PR TITLE
Fix: Disable bulk rating fetch for shows

### DIFF
--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -225,7 +225,7 @@ class PlexLibraryItem:
     @nocache
     @retry(retries=1)
     def rating(self):
-        if self.plex is not None:
+        if self.plex is not None and self.media_type == "movies":
             ratings = self.plex.ratings[self.item.librarySectionID]
             user_rating = (
                 ratings[self.item.ratingKey] if self.item.ratingKey in ratings else None


### PR DESCRIPTION
See details:
- https://github.com/Taxel/PlexTraktSync/issues/815#issuecomment-1331189557

Fixes https://github.com/Taxel/PlexTraktSync/issues/778, Fixes https://github.com/Taxel/PlexTraktSync/issues/815

The queries made to PMS:

- https://*redacted*.plex.direct:32400/library/sections/2/all?includeGuids=1&push=1&show.userRating%3E%3E=-1&pop=1&X-Plex-Container-Start=0&X-Plex-Container-Size=100
- https://*redacted*.plex.direct:32400/library/sections/1/all?includeGuids=1&push=1&userRating%3E%3E=-1&pop=1&X-Plex-Container-Start=0&X-Plex-Container-Size=100


note the keys differ: `show.userRating` for episodes and `userRating` for movies.