### PR TITLE
Fetch show ratings for episodes

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -180,7 +180,8 @@ class Media:
 
     @cached_property
     def plex_rating(self):
-        return self.plex.rating()
+        show_id = self.show.plex.item.ratingKey if self.media_type == "episodes" else None
+        return self.plex.rating(show_id)
 
     def trakt_rate(self):
         self.trakt_api.rate(self.trakt, self.plex_rating)

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -178,9 +178,9 @@ class Media:
     def trakt_rating(self):
         return self.trakt_api.rating(self.trakt)
 
-    @property
+    @cached_property
     def plex_rating(self):
-        return self.plex.rating
+        return self.plex.rating()
 
     def trakt_rate(self):
         self.trakt_api.rate(self.trakt, self.plex_rating)

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -224,7 +224,7 @@ class PlexLibraryItem:
     @nocache
     @retry(retries=1)
     def rating(self):
-        if self.plex is not None and self.media_type == "movies":
+        if self.plex is not None:
             ratings = self.plex.ratings[self.item.librarySectionID]
             user_rating = (
                 ratings[self.item.ratingKey] if self.item.ratingKey in ratings else None

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -221,7 +221,6 @@ class PlexLibraryItem:
 
         return value
 
-    @cached_property
     @nocache
     @retry(retries=1)
     def rating(self):

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -451,9 +451,10 @@ class PlexLibrarySection:
 
     @nocache
     def find_with_rating(self):
+        key = "episode.userRating" if self.type == "show" else "userRating"
         filters = {
             "and": [
-                {"userRating>>": -1},
+                {f"{key}>>": -1},
             ]
         }
 

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -223,12 +223,21 @@ class PlexLibraryItem:
 
     @nocache
     @retry(retries=1)
-    def rating(self):
+    def rating(self, show_id: int = None):
         if self.plex is not None:
             ratings = self.plex.ratings[self.item.librarySectionID]
-            user_rating = (
-                ratings[self.item.ratingKey] if self.item.ratingKey in ratings else None
-            )
+            if self.type in ["movie", "show"]:
+                user_rating = (
+                    ratings[self.item.ratingKey] if self.item.ratingKey in ratings else None
+                )
+            elif self.type == "episode":
+                # For episodes the ratings is just (show_id, show_rating) tuples
+                # if show id is not listed, return none, otherwise fetch from item itself
+                if show_id not in ratings:
+                    return None
+                user_rating = self.item.userRating
+            else:
+                raise RuntimeError(f"Unsupported media type: {self.media_type}")
         else:
             user_rating = self.item.userRating
 


### PR DESCRIPTION
Implement:
- https://github.com/Taxel/PlexTraktSync/pull/1239#issuecomment-1331285446

Fetches show ratings for episodes, as the `episode.userRating` filter will return shows that have ratings. So skip episodes that are not in that list. For episodes whose show is in the list, every item will be reloaded by python-plexapi:

```
2022-11-29 23:38:32,531 DEBUG[plexapi]:Reloading Episode 'Bla Bla' for attr 'userRating'
```

so shows having just one episode with userRating will be still slow.