### PR TITLE
Refactor Plex ratings logic into PlexRatings class

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@
 !/plextraktsync/config/*.py
 !/plextraktsync/decorators/*.py
 !/plextraktsync/logger/*.py
+!/plextraktsync/plex/*.py
 !/plextraktsync/servers.default.yml
 !/plextraktsync/util/*.py

--- a/plextraktsync/plex/PlexRatings.py
+++ b/plextraktsync/plex/PlexRatings.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from plextraktsync.decorators.flatten import flatten_dict
+from plextraktsync.decorators.memoize import memoize
+from plextraktsync.plex_api import PlexApi, PlexLibraryItem, PlexLibrarySection
+
+
+class PlexRatings:
+    plex: PlexApi
+
+    def __init__(self, plex: PlexApi):
+        self.plex = plex
+
+    def get(self, m: PlexLibraryItem, show_id: int = None):
+        section_id = m.item.librarySectionID
+        media_type = m.media_type
+        section = self.plex.library_sections[section_id]
+        ratings = self.ratings(section, media_type)
+
+        if media_type in ["movies", "shows"]:
+            # For movies and shows, just return from the dict
+            user_rating = (
+                ratings[m.item.ratingKey] if m.item.ratingKey in ratings else None
+            )
+        elif media_type == "episodes":
+            # For episodes the ratings is just (show_id, show_rating) tuples
+            # if show id is not listed, return none, otherwise fetch from item itself
+            if show_id not in ratings:
+                return None
+            user_rating = m.item.userRating
+        else:
+            raise RuntimeError(f"Unsupported media type: {media_type}")
+
+        if user_rating is None:
+            return None
+
+        return int(user_rating)
+
+    @staticmethod
+    @memoize
+    @flatten_dict
+    def ratings(section: PlexLibrarySection, media_type: str):
+        key = {
+            "movies": "userRating",
+            "episodes": "episode.userRating",
+            "shows": "show.userRating",
+        }[media_type]
+
+        filters = {
+            "and": [
+                {f"{key}>>": -1},
+            ]
+        }
+
+        for item in section.search(filters=filters):
+            yield item.ratingKey, item.userRating

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -427,17 +427,6 @@ class PlexLibrarySection:
             return None
 
     @nocache
-    def find_with_rating(self):
-        key = "episode.userRating" if self.type == "show" else "userRating"
-        filters = {
-            "and": [
-                {f"{key}>>": -1},
-            ]
-        }
-
-        return self.section.search(filters=filters)
-
-    @nocache
     def search(self, **kwargs):
         return self.section.search(**kwargs)
 

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -92,25 +92,6 @@ class PlexGuid:
         return f"<PlexGuid:{self.guid}>"
 
 
-class PlexRatingCollection(dict):
-    def __init__(self, plex: PlexApi):
-        super().__init__()
-        self.plex = plex
-
-    def __missing__(self, section_id: int):
-        section = self.plex.library_sections[section_id]
-        ratings = self.ratings(section)
-        self[section_id] = ratings
-
-        return ratings
-
-    @flatten_dict
-    def ratings(self, section: PlexLibrarySection):
-        ratings = section.find_with_rating()
-        for item in ratings:
-            yield item.ratingKey, item.userRating
-
-
 class PlexAudioCodec:
     def match(self, codec):
         for key, regex in self.audio_codecs.items():

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -225,19 +225,7 @@ class PlexLibraryItem:
     @retry(retries=1)
     def rating(self, show_id: int = None):
         if self.plex is not None:
-            ratings = self.plex.ratings[self.item.librarySectionID]
-            if self.type in ["movie", "show"]:
-                user_rating = (
-                    ratings[self.item.ratingKey] if self.item.ratingKey in ratings else None
-                )
-            elif self.type == "episode":
-                # For episodes the ratings is just (show_id, show_rating) tuples
-                # if show id is not listed, return none, otherwise fetch from item itself
-                if show_id not in ratings:
-                    return None
-                user_rating = self.item.userRating
-            else:
-                raise RuntimeError(f"Unsupported media type: {self.media_type}")
+            return self.plex.ratings.get(self, show_id)
         else:
             user_rating = self.item.userRating
 
@@ -615,7 +603,9 @@ class PlexApi:
 
     @cached_property
     def ratings(self):
-        return PlexRatingCollection(self)
+        from plextraktsync.plex.PlexRatings import PlexRatings
+
+        return PlexRatings(self)
 
     @nocache
     @retry()

--- a/plextraktsync/plex_api.py
+++ b/plextraktsync/plex_api.py
@@ -469,6 +469,10 @@ class PlexLibrarySection:
         return self.section.search(filters=filters)
 
     @nocache
+    def search(self, **kwargs):
+        return self.section.search(**kwargs)
+
+    @nocache
     def find_by_id(self, id: Union[str, int]) -> Optional[Union[Movie, Show, Episode]]:
         try:
             return self.section.fetchItem(int(id))

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ packages =
     plextraktsync.config
     plextraktsync.decorators
     plextraktsync.logger
+    plextraktsync.plex
     plextraktsync.util
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
Improve https://github.com/Taxel/PlexTraktSync/pull/1242, shows ratings were not working.

Add PlexRatings class dealing with ratings. There's too much logic spewed around multiple places it's difficult to follow the logic anymore.