### PR TITLE
Fix TraktBatch not to send out batch immediately

### DIFF
--- a/plextraktsync/trakt_api.py
+++ b/plextraktsync/trakt_api.py
@@ -423,6 +423,9 @@ class TraktBatch:
         if self.queue_size() == 0:
             return
 
+        if not self.last_sent_time:
+            self.last_sent_time = time()
+
         elapsed = time() - self.last_sent_time
         if elapsed >= self.batch_delay or force is True:
             self.submit()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,38 +7,38 @@ from tests.conftest import factory, load_mock
 trakt = factory.trakt_api
 
 
-def test_batch_size_none():
+def test_batch_delay_none():
     response = load_mock("trakt_sync_collection_response.json")
-    b = TraktBatch(trakt)
-    b.trakt_sync_collection = Mock(return_value=response)
+    b = TraktBatch(trakt, "collection", add=True)
+    b.trakt_sync = Mock(return_value=response)
 
     assert b.queue_size() == 0
 
     request = load_mock("trakt_sync_collection_request.json")
     for media_type, items in request.items():
         for item in items:
-            b.add_to_collection(media_type, item)
+            b.add_to_items(media_type, item)
     assert b.queue_size() == 7
 
-    b.submit_collection()
+    b.submit()
     assert b.queue_size() == 0
-    assert b.trakt_sync_collection.call_count == 1
+    assert b.trakt_sync.call_count == 1
 
 
-def test_batch_size_1():
+def test_batch_delay_1():
     response = load_mock("trakt_sync_collection_response.json")
-    b = TraktBatch(trakt, batch_delay=1)
-    b.trakt_sync_collection = Mock(return_value=response)
+    b = TraktBatch(trakt, "collection", add=True, batch_delay=1)
+    b.trakt_sync = Mock(return_value=response)
 
     assert b.queue_size() == 0
 
     request = load_mock("trakt_sync_collection_request.json")
     for media_type, items in request.items():
         for item in items:
-            b.add_to_collection(media_type, item)
-    assert b.queue_size() == 0
-    assert b.trakt_sync_collection.call_count == 7
+            b.add_to_items(media_type, item)
+    assert b.queue_size() == 7
+    assert b.trakt_sync.call_count == 0
 
-    b.submit_collection()
+    b.submit()
     assert b.queue_size() == 0
-    assert b.trakt_sync_collection.call_count == 7
+    assert b.trakt_sync.call_count == 1


### PR DESCRIPTION
This fixes that on first call to batch() 1-size batch is sent out immediately without the time delay.

This came out when fixing `tests/test_batch.py` after changes from https://github.com/Taxel/PlexTraktSync/pull/869