### PR TITLE
Deprecate usage without command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Installing from GitHub is considered developer mode, and it's documented in
   - Enter `urn:ietf:wg:oauth:2.0:oob` as the redirect url
   - You can leave Javascript origins and the Permissions checkboxes blank
 
-- Run `plextraktsync sync`, the script will ask for missing credentials
+- Run `plextraktsync login`, the script will ask for missing credentials
 
   > **Note**
   > To setup the credentials in the Docker Container, refer to the [Run the Docker Container](#run-the-docker-container) section

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pipx upgrade PlexTraktSync
 to run:
 
 ```
-plextraktsync
+plextraktsync sync
 ```
 
 NOTE: `pipx` install will use OS specific paths for Config, Logs, Cache, see
@@ -112,6 +112,7 @@ version: '2'
 services:
   plextraktsync:
     image: ghcr.io/taxel/plextraktsync
+    command: sync
     container_name: plextraktsync
     restart: on-failure:2
     volumes:
@@ -127,7 +128,7 @@ services:
 To run sync:
 
 ```
-docker-compose run --rm plextraktsync
+docker-compose run --rm plextraktsync sync
 ```
 
 The container will stop after the sync is completed. Read Setup section to run
@@ -207,7 +208,7 @@ Installing from GitHub is considered developer mode, and it's documented in
   - Enter `urn:ietf:wg:oauth:2.0:oob` as the redirect url
   - You can leave Javascript origins and the Permissions checkboxes blank
 
-- Run `plextraktsync`, the script will ask for missing credentials
+- Run `plextraktsync sync`, the script will ask for missing credentials
 
   > **Note**
   > To setup the credentials in the Docker Container, refer to the [Run the Docker Container](#run-the-docker-container) section
@@ -227,7 +228,7 @@ Installing from GitHub is considered developer mode, and it's documented in
 
   ```
   $ crontab -e
-  0 */2 * * * $HOME/.local/bin/plextraktsync
+  0 */2 * * * $HOME/.local/bin/plextraktsync sync
   ```
 
   - Note the command in the example above may not immediately work. Use the `which plextraktsync` command to locate your system's plextraktsync executable file and update it accordingly.
@@ -256,6 +257,7 @@ services:
   plextraktsync:
     image: ghcr.io/taxel/plextraktsync:latest
     container_name: plextraktsync
+    command: sync
     volumes:
       - ./config:/app/config
 ```

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -49,6 +49,8 @@ def cli(ctx, version: bool):
         return
 
     if not ctx.invoked_subcommand:
+        logger = factory.logger
+        logger.warning('plextraktsync without command is deprecated. Executing "plextraktsync sync"')
         sync()
 
 


### PR DESCRIPTION
```
$ plextraktsync
WARNING  plextraktsync without command is deprecated. Executing "plextraktsync sync"
```

The technical reason for dropping support is because supporting it makes difficult to implement a cleanup handler for two commands (main and subcommand). Implementing Exception handler is already quite hackish:
- https://click.palletsprojects.com/en/8.1.x/exceptions/

Fixes: https://github.com/Taxel/PlexTraktSync/issues/780