### PR TITLE
Fix: Handle empty http_cache section

### DIFF
--- a/plextraktsync/config/Config.py
+++ b/plextraktsync/config/Config.py
@@ -66,7 +66,7 @@ class Config(ChangeNotifier, ConfigMergeMixin, dict):
     def http_cache(self):
         from plextraktsync.config.HttpCacheConfig import HttpCacheConfig
 
-        cache = self["http_cache"] if "http_cache" in self else {"policy": {}}
+        cache = self["http_cache"] if "http_cache" in self and self["http_cache"] else {"policy": {}}
 
         return HttpCacheConfig(**cache)
 

--- a/tests/mock_data/http_cache-1-entry.yml
+++ b/tests/mock_data/http_cache-1-entry.yml
@@ -1,0 +1,5 @@
+http_cache:
+  policy:
+    a: b
+
+# vim:ts=2:sw=2:et

--- a/tests/mock_data/http_cache-blank.yml
+++ b/tests/mock_data/http_cache-blank.yml
@@ -1,0 +1,6 @@
+something: false
+
+#http_cache:
+#  policy:
+
+# vim:ts=2:sw=2:et

--- a/tests/mock_data/http_cache-empty.yml
+++ b/tests/mock_data/http_cache-empty.yml
@@ -1,0 +1,4 @@
+http_cache:
+#  policy:
+
+# vim:ts=2:sw=2:et

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,24 @@ def test_sync_config():
     assert sync_config.plex_to_trakt["collection"] is False
 
 
+def test_http_config():
+    from tests.conftest import MOCK_DATA_DIR
+
+    config = Config()
+    config.config_yml = join(MOCK_DATA_DIR, "http_cache-blank.yml")
+    assert config.http_cache is not None
+
+    config = Config()
+    config.config_yml = join(MOCK_DATA_DIR, "http_cache-empty.yml")
+    assert config.http_cache is not None
+
+    config = Config()
+    config.config_yml = join(MOCK_DATA_DIR, "http_cache-1-entry.yml")
+    cache = config.http_cache
+    assert cache is not None
+    assert cache.policy["a"] == "b"
+
+
 def test_config():
     config = factory.config
 


### PR DESCRIPTION
Fixing https://github.com/Taxel/PlexTraktSync/pull/1221

Do not fail if user has config `http_cache` but no entries:

```yml
http_cache:
```