### PR TITLE
Refactor: Move sync options to global that are global options

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -40,8 +40,14 @@ def command():
 @click.option("--version", is_flag=True, help="Print version and exit")
 @click.option("--no-cache", is_flag=True, help="Disable cache in for Trakt HTTP requests")
 @click.option("--no-progressbar", is_flag=True, help="Disable progressbar")
+@click.option("--server", help="Plex Server name from servers.yml")
 @click.pass_context
-def cli(ctx, version: bool, no_cache: bool, no_progressbar: bool):
+def cli(ctx,
+        version: bool,
+        no_cache: bool,
+        no_progressbar: bool,
+        server: str,
+        ):
     """
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
@@ -54,6 +60,7 @@ def cli(ctx, version: bool, no_cache: bool, no_progressbar: bool):
     factory.run_config.update(
         cache=not no_cache,
         progressbar=not no_progressbar,
+        server=server,
     )
 
     if not ctx.invoked_subcommand:

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -39,8 +39,9 @@ def command():
 @click.group(invoke_without_command=True)
 @click.option("--version", is_flag=True, help="Print version and exit")
 @click.option("--no-cache", is_flag=True, help="Disable cache in for Trakt HTTP requests")
+@click.option("--no-progressbar", is_flag=True, help="Disable progressbar")
 @click.pass_context
-def cli(ctx, version: bool, no_cache: bool):
+def cli(ctx, version: bool, no_cache: bool, no_progressbar: bool):
     """
     Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
     """
@@ -52,6 +53,7 @@ def cli(ctx, version: bool, no_cache: bool):
 
     factory.run_config.update(
         cache=not no_cache,
+        progressbar=not no_progressbar,
     )
 
     if not ctx.invoked_subcommand:

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -40,12 +40,15 @@ def command():
 @click.option("--version", is_flag=True, help="Print version and exit")
 @click.option("--no-cache", is_flag=True, help="Disable cache in for Trakt HTTP requests")
 @click.option("--no-progressbar", is_flag=True, help="Disable progressbar")
+@click.option("--batch-delay", default=5, show_default=True,
+              help="Time in seconds between each collection batch submit to Trakt")
 @click.option("--server", help="Plex Server name from servers.yml")
 @click.pass_context
 def cli(ctx,
         version: bool,
         no_cache: bool,
         no_progressbar: bool,
+        batch_delay: int,
         server: str,
         ):
     """
@@ -60,6 +63,7 @@ def cli(ctx,
     factory.run_config.update(
         cache=not no_cache,
         progressbar=not no_progressbar,
+        batch_delay=batch_delay,
         server=server,
     )
 

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -194,8 +194,6 @@ def plex_login():
     "--batch-delay",
     "batch_delay",
     type=int,
-    default=5,
-    show_default=True,
     help="Time in seconds between each collection batch submit to trakt",
 )
 @click.option(

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -29,10 +29,12 @@ def sync(
     shows = sync_option in ["all", "tv", "shows"]
 
     config = factory.run_config.update(
-        server=server,
         batch_delay=batch_delay,
         dry_run=dry_run,
     )
+    if server:
+        logger.warning('"plextraktsync sync --server=<name>" is deprecated use "plextraktsync --server=<name> sync"')
+        config.update(server=server)
     if no_progress_bar:
         logger.warning('"plextraktsync sync --no-progress-bar" is deprecated use "plextraktsync --no-progressbar sync"')
         config.update(progress=False)

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -29,7 +29,6 @@ def sync(
     shows = sync_option in ["all", "tv", "shows"]
 
     config = factory.run_config.update(
-        batch_delay=batch_delay,
         dry_run=dry_run,
     )
     if server:
@@ -38,6 +37,11 @@ def sync(
     if no_progress_bar:
         logger.warning('"plextraktsync sync --no-progress-bar" is deprecated use "plextraktsync --no-progressbar sync"')
         config.update(progress=False)
+    if batch_delay:
+        logger.warning(
+            '"plextraktsync sync --batch-delay=<number>" is deprecated use "plextraktsync ---batch-delay=<number> sync"'
+        )
+        config.update(batch_delay=batch_delay)
 
     ensure_login()
     wc = factory.walk_config.update(movies=movies, shows=shows)

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -32,8 +32,11 @@ def sync(
         server=server,
         batch_delay=batch_delay,
         dry_run=dry_run,
-        progressbar=not no_progress_bar,
     )
+    if no_progress_bar:
+        logger.warning('"plextraktsync sync --no-progress-bar" is deprecated use "plextraktsync --no-progressbar sync"')
+        config.update(progress=False)
+
     ensure_login()
     wc = factory.walk_config.update(movies=movies, shows=shows)
     w = factory.walker


### PR DESCRIPTION
New global options:
- `plextraktsync --no-progressbar`
- `plextraktsync --batch-delay`
- `plextraktsync --server`

The `sync` command options are deprecated:
- `plextraktsync sync --no-progress-bar`
- `plextraktsync sync --batch-delay`
- `plextraktsync sync --server`
