### PR TITLE
Refactor: Use atexit for shutdown handlers

### DIFF
--- a/plextraktsync/__main__.py
+++ b/plextraktsync/__main__.py
@@ -13,6 +13,6 @@ Usage: {sys.executable} -m plextraktsync {' '.join(sys.argv[1:])}
     )
     sys.exit(2)
 
-from plextraktsync.cli import main
+from plextraktsync.cli import cli
 
-main()
+cli()

--- a/plextraktsync/trakt/TraktBatch.py
+++ b/plextraktsync/trakt/TraktBatch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -27,8 +28,7 @@ class TraktBatch:
         self.trakt = trakt
         self.items = defaultdict(list)
         self.timer = timer
-        if cleanup:
-            cleanup.add(self.flush)
+        atexit.register(self.flush)
 
     @rate_limit()
     @time_limit()

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ exclude =
 
 [options.entry_points]
 console_scripts =
-    plextraktsync = plextraktsync.cli:main
+    plextraktsync = plextraktsync.cli:cli
 
 [options.data_files]
 . =


### PR DESCRIPTION
Looks like we can use builtin `atexit` for shutdown handlers:
- https://docs.python.org/3/library/atexit.html#module-atexit

So the code from this PR is not really needed:
- https://github.com/Taxel/PlexTraktSync/pull/1269