### PR TITLE
Bugreport: remove required for downgrade checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,6 @@ body:
         - label: I have checked if identical issue already exists
           required: true
         - label: I have tried downgrading to find version that can be used as a workaround
-          required: true
 
   - type: textarea
     id: description


### PR DESCRIPTION
So users can fill the issue without lying about it.

Problem: Users check the box just. to get the issue going, but they really didn't do any downgrade attempts:
- https://github.com/Taxel/PlexTraktSync/issues/1314