### PR TITLE
Feature: Add config for media_progressbar

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -214,17 +214,20 @@ class WatchStateUpdater:
         state = event.state
 
         if state == "playing":
-            self.progressbar.play(m.plex, percent)
+            if self.progressbar:
+                self.progressbar.play(m.plex, percent)
 
             return self.scrobblers[tm].update(percent)
 
         if state == "paused":
-            self.progressbar.pause(m.plex, percent)
+            if self.progressbar:
+                self.progressbar.pause(m.plex, percent)
 
             return self.scrobblers[tm].pause(percent)
 
         if state == "stopped":
-            self.progressbar.stop(m.plex)
+            if self.progressbar:
+                self.progressbar.stop(m.plex)
 
             value = self.scrobblers[tm].stop(percent)
             del self.scrobblers[tm]

--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -125,14 +125,11 @@ class WatchStateUpdater:
         else:
             self.username_filter = None
         self.sessions = SessionCollection(plex) if self.username_filter else None
+        self.progressbar = ProgressBar() if config["watch"]["media_progressbar"] else None
 
     @cached_property
     def scrobblers(self):
         return ScrobblerCollection(self.trakt, self.threshold)
-
-    @cached_property
-    def progressbar(self):
-        return ProgressBar()
 
     def find_by_key(self, key: str, reload=False):
         pm: PlexLibraryItem = self.plex.fetch_item(key)

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -71,6 +71,8 @@ watch:
   scrobble_threshold: 80
   # true to scrobble only what's watched by you, false for all your PMS users
   username_filter: true
+  # Show the progress bar of played media in terminal
+  media_progressbar: true
 
 xbmc-providers:
   movies: imdb


### PR DESCRIPTION
Add an option to turn it off. It corrupts tmux session on Debian 10, so it's rather annoying as it also makes scrolling also useless.

```yaml
watch:
  # Show the progress bar of played media in terminal
  media_progressbar: true
```