### PR TITLE
Use TraktBatch in clear_collections

### DIFF
--- a/plextraktsync/commands/clear_collections.py
+++ b/plextraktsync/commands/clear_collections.py
@@ -13,9 +13,9 @@ def clear_collections(confirm, dry_run):
     for movie in trakt.movie_collection:
         logger.info(f"Deleting: {movie}")
         if not dry_run:
-            trakt.remove_from_library(movie)
+            trakt.remove_from_collection(movie)
 
     for show in trakt.show_collection:
         logger.info(f"Deleting: {show}")
         if not dry_run:
-            trakt.remove_from_library(show)
+            trakt.remove_from_collection(show)


### PR DESCRIPTION
<del>
Updates code to use `TraktBatch`, so API requests to Trakt are sent in 5s batches. Old code sends each removal as a single request.
</del>

----

Update to use `trakt.remove_from_collection(movie)` rather deprecated `trakt.remove_from_library(movie)`.

Enable debug logging and see the `plextraktsync.log` what requests are made.

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/374