### PR TITLE
Reset cursor when watch command is aborted (ctrl+c)

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -80,6 +80,9 @@ class ProgressBar(dict):
         )
         progress.start()
 
+        import atexit
+        atexit.register(lambda: progress.stop())
+
         return progress
 
     def __missing__(self, m: PlexLibraryItem):


### PR DESCRIPTION
Refs:
- https://github.com/Taxel/PlexTraktSync/pull/1324
- https://stackoverflow.com/a/72304083/2314626