### PR TITLE
Feature: Add TraktApi.remove_from_collection method

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -125,7 +125,7 @@ class Media:
         self.trakt_api.add_to_collection(self.trakt, self.plex, batch=batch)
 
     def remove_from_collection(self):
-        self.trakt_api.remove_from_library(self.trakt)
+        self.trakt_api.remove_from_collection(self.trakt)
 
     def add_to_trakt_watchlist(self, batch=False):
         self.trakt_api.add_to_watchlist(self.trakt, batch=batch)

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -6,6 +6,7 @@ import trakt
 import trakt.movies
 import trakt.sync
 import trakt.users
+from deprecated import deprecated
 from trakt.errors import ForbiddenException, OAuthException
 
 from plextraktsync import pytrakt_extensions
@@ -84,11 +85,9 @@ class TraktApi:
     def show_collection(self):
         return self.me.show_collection
 
-    @rate_limit()
-    @time_limit()
-    @retry()
+    @deprecated("Use remove_from_collection")
     def remove_from_library(self, media: TraktMedia):
-        media.remove_from_library()
+        self.remove_from_collection(media)
 
     def remove_from_collection(self, m: TraktMedia):
         if m.media_type in ["movies", "shows"]:

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -90,6 +90,18 @@ class TraktApi:
     def remove_from_library(self, media: TraktMedia):
         media.remove_from_library()
 
+    def remove_from_collection(self, m: TraktMedia):
+        if m.media_type in ["movies", "shows"]:
+            item = dict(
+                title=m.title,
+                year=m.year,
+                **m.ids,
+            )
+        else:
+            raise ValueError(f"Unsupported media type: {m.media_type}")
+
+        self.queue.remove_from_collection((m.media_type, item))
+
     @cached_property
     def movie_collection_set(self):
         return set(map(lambda m: m.trakt, self.movie_collection))


### PR DESCRIPTION
`trakt_api.remove_from_library` from wasn't using queue like the other ones defined in Queue class. Add new `trakt_api.remove_from_collection` method and deprecate `trakt_api.remove_from_library`

Refs:
- https://github.com/Taxel/PlexTraktSync/pull/1326#issuecomment-1367557046