### PR TITLE
Feature: Add --sync=watchlist option

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -177,7 +177,7 @@ def plex_login():
 @click.option(
     "--sync",
     "sync_option",
-    type=click.Choice(["all", "movies", "tv", "shows"], case_sensitive=False),
+    type=click.Choice(["all", "movies", "tv", "shows", "watchlist"], case_sensitive=False),
     default="all",
     show_default=True,
     help="Specify what to sync",

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -32,6 +32,7 @@ def sync(
 
     movies = sync_option in ["all", "movies"]
     shows = sync_option in ["all", "tv", "shows"]
+    watchlist = sync_option in ["all", "watchlist"]
 
     config = factory.run_config.update(
         dry_run=dry_run,
@@ -49,7 +50,7 @@ def sync(
         config.update(batch_delay=batch_delay)
 
     ensure_login()
-    wc = factory.walk_config.update(movies=movies, shows=shows)
+    wc = factory.walk_config.update(movies=movies, shows=shows, watchlist=watchlist)
     w = factory.walker
 
     if ids:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -153,7 +153,7 @@ class Sync:
             for show in walker.walk_shows(shows, title="Syncing show ratings"):
                 self.sync_ratings(show, dry_run=dry_run)
 
-        if self.sync_wl or self.config.sync_liked_lists:
+        if walker.config.walk_watchlist and (self.sync_wl or self.config.sync_liked_lists):
             if is_partial:
                 logger.warning("Partial walk, watchlist and/or liked list updating was skipped")
             else:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -153,15 +153,16 @@ class Sync:
             for show in walker.walk_shows(shows, title="Syncing show ratings"):
                 self.sync_ratings(show, dry_run=dry_run)
 
-        if walker.config.walk_watchlist and (self.sync_wl or self.config.sync_liked_lists):
+        if self.config.update_plex_wl_as_pl or self.config.sync_liked_lists:
             if is_partial:
-                logger.warning("Partial walk, watchlist and/or liked list updating was skipped")
+                logger.warning("Running partial library sync. Liked lists won't update because it needs full library sync.")
             else:
-                with measure_time("Updated watchlist and/or liked list"):
-                    if self.config.update_plex_wl_as_pl or self.config.sync_liked_lists:
-                        self.update_playlists(listutil, dry_run=dry_run)
-                    if self.sync_wl:
-                        self.sync_watchlist(walker, dry_run=dry_run)
+                with measure_time("Updated liked list"):
+                    self.update_playlists(listutil, dry_run=dry_run)
+
+        if walker.config.walk_watchlist and self.sync_wl:
+            with measure_time("Updated watchlist"):
+                self.sync_watchlist(walker, dry_run=dry_run)
 
     def update_playlists(self, listutil: TraktListUtil, dry_run=False):
         if dry_run:

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -78,6 +78,9 @@ class WalkConfig:
         if self.walk_movies or self.walk_shows:
             return True
 
+        if self.walk_watchlist:
+            return True
+
         return False
 
 

--- a/plextraktsync/walker.py
+++ b/plextraktsync/walker.py
@@ -23,20 +23,24 @@ if TYPE_CHECKING:
 class WalkConfig:
     walk_movies = True
     walk_shows = True
+    walk_watchlist = True
     library = []
     show = []
     movie = []
     id = []
 
-    def __init__(self, movies=True, shows=True):
+    def __init__(self, movies=True, shows=True, watchlist=True):
         self.walk_movies = movies
         self.walk_shows = shows
+        self.walk_watchlist = watchlist
 
-    def update(self, movies=None, shows=None):
+    def update(self, movies=None, shows=None, watchlist=None):
         if movies is not None:
             self.walk_movies = movies
         if shows is not None:
             self.walk_shows = shows
+        if watchlist is not None:
+            self.walk_watchlist = watchlist
 
         return self
 


### PR DESCRIPTION
Allows syncing only watchlist:

```
$ plextraktsync sync --sync=watchlist
```

does not work when `watchlist_as_playlist` is enabled.

syncing plain watchlist, does not need to walk through libraries, so can work fine in partial mode or no library walk mode at all.