### PR TITLE
Feature: Allow filtering logs by name

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -36,6 +36,12 @@ logging:
 #    - message: "because provider local has no external Id"
 #    - message: "because provider none has no external Id"
 #    - message: "Retry using search for specific Plex Episode"
+#    # Filter out messages by requests_cache
+#    - name: requests_cache.backends
+#    - name: requests_cache.backends.base
+#    - name: requests_cache.backends.sqlite
+#    - name: requests_cache.policy.actions
+#    - name: requests_cache.session
 
 # settings for 'sync' command (default)
 sync:

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -17,6 +17,16 @@ logging:
   console_time: false
   debug: false
   filename: plextraktsync.log
+  # Additional logger names to apply filtering
+  filter_loggers:
+#    - plexapi
+#    - requests_cache.backends
+#    - requests_cache.backends.base
+#    - requests_cache.backends.sqlite
+#    - requests_cache.policy.actions
+#    - requests_cache.session
+#    - trakt.core
+#    - urllib3.connectionpool
   filter:
 #    # Filter out all messages with level WARNING
 #    - level: WARNING

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -210,7 +210,11 @@ class Factory:
         config = self.config
 
         from plextraktsync.logger.filter import LoggerFilter
-        logger.addFilter(LoggerFilter(config["logging"]["filter"], logger))
+        filter = LoggerFilter(config["logging"]["filter"], logger)
+        logger.addFilter(filter)
+
+        for name in config["logging"]["filter_loggers"] or []:
+            self.logging.getLogger(name).addFilter(filter)
 
         return logger
 

--- a/plextraktsync/factory.py
+++ b/plextraktsync/factory.py
@@ -208,12 +208,23 @@ class Factory:
     def logger(self):
         logger = self.logging.getLogger("PlexTraktSync")
         config = self.config
+        loggers = [
+            "PlexTraktSync",
+            "PlexTraktSync.BackgroundTask",
+            "PlexTraktSync.EventDispatcher",
+            "PlexTraktSync.PlexServerConnection",
+            "PlexTraktSync.ScrobblerProxy",
+            "PlexTraktSync.Timer",
+            "PlexTraktSync.TraktBatchWorker",
+            "PlexTraktSync.WatchStateUpdater",
+            "PlexTraktSync.WebSocketListener",
+        ]
+        loggers.extend(config["logging"]["filter_loggers"] or [])
 
         from plextraktsync.logger.filter import LoggerFilter
         filter = LoggerFilter(config["logging"]["filter"], logger)
-        logger.addFilter(filter)
 
-        for name in config["logging"]["filter_loggers"] or []:
+        for name in loggers:
             self.logging.getLogger(name).addFilter(filter)
 
         return logger

--- a/plextraktsync/logger/filter.py
+++ b/plextraktsync/logger/filter.py
@@ -61,6 +61,12 @@ class LoggerFilter(Filter):
                     matched = True
                 else:
                     continue
+            # Filter by name
+            if rule.name:
+                if rule.name == record.name:
+                    matched = True
+                else:
+                    continue
             # Filter by message
             if rule.message:
                 if rule.message in message:

--- a/plextraktsync/logger/filter.py
+++ b/plextraktsync/logger/filter.py
@@ -17,6 +17,8 @@ class FilterRule:
     Structure to hold log filters
     """
 
+    # filter by name
+    name: str = None
     # filter by level
     level: bool = False
     # filter by message

--- a/plextraktsync/logger/filter.py
+++ b/plextraktsync/logger/filter.py
@@ -28,16 +28,15 @@ class LoggerFilter(Filter):
     def __init__(self, rules: List[Dict], logger: Logger):
         super().__init__()
         self.logger = logger
-        self._rules = rules or []
+        self.rules = self.build_rules(rules or [])
 
     @cached_property
     def nrules(self):
         return len(self.rules)
 
-    @cached_property
-    def rules(self):
+    def build_rules(self, rules):
         filters = []
-        for rule in self._rules:
+        for rule in rules:
             try:
                 f = FilterRule(**rule)
             except TypeError as e:


### PR DESCRIPTION
This turns off all logs for typical "sync" command run :)

```yml
  # Additional logger names to apply filtering
  filter_loggers:
    - plexapi
    - requests_cache.backends
    - requests_cache.backends.base
    - requests_cache.backends.sqlite
    - requests_cache.policy.actions
    - requests_cache.session
    - trakt.core
    - urllib3.connectionpool
  filter:
    - name: PlexTraktSync
    - name: PlexTraktSync.PlexServerConnection
    - name: plexapi
    - name: requests_cache.backends
    - name: requests_cache.backends.base
    - name: requests_cache.backends.sqlite
    - name: requests_cache.policy.actions
    - name: trakt.core
    - name: urllib3.connectionpool
```