### PR TITLE
Set some cache to responses that can generate 304 response

### DIFF
--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -35,16 +35,23 @@ class HttpCacheConfig:
         "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "*.trakt.tv/shows/*/seasons?extended=episodes": "1m",
         "*.trakt.tv/sync/collection/shows": "1m",
-        "*.trakt.tv/sync/watched/shows": "1m",
         "*.trakt.tv/users/*/collection/movies?extended=metadata": "1m",
         "*.trakt.tv/users/*/collection/movies": DO_NOT_CACHE,
         "*.trakt.tv/users/*/collection/shows": "1m",
         "*.trakt.tv/users/*/ratings/episodes": "1m",
         "*.trakt.tv/users/*/ratings/shows": "1m",
         "*.trakt.tv/users/*/ratings/movies": "1m",
-        "*.trakt.tv/users/*/watched/movies": "1m",
-        "*.trakt.tv/users/*/watchlist/movies": "1m",
-        "*.trakt.tv/users/*/watchlist/shows": "1m",
+
+        # Keep watched status cached, but fresh
+        "*.trakt.tv/sync/watched/shows": "1s",
+        "*.trakt.tv/users/*/watched/movies": "1s",
+
+        # Watchlist better be fresh for next run
+        "*.trakt.tv/users/*/watchlist/movies": "1s",
+        "*.trakt.tv/users/*/watchlist/shows": "1s",
+        "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "1s",
+        "metadata.provider.plex.tv/library/sections/watchlist/all": "1s",
+
         "*.trakt.tv/users/likes/lists": DO_NOT_CACHE,
         "*.trakt.tv/users/me": DO_NOT_CACHE,
 
@@ -52,8 +59,6 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*/userState": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/metadata/*?*includeUserState=1": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
-        "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "1m",
-        "metadata.provider.plex.tv/library/sections/watchlist/all": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=movies&includeMetadata=1": "1h",
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=tv&includeMetadata=1": "1h",
         # plex account

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -33,6 +33,7 @@ class HttpCacheConfig:
     default_policy = {
         # Requests matching these patterns will not be cached
         "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
+        "*.trakt.tv/shows/*/seasons?extended=episodes": "1m",
         "*.trakt.tv/sync/collection/shows": "1m",
         "*.trakt.tv/sync/watched/shows": "1m",
         "*.trakt.tv/users/*/collection/movies?extended=metadata": "1m",

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -32,8 +32,8 @@ class HttpCacheConfig:
 
     default_policy = {
         # Requests matching these patterns will not be cached
-        "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "*.trakt.tv/shows/*/seasons?extended=episodes": "1m",
+        "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "*.trakt.tv/sync/collection/shows": "1m",
         "*.trakt.tv/users/*/collection/movies?extended=metadata": "1m",
         "*.trakt.tv/users/*/collection/movies": DO_NOT_CACHE,

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -33,14 +33,17 @@ class HttpCacheConfig:
     default_policy = {
         # Requests matching these patterns will not be cached
         "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
-        "*.trakt.tv/sync/collection/shows": DO_NOT_CACHE,
-        "*.trakt.tv/sync/watched/shows": DO_NOT_CACHE,
+        "*.trakt.tv/sync/collection/shows": "1m",
+        "*.trakt.tv/sync/watched/shows": "1m",
+        "*.trakt.tv/users/*/collection/movies?extended=metadata": "1m",
         "*.trakt.tv/users/*/collection/movies": DO_NOT_CACHE,
-        "*.trakt.tv/users/*/collection/shows": DO_NOT_CACHE,
-        "*.trakt.tv/users/*/ratings/*": DO_NOT_CACHE,
-        "*.trakt.tv/users/*/watched/movies": DO_NOT_CACHE,
-        "*.trakt.tv/users/*/watchlist/movies": DO_NOT_CACHE,
-        "*.trakt.tv/users/*/watchlist/shows": DO_NOT_CACHE,
+        "*.trakt.tv/users/*/collection/shows": "1m",
+        "*.trakt.tv/users/*/ratings/episodes": "1m",
+        "*.trakt.tv/users/*/ratings/shows": "1m",
+        "*.trakt.tv/users/*/ratings/movies": "1m",
+        "*.trakt.tv/users/*/watched/movies": "1m",
+        "*.trakt.tv/users/*/watchlist/movies": "1m",
+        "*.trakt.tv/users/*/watchlist/shows": "1m",
         "*.trakt.tv/users/likes/lists": DO_NOT_CACHE,
         "*.trakt.tv/users/me": DO_NOT_CACHE,
 
@@ -50,7 +53,7 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
         "metadata.provider.plex.tv/library/sections/watchlist/all": DO_NOT_CACHE,
         # plex account
-        "plex.tv/users/account": DO_NOT_CACHE,
+        "plex.tv/users/account": "1m",
 
         # Plex patterns
         # Ratings search

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -31,7 +31,6 @@ class HttpCacheConfig:
     }
 
     default_policy = {
-        # Requests matching these patterns will not be cached
         "*.trakt.tv/shows/*/seasons?extended=episodes": 28800,
         "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "*.trakt.tv/sync/collection/shows": "1m",

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -61,7 +61,9 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=movies&includeMetadata=1": "1h",
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=tv&includeMetadata=1": "1h",
-        # plex account
+
+        # Plex account
+        # Cache for some time, this activates 304 responses
         "plex.tv/users/account": "1m",
 
         # Plex patterns

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -53,6 +53,8 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
         "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "1m",
         "metadata.provider.plex.tv/library/sections/watchlist/all": DO_NOT_CACHE,
+        "metadata.provider.plex.tv/library/search?query=*&searchTypes=movies&includeMetadata=1": "1h",
+        "metadata.provider.plex.tv/library/search?query=*&searchTypes=tv&includeMetadata=1": "1h",
         # plex account
         "plex.tv/users/account": "1m",
 

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -32,7 +32,7 @@ class HttpCacheConfig:
 
     default_policy = {
         # Requests matching these patterns will not be cached
-        "*.trakt.tv/shows/*/seasons?extended=episodes": "1m",
+        "*.trakt.tv/shows/*/seasons?extended=episodes": 28800,
         "*.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "*.trakt.tv/sync/collection/shows": "1m",
         "*.trakt.tv/users/*/collection/movies?extended=metadata": "1m",

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -61,6 +61,9 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=movies&includeMetadata=1": "1h",
         "metadata.provider.plex.tv/library/search?query=*&searchTypes=tv&includeMetadata=1": "1h",
+        # https://web.dev/stale-while-revalidate/
+        # cache-control: max-age=0,stale-while-revalidate=86400
+        "metadata.provider.plex.tv/": 86400,
 
         # Plex account
         # Cache for some time, this activates 304 responses

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -51,6 +51,7 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/metadata/*/userState": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/metadata/*?*includeUserState=1": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/metadata/*": LONG_EXPIRY,
+        "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "1m",
         "metadata.provider.plex.tv/library/sections/watchlist/all": DO_NOT_CACHE,
         # plex account
         "plex.tv/users/account": "1m",

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -108,6 +108,7 @@ class Factory:
 
         return CachedSession(
             cache_name=self.config.cache_path,
+            cache_control=True,
             urls_expire_after=urls_expire_after,
         )
 


### PR DESCRIPTION
Cache for some time, this activates 304 responses, need some cache value to be able to compare and make conditional requests.

Commands to expire existing cache (Not needed as previously these were not cached at all). Replace `*` with your trakt account.

```sh
plextraktsync cache --expire https://plex.tv/users/account
plextraktsync cache --expire https://api-v2launch.trakt.tv/sync/collection/shows
plextraktsync cache --expire https://api-v2launch.trakt.tv/sync/watched/shows
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/collection/movies
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/ratings/episodes
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/ratings/movies
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/ratings/shows
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/watched/movies
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/watchlist/movies
plextraktsync cache --expire https://api-v2launch.trakt.tv/users/*/watchlist/shows
```