### PR TITLE
Feature: Add sync.plex_to_trakt.clear_collected config (for Movies only)

### DIFF
--- a/plextraktsync/commands/clear_collections.py
+++ b/plextraktsync/commands/clear_collections.py
@@ -11,16 +11,15 @@ def clear_collections(confirm: bool, dry_run: bool, collection: str):
         return
 
     trakt = factory.trakt_api
-
     movies = collection in ["all", "movies"]
     shows = collection in ["all", "shows"]
 
     for movie in trakt.movie_collection if movies else []:
-        logger.info(f"Deleting: {movie}")
+        logger.info(f"Deleting from Trakt: {movie}")
         if not dry_run:
             trakt.remove_from_collection(movie)
 
     for show in trakt.show_collection if shows else []:
-        logger.info(f"Deleting: {show}")
+        logger.info(f"Deleting from Trakt: {show}")
         if not dry_run:
             trakt.remove_from_collection(show)

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -47,6 +47,8 @@ logging:
 sync:
   plex_to_trakt:
     collection: true
+    # Clear collected state of items not present in Plex
+    clear_collected: false
     ratings: true
     watched_status: true
     # If plex_to_trakt watchlist=false and trakt_to_plex watchlist=true

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -122,6 +122,9 @@ class Sync:
         listutil = TraktListUtil()
         is_partial = walker.is_partial
 
+        if is_partial and self.config.clear_collected:
+            logger.warning("Running partial library sync. Clear collected will be disabled.")
+
         if self.config.update_plex_wl_as_pl:
             if is_partial:
                 logger.warning("Running partial library sync. Watchlist as playlist won't update because it needs full library sync.")

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -56,6 +56,10 @@ class SyncConfig:
         return self.trakt_to_plex["watchlist"] or self.plex_to_trakt["watchlist"]
 
     @cached_property
+    def clear_collected(self):
+        return self.plex_to_trakt["collection"] and self["plex_to_trakt"]["clear_collected"]
+
+    @cached_property
     def sync_watched_status(self):
         return (
             self.trakt_to_plex["watched_status"] or self.plex_to_trakt["watched_status"]

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -142,12 +142,18 @@ class Sync:
                     listutil.addList(lst["listid"], lst["listname"])
 
         if self.config.need_library_walk:
+            movie_trakt_ids = set()
             for movie in walker.find_movies():
                 self.sync_collection(movie, dry_run=dry_run)
                 self.sync_ratings(movie, dry_run=dry_run)
                 self.sync_watched(movie, dry_run=dry_run)
                 if not is_partial:
                     listutil.addPlexItemToLists(movie)
+                    if self.config.clear_collected:
+                        movie_trakt_ids.add(movie.trakt_id)
+
+            if movie_trakt_ids:
+                self.clear_collected(self.trakt.movie_collection, movie_trakt_ids)
 
             shows = set()
             for episode in walker.find_episodes():

--- a/plextraktsync/trakt/trakt_set.py
+++ b/plextraktsync/trakt/trakt_set.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Set
+
+    from plextraktsync.trakt.types import TraktMedia
+
+
+def trakt_set(collection: Iterable[TraktMedia]) -> Set[int]:
+    """
+    Create set of trakt_id's from collection
+    """
+    return set(map(lambda m: m.trakt, collection))


### PR DESCRIPTION
Implementation for:
- https://github.com/Taxel/PlexTraktSync/issues/374#issuecomment-1380076905

```yml
sync:
  plex_to_trakt:
    collection: true
    # Clear collected state of items not present in Plex
    clear_collected: true
```

This configuration enables deletion of movies from Trakt that are no longer present in Plex.

Must do full collection sync for this to be applied:

```
plextraktsync sync
```

Shows (or episodes) not implemented yet:
- https://github.com/Taxel/PlexTraktSync/issues/374#issuecomment-1382904372