### PR TITLE
Set python_versions in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,7 @@ requests = "==2.28.2"
 requests-cache = "==0.9.7"
 requests-oauthlib = {version="==1.3.1", python_version=">='3.4'"}
 rich = "==13.0.1"
+six = {version="==1.16.0", python_version=">='3.4'"}
 tqdm = "==4.64.1"
 urllib3 = "==1.26.14"
 websocket-client = "==1.4.2"

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ deprecated = "==1.2.13"
 idna = {version="==3.4", python_version=">='3.5'"}
 inquirerpy = "==0.3.4"
 oauthlib = "==3.2.2"
+pfzy = {version="==0.3.4", python_version=">='3.7'"}
 plexapi = "==4.13.2"
 prompt-toolkit = "==3.0.36"
 pygments = "==2.14.0"

--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ tqdm = "==4.64.1"
 url-normalize = {version="==1.4.3", python_version=">='3.6'"}
 urllib3 = "==1.26.14"
 websocket-client = "==1.4.2"
+wrapt = {version="==1.14.1", python_version=">='3.5'"}
 
 [requires]
 python_version = "3"

--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ pytrakt = "==3.4.17"
 pyyaml = "==6.0"
 requests = "==2.28.2"
 requests-cache = "==0.9.7"
+requests-oauthlib = {version="==1.3.1", python_version=">='3.4'"}
 rich = "==13.0.1"
 tqdm = "==4.64.1"
 urllib3 = "==1.26.14"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 appdirs = "==1.4.4"
 attrs = "==22.2.0"
-"backports.cached-property" = "==1.0.2"
+"backports.cached-property" = {version="==1.0.2", python_version="<='3.7'"}
 certifi = "==2022.12.7"
 charset-normalizer = "==3.0.1"
 click = "==8.1.3"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ certifi = "==2022.12.7"
 charset-normalizer = "==3.0.1"
 click = "==8.1.3"
 deprecated = "==1.2.13"
+idna = {version="==3.4", python_version=">='3.5'"}
 inquirerpy = "==0.3.4"
 oauthlib = "==3.2.2"
 plexapi = "==4.13.2"

--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ requests-oauthlib = {version="==1.3.1", python_version=">='3.4'"}
 rich = "==13.0.1"
 six = {version="==1.16.0", python_version=">='3.4'"}
 tqdm = "==4.64.1"
+url-normalize = {version="==1.4.3", python_version=">='3.6'"}
 urllib3 = "==1.26.14"
 websocket-client = "==1.4.2"
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 appdirs = "==1.4.4"
 attrs = "==22.2.0"
 "backports.cached-property" = {version="==1.0.2", python_version="<='3.7'"}
+cattrs = {version="==22.2.0", python_version=">='3.7'"}
 certifi = "==2022.12.7"
 charset-normalizer = "==3.0.1"
 click = "==8.1.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e0a562e0c610762c1cd10dfede647b0ba0049b50ca348f59378106cdb691904a"
+            "sha256": "caa4942919be3cbd957be666d0e43a8d668f5d89466954150f9965de73a3d723"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -204,7 +204,8 @@
                 "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96",
                 "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.3.4"
         },
         "plexapi": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "df157776ca839e71d2f2c4b859bcba758f010e5b7e47c16066559720692db600"
+            "sha256": "fcfc097f0e38879f1f68d476ba89c39db1f721bc25707ae45ea6f815b1f5d021"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -459,7 +459,8 @@
                 "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
                 "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "index": "pypi",
+            "markers": "python_version >= '3.5'",
             "version": "==1.14.1"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f587cf92cbd24ea6f859b0d8e6be6a7bb035129aeb392d3e5696133aa525883"
+            "sha256": "e0a562e0c610762c1cd10dfede647b0ba0049b50ca348f59378106cdb691904a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -179,6 +179,7 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8eeeeb70b6461d678392567a0a8868eb64ea31ebd283f44236043e337576f770"
+            "sha256": "ec8919e030fed4c97a8e9c3e3959f01e6aaad928ffc4964b6491cdc391a75fde"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -348,7 +348,8 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
+            "markers": "python_version >= '3.4'",
             "version": "==1.16.0"
         },
         "tqdm": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "08f00286dcea41af68263d736cb436dc550aeb39ba5664897b1a34c19e628e05"
+            "sha256": "fe0ad06f8c96044a83ee3f81adb53ce096463cb9fc91f9f9dc94e57af4d9cb1d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,7 +37,7 @@
                 "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd",
                 "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"
             ],
-            "index": "pypi",
+            "markers": "python_version <= '3.7'",
             "version": "==1.0.2"
         },
         "cattrs": {
@@ -202,7 +202,7 @@
                 "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96",
                 "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.3.4"
         },
         "plexapi": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "caa4942919be3cbd957be666d0e43a8d668f5d89466954150f9965de73a3d723"
+            "sha256": "8eeeeb70b6461d678392567a0a8868eb64ea31ebd283f44236043e337576f770"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -331,7 +331,8 @@
                 "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5",
                 "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
+            "markers": "python_version >= '3.4'",
             "version": "==1.3.1"
         },
         "rich": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fe0ad06f8c96044a83ee3f81adb53ce096463cb9fc91f9f9dc94e57af4d9cb1d"
+            "sha256": "8f587cf92cbd24ea6f859b0d8e6be6a7bb035129aeb392d3e5696133aa525883"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,6 +45,7 @@
                 "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21",
                 "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==22.2.0"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ec8919e030fed4c97a8e9c3e3959f01e6aaad928ffc4964b6491cdc391a75fde"
+            "sha256": "df157776ca839e71d2f2c4b859bcba758f010e5b7e47c16066559720692db600"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -365,7 +365,8 @@
                 "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2",
                 "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==1.4.3"
         },
         "urllib3": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ requests-cache==0.9.7
 requests-oauthlib==1.3.1; python_version >= '3.4'
 requests==2.28.2
 rich==13.0.1
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+six==1.16.0; python_version >= '3.4'
 tqdm==4.64.1
 url-normalize==1.4.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 urllib3==1.26.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ deprecated==1.2.13
 idna==3.4; python_version >= '3.5'
 inquirerpy==0.3.4
 oauthlib==3.2.2
-pfzy==0.3.4; python_version >= '3.7' and python_version < '4.0'
+pfzy==0.3.4; python_version >= '3.7'
 plexapi==4.13.2
 prompt-toolkit==3.0.36
 pygments==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ requests==2.28.2
 rich==13.0.1
 six==1.16.0; python_version >= '3.4'
 tqdm==4.64.1
-url-normalize==1.4.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+url-normalize==1.4.3; python_version >= '3.6'
 urllib3==1.26.14
 wcwidth==0.2.5
 websocket-client==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ deprecated==1.2.13
 idna==3.4; python_version >= '3.5'
 inquirerpy==0.3.4
 oauthlib==3.2.2
-pfzy==0.3.4; python_version >= '3.7' and python_version < '4'
+pfzy==0.3.4; python_version >= '3.7' and python_version < '4.0'
 plexapi==4.13.2
 prompt-toolkit==3.0.36
 pygments==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytimeparse==1.1.8
 pytrakt==3.4.17
 pyyaml==6.0
 requests-cache==0.9.7
-requests-oauthlib==1.3.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+requests-oauthlib==1.3.1; python_version >= '3.4'
 requests==2.28.2
 rich==13.0.1
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ url-normalize==1.4.3; python_version >= '3.6'
 urllib3==1.26.14
 wcwidth==0.2.5
 websocket-client==1.4.2
-wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wrapt==1.14.1; python_version >= '3.5'


### PR DESCRIPTION
This should generate more stable Pipfile.lock. But might not, dependabot is full of surprises.

Refs:
    - https://github.com/dependabot/dependabot-core/issues/6200
    - https://github.com/pypa/pipenv/issues/5569