### PR TITLE
Fix: Ensure username_filter gets username regardless what PLEX_USERNAME has

### DIFF
--- a/plextraktsync/watch/WatchStateUpdater.py
+++ b/plextraktsync/watch/WatchStateUpdater.py
@@ -37,7 +37,8 @@ class WatchStateUpdater:
             return None
 
         if self.plex.has_sessions():
-            return self.config["PLEX_USERNAME"]
+            # This must be username, not email
+            return self.plex.account.username
 
         self.logger.warning("No permission to access sessions, disabling username filter")
         return None


### PR DESCRIPTION
You may log in with email,  then filter username will go wrong.

NOTE: This may need `PLEX_OWNER_TOKEN` or `PLEX_ACCOUNT_TOKEN`, depending on setup. They may need to re-login for these to appear in `.env`