### PR TITLE
Fix AttributeError on inspect with no access to markers

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -64,7 +64,7 @@ def inspect_media(id: str):
             print(f"  Part {index}: [link=file://{quote_plus(part.file)}]{part.file}[/link]")
 
         print("Markers:")
-        for marker in pm.item.markers:
+        for marker in pm.markers:
             start = millisecondToHumanstr(marker.start)
             end = millisecondToHumanstr(marker.end)
             print(f"  {marker.type}: {start} - {end}")

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -136,6 +136,14 @@ class PlexLibraryItem:
         return self.date_value(self.item.addedAt)
 
     @property
+    def markers(self) -> List[MediaPart]:
+        try:
+            return self.item.markers
+        except AttributeError:
+            # If not enough access to server, the markers attribute is missing
+            return []
+
+    @property
     def parts(self) -> List[MediaPart]:
         item = self.plex.fetch_item(self.item.ratingKey)
         for media in item.item.media:


### PR DESCRIPTION
If not enough access to server, the markers attribute is missing.