### PR TITLE
Prefer trakt title over plex to avoid editionTitle extra request

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -43,10 +43,9 @@ class Media:
 
     @property
     def title(self):
-        if self.plex:
-            return self.plex.title
-
-        return f"{self.trakt.title} ({self.trakt.year})"
+        if self.trakt:
+            return f"{self.trakt.title} ({self.trakt.year})"
+        return self.plex.title
 
     @cached_property
     def media_type(self):


### PR DESCRIPTION
Every output of movie title in logs or console needs an extra request to Plex server to check the `editionTitle` and display it if available.
This PR removes this extra request by displaying trakt title instead.

Trakt movie title already contains edition title (Extended, Director's cut'...) :
```
https://trakt.tv/movies/the-lord-of-the-rings-the-fellowship-of-the-ring-extended-2001
https://trakt.tv/movies/star-wars-episode-v-the-empire-strikes-back-special-edition-1997-02-21
https://trakt.tv/movies/blade-runner-director-s-cut-702424
```

Note : [Multiple Editions](https://support.plex.tv/articles/multiple-editions/) for Plex movies is a Plex Pass feature.

fixes #1436