### PR TITLE
Set edition_title property without reloading Plex data

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -37,8 +37,8 @@ def inspect_media(id: str):
 
     media = pm.item
     print(f"Title: {media.title}")
-    if media.type == 'movie' and media.editionTitle:
-        print(f"Edition Title: {media.editionTitle}")
+    if media.type == 'movie' and pm.edition_title:
+        print(f"Edition Title: {pm.edition_title}")
     if pm.has_media:
         print(f"Media.Duration: {pm.duration}")
     print(f"Media.Type: '{media.type}'")

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -97,10 +97,17 @@ class PlexLibraryItem:
         return self.plex.library_sections[self.item.librarySectionID]
 
     @cached_property
+    def edition_title(self):
+        if self.type == "movie":
+            # Use __dict__ access to prevent reloads
+            return self.item.__dict__.get('editionTitle')
+        return None
+
+    @cached_property
     def title(self):
         value = self.item.title
-        if self.type == "movie" and self.item.editionTitle:
-            value = f"{value} ({self.item.editionTitle})"
+        if self.type == "movie" and self.edition_title:
+            value = f"{value} ({self.edition_title})"
 
         if self.type == "episode":
             value = f"{self.item.grandparentTitle}/{self.item.seasonEpisode}/{value}"


### PR DESCRIPTION
Extracted from #1437 

By default, plex item data is fully loaded from PMS if a requested attribute has value `None`.
`editionTitle` is an attribute printed out during sync and is almost always `None` for average movies.
This PR creates `edition_title` property (e.g.: director's cut, extended, special edition,...) for `PlexLibraryItem` without reloading data from Plex server.

refs:
- https://github.com/pkkid/python-plexapi/pull/1093
- https://support.plex.tv/articles/multiple-editions/

fixes #1436