### PR TITLE
Fix: Use basename when downloading

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -260,6 +260,12 @@ def watch():
     is_flag=True,
     help="Download only subtitles",
 )
+@click.option(
+    "--target",
+    help="Download directory",
+    default=".",
+    show_default=True,
+)
 def download():
     """
     Downloads movie or subtitles to a local directory

--- a/plextraktsync/commands/download.py
+++ b/plextraktsync/commands/download.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from os.path import exists
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 
 from plextraktsync.factory import factory
@@ -14,8 +15,12 @@ if TYPE_CHECKING:
 def download_media(plex: PlexApi, pm: PlexLibraryItem):
     print(f"Download media for {pm}:")
     for index, part in enumerate(pm.parts, start=1):
-        print(f"Downloading part {index}: {part.file}")
-        plex.download(part, filename=part.file, showstatus=True)
+        # Remove directory part (Windows server on Unix)
+        # plex.download() is able to do that on Unix to Unix server, but not Windows to Unix
+        filename = PureWindowsPath(part.file).name
+
+        print(f"Downloading part {index}: {filename}")
+        plex.download(part, filename=filename, showstatus=True)
 
 
 def download_subtitles(plex: PlexApi, pm: PlexLibraryItem):

--- a/plextraktsync/commands/download.py
+++ b/plextraktsync/commands/download.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from os.path import exists
-from pathlib import PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING
 
 from plextraktsync.factory import factory
@@ -12,19 +12,22 @@ if TYPE_CHECKING:
     from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 
 
-def download_media(plex: PlexApi, pm: PlexLibraryItem):
+def download_media(plex: PlexApi, pm: PlexLibraryItem, savepath: str):
     print(f"Download media for {pm}:")
     for index, part in enumerate(pm.parts, start=1):
         # Remove directory part (Windows server on Unix)
         # plex.download() is able to do that on Unix to Unix server, but not Windows to Unix
         filename = PureWindowsPath(part.file).name
+        # Prepend save path, and expand ~ as HOME
+        filename = Path(savepath, filename).expanduser()
 
         if exists(filename):
             print(f"Skip existing file: {filename}")
             continue
 
-        print(f"Downloading part {index}: {filename}")
-        plex.download(part, filename=filename, showstatus=True)
+        print(f"Downloading part {index}: {part.file}")
+        print(f"Saving as {filename}")
+        plex.download(part, savepath=savepath, filename=filename, showstatus=True)
 
 
 def download_subtitles(plex: PlexApi, pm: PlexLibraryItem):
@@ -61,6 +64,6 @@ def download(input: list[str], only_subs: bool, target: str):
             continue
 
         if not only_subs:
-            download_media(plex, pm)
+            download_media(plex, pm, target)
 
         download_subtitles(plex, pm)

--- a/plextraktsync/commands/download.py
+++ b/plextraktsync/commands/download.py
@@ -50,7 +50,7 @@ def download_subtitles(plex: PlexApi, pm: PlexLibraryItem):
             print(f"Downloaded: {filename}")
 
 
-def download(input: list[str], only_subs: bool):
+def download(input: list[str], only_subs: bool, target: str):
     plex = factory.plex_api
     print = factory.print
 

--- a/plextraktsync/commands/download.py
+++ b/plextraktsync/commands/download.py
@@ -30,7 +30,7 @@ def download_media(plex: PlexApi, pm: PlexLibraryItem, savepath: str):
         plex.download(part, savepath=savepath, filename=filename, showstatus=True)
 
 
-def download_subtitles(plex: PlexApi, pm: PlexLibraryItem):
+def download_subtitles(plex: PlexApi, pm: PlexLibraryItem, savepath: str):
     print(f"Subtitles for {pm}:")
     for index, sub in enumerate(pm.subtitle_streams, start=1):
         print(
@@ -44,12 +44,15 @@ def download_subtitles(plex: PlexApi, pm: PlexLibraryItem):
             f"{sub.languageCode}.{sub.codec}"
         ])
 
+        # Prepend save path, and expand ~ as HOME
+        filename = Path(savepath, filename).expanduser()
+
         if not exists(filename):
             if not sub.key:
                 print(f"  ERROR: Subtitle {index}: has no key: Not downloadable")
                 continue
 
-            plex.download(sub, filename=filename, showstatus=True)
+            plex.download(sub, savepath=savepath, filename=filename, showstatus=True)
             print(f"Downloaded: {filename}")
 
 
@@ -66,4 +69,4 @@ def download(input: list[str], only_subs: bool, target: str):
         if not only_subs:
             download_media(plex, pm, target)
 
-        download_subtitles(plex, pm)
+        download_subtitles(plex, pm, target)

--- a/plextraktsync/commands/download.py
+++ b/plextraktsync/commands/download.py
@@ -19,6 +19,10 @@ def download_media(plex: PlexApi, pm: PlexLibraryItem):
         # plex.download() is able to do that on Unix to Unix server, but not Windows to Unix
         filename = PureWindowsPath(part.file).name
 
+        if exists(filename):
+            print(f"Skip existing file: {filename}")
+            continue
+
         print(f"Downloading part {index}: {filename}")
         plex.download(part, filename=filename, showstatus=True)
 


### PR DESCRIPTION
When downloading from PMS that is on Windows, media file is saved with absolute path looking like `E:\Movies\Movie.avi`.

`plex.download()` is able to remove directory part of the filename on Unix to Unix server, but not Windows to Unix, so we have to do basename for windows files.

Also adds `--target` option to save files to, it suppots tilde expansion (`~`) as `$HOME`.

```
$ plextraktsync download --help
Usage: python -m plextraktsync download [OPTIONS] [INPUT]...

  Downloads movie or subtitles to a local directory

Options:
  --only_subs    Download only subtitles
  --target TEXT  Download directory  [default: .]
  --help         Show this message and exit.
```