### PR TITLE
Use rich links when printing titles

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -9,6 +9,7 @@ from trakt.errors import TraktException
 from plextraktsync.decorators.cached_property import cached_property
 from plextraktsync.factory import logger
 from plextraktsync.trakt.TraktLookup import TraktLookup
+from rich.markup import escape
 
 if TYPE_CHECKING:
     from plextraktsync.plex.PlexApi import PlexApi
@@ -47,6 +48,12 @@ class Media:
             return self.plex.title
 
         return f"{self.trakt.title} ({self.trakt.year})"
+
+    @property
+    def title_link(self):
+        link = self.plex_api.media_url(self.plex)
+
+        return f"[link={link}][green]{escape(self.title)}[/][/]"
 
     @cached_property
     def media_type(self):

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -122,7 +122,8 @@ class Sync:
         if m.is_collected:
             return
 
-        logger.info(f"Adding to collection: '{m.title}'")
+        logger.info(f"Adding to collection: {m.title_link}", extra={"markup": True})
+
         if not dry_run:
             m.add_to_collection()
 
@@ -135,11 +136,11 @@ class Sync:
 
         # If two-way rating sync, Plex rating takes precedence over Trakt rating
         if m.plex_rating is not None and self.config.plex_to_trakt["ratings"]:
-            logger.info(f"Rating '{m.title}' with {m.plex_rating} on Trakt")
+            logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
             if not dry_run:
                 m.trakt_rate()
         elif m.trakt_rating is not None and self.config.trakt_to_plex["ratings"]:
-            logger.info(f"Rating '{m.title}' with {m.trakt_rating} on Plex")
+            logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
             if not dry_run:
                 m.plex_rate()
 
@@ -161,22 +162,22 @@ class Sync:
                 if not dry_run:
                     m.reset_show()
             else:
-                logger.info(f"Marking as watched in Trakt: '{m.title}'")
+                logger.info(f"Marking as watched in Trakt: {m.title_link}", extra={"markup": True})
                 if not dry_run:
                     m.mark_watched_trakt()
         elif m.watched_on_trakt:
             if not self.config.trakt_to_plex["watched_status"]:
                 return
-            logger.info(f"Marking as watched in Plex: '{m.title}'")
+            logger.info(f"Marking as watched in Plex: {m.title_link}", extra={"markup": True})
             if not dry_run:
                 m.mark_watched_plex()
 
     def watchlist_sync_item(self, m: Media, dry_run=False):
         if m.plex is None:
             if self.config.update_plex_wl:
-                logger.info(f"Skipping '{m.title}' from Trakt watchlist because not found in Plex Discover")
+                logger.info(f"Skipping {m.title_link} from Trakt watchlist because not found in Plex Discover", extra={"markup": True})
             elif self.config.update_trakt_wl:
-                logger.info(f"Removing '{m.title}' from Trakt watchlist")
+                logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
                 if not dry_run:
                     m.remove_from_trakt_watchlist()
             return
@@ -184,11 +185,11 @@ class Sync:
         if m in self.plex_wl:
             if m not in self.trakt_wl:
                 if self.config.update_trakt_wl:
-                    logger.info(f"Adding '{m.title}' to Trakt watchlist")
+                    logger.info(f"Adding {m.title_link} to Trakt watchlist", extra={"markup": True})
                     if not dry_run:
                         m.add_to_trakt_watchlist()
                 else:
-                    logger.info(f"Removing '{m.title}' from Plex watchlist")
+                    logger.info(f"Removing {m.title_link} from Plex watchlist", extra={"markup": True})
                     if not dry_run:
                         m.remove_from_plex_watchlist()
             else:
@@ -200,11 +201,11 @@ class Sync:
                 del self.trakt_wl[m]
         elif m in self.trakt_wl:
             if self.config.update_plex_wl:
-                logger.info(f"Adding '{m.title}' to Plex watchlist")
+                logger.info(f"Adding {m.title_link} to Plex watchlist", extra={"markup": True})
                 if not dry_run:
                     m.add_to_plex_watchlist()
             else:
-                logger.info(f"Removing '{m.title}' from Trakt watchlist")
+                logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
                 if not dry_run:
                     m.remove_from_trakt_watchlist()
 


### PR DESCRIPTION
This fixes issues like:
1. titles with aposthrophes continue be colored
2. having title on screen it's difficult to find actual item

now it's clickable links, if terminal supports it.