### PR TITLE
Skip link for media if no plex (only trakt)

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -51,9 +51,12 @@ class Media:
 
     @property
     def title_link(self):
-        link = self.plex_api.media_url(self.plex)
+        if self.plex:
+            link = self.plex_api.media_url(self.plex)
 
-        return f"[link={link}][green]{escape(self.title)}[/][/]"
+            return f"[link={link}][green]{escape(self.title)}[/][/]"
+
+        return f"[green]{escape(self.title)}[/]"
 
     @cached_property
     def media_type(self):


### PR DESCRIPTION
Fixes https://github.com/Taxel/PlexTraktSync/issues/1462