### PR TITLE
Add "sh" command to docker compose to passthrough to shell

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,12 @@ needs_switch_user() {
 set -eu
 test -n "$TRACE" && set -x
 
+# fix permissions and switch user if configured
+if needs_switch_user; then
+	setup_user
+	fix_permissions
+fi
+
 # Use "sh" command to passthrough to shell
 if [ "${1:-}" != "sh" ]; then
 	# Prepend default command
@@ -62,8 +68,6 @@ fi
 
 # fix permissions and switch user if configured
 if needs_switch_user; then
-	setup_user
-	fix_permissions
 	switch_user "$@"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,8 +54,11 @@ needs_switch_user() {
 set -eu
 test -n "$TRACE" && set -x
 
-# prepend default command
-set -- python -m plextraktsync "$@"
+# Use "sh" command to passthrough to shell
+if [ "${1:-}" != "sh" ]; then
+	# Prepend default command
+	set -- python -m plextraktsync "$@"
+fi
 
 # fix permissions and switch user if configured
 if needs_switch_user; then


### PR DESCRIPTION
This simplifies container access without needing to override with `--entrypoint sh`:

```
$ docker-compose run --rm plextraktsync sh         
~ $ ls -l
total 8
drwxr-xr-x    2 plextrak plextrak       120 Apr 19 13:59 config
drwxr-xr-x   13 root     root          4096 Apr 21 07:00 plextraktsync
-rwxr-xr-x    1 root     root           113 Jan 16 06:27 plextraktsync.sh
~ $
```