### PR TITLE
Feature: Add pipx docker compose alias to prepare pipx in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ ENV \
 	# https://pypa.github.io/pipx/docs/
 	PIPX_BIN_DIR=/app/xdg/bin \
 	PIPX_HOME=/app/xdg/pipx \
+	# https://stackoverflow.com/questions/2915471/install-a-python-package-into-a-different-directory-using-pip/29103053#29103053
+	PYTHONUSERBASE=/app/xdg \
 	# Fallback for anything else
 	HOME=/app/xdg \
 	\

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,18 @@ ENTRYPOINT ["/init"]
 LABEL org.opencontainers.image.description Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
 
 ENV \
-	PATH=/root/.local/bin:$PATH \
+	\
+	# https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
+	XDG_CACHE_HOME=/app/xdg/cache \
+	XDG_CONFIG_HOME=/app/xdg/config \
+	XDG_DATA_HOME=/app/xdg/data \
+	# https://pypa.github.io/pipx/docs/
+	PIPX_BIN_DIR=/app/xdg/bin \
+	PIPX_HOME=/app/xdg/pipx \
+	# Fallback for anything else
+	HOME=/app/xdg \
+	\
+	PATH=/app/xdg/bin:/app/xdg/.local/bin:/root/.local/bin:$PATH \
 	PTS_CONFIG_DIR=/app/config \
 	PTS_CACHE_DIR=/app/config \
 	PTS_LOG_DIR=/app/config \
@@ -60,6 +71,7 @@ ENV \
 	PYTHONUNBUFFERED=1
 
 VOLUME /app/config
+VOLUME $HOME
 
 # Add user/group
 RUN <<eot

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ switch_user() {
 fix_permissions() {
 	ensure_dir /app/config
 	ensure_owner /app/config -R
+	ensure_owner "$HOME"
 }
 
 needs_switch_user() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,15 @@ if needs_switch_user; then
 	fix_permissions
 fi
 
+# Shortcut to pre-install "pipx" and enter as "sh"
+if [ "${1:-}" = "pipx" ]; then
+	# https://github.com/Taxel/PlexTraktSync/blob/main/CONTRIBUTING.md#install-code-from-pull-request
+	apk add git
+	run_user pip install pipx
+	run_user pipx install plextraktsync
+	set -- "sh"
+fi
+
 # Use "sh" command to passthrough to shell
 if [ "${1:-}" != "sh" ]; then
 	# Prepend default command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,13 @@ setup_user() {
 
 # Run command as app user
 # https://github.com/karelzak/util-linux/issues/325
+run_user() {
+	local uid=$(id -u "$APP_USER")
+	local gid=$(id -g "$APP_GROUP")
+
+	setpriv --euid "$uid" --ruid "$uid" --clear-groups --egid "$gid" --rgid "$gid" -- "$@"
+}
+
 switch_user() {
 	local uid=$(id -u "$APP_USER")
 	local gid=$(id -g "$APP_GROUP")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,8 +75,11 @@ fi
 # Shortcut to pre-install "pipx" and enter as "sh"
 if [ "${1:-}" = "pipx" ]; then
 	# https://github.com/Taxel/PlexTraktSync/blob/main/CONTRIBUTING.md#install-code-from-pull-request
+	msg "Installing git"
 	apk add git
+	msg "Installing pipx"
 	run_user pip install pipx
+	msg "Installing plextraktsync from pipx"
 	run_user pipx install plextraktsync
 	set -- "sh"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,10 @@
 : ${APP_USER:=plextraktsync}
 : ${APP_GROUP:=plextraktsync}
 
+msg() {
+	echo >&2 "* $*"
+}
+
 ensure_dir() {
 	install -o "$APP_USER" -g "$APP_GROUP" -d "$@"
 }


### PR DESCRIPTION
Inspired by https://github.com/Taxel/PlexTraktSync/pull/1464

```
$ docker-compose run --rm plextraktsync pipx
* Installing git
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/5) Installing brotli-libs (1.0.9-r6)
(2/5) Installing nghttp2-libs (1.47.0-r0)
(3/5) Installing libcurl (8.0.1-r0)
(4/5) Installing pcre2 (10.40-r0)
(5/5) Installing git (2.36.5-r0)
Executing busybox-1.35.0-r17.trigger
OK: 27 MiB in 41 packages
* Installing pipx
Defaulting to user installation because normal site-packages is not writeable
Collecting pipx
  Downloading pipx-1.2.0-py3-none-any.whl (57 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 57.8/57.8 kB 2.3 MB/s eta 0:00:00
Collecting argcomplete>=1.9.4
  Downloading argcomplete-3.0.6-py3-none-any.whl (40 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 40.0/40.0 kB 2.4 MB/s eta 0:00:00
Collecting packaging>=20.0
  Downloading packaging-23.1-py3-none-any.whl (48 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.9/48.9 kB 7.9 MB/s eta 0:00:00
Collecting userpath>=1.6.0
  Downloading userpath-1.8.0-py3-none-any.whl (9.0 kB)
Requirement already satisfied: click in /usr/local/lib/python3.11/site-packages (from userpath>=1.6.0->pipx) (8.1.3)
Installing collected packages: userpath, packaging, argcomplete, pipx
Successfully installed argcomplete-3.0.6 packaging-23.1 pipx-1.2.0 userpath-1.8.0

[notice] A new release of pip is available: 23.0.1 -> 23.1.1
[notice] To update, run: pip install --upgrade pip
* Installing plextraktsync from pipx
⚠️  Note: plextraktsync was already on your PATH at /usr/bin/plextraktsync
  installed package plextraktsync 0.26.2, installed using Python 3.11.3
  These apps are now globally available
    - plextraktsync
done! ✨ 🌟 ✨
~ $ 
```