### PR TITLE
CustomFormatter to remove rich markup in logfile

### DIFF
--- a/plextraktsync/logging.py
+++ b/plextraktsync/logging.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from .factory import factory
 
@@ -17,7 +18,7 @@ def initialize(config):
     mode = "a" if config.log_append else "w"
     file_handler = logging.FileHandler(config.log_file, mode, "utf-8")
     file_handler.setFormatter(
-        logging.Formatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s")
+        CustomFormatter("%(asctime)-15s %(levelname)s[%(name)s]:%(message)s")
     )
     file_handler.setLevel(logging.DEBUG)
 
@@ -34,3 +35,13 @@ def initialize(config):
 
         logger.removeHandler(loghandler)
         logger.setLevel(logging.DEBUG)
+
+
+class CustomFormatter(logging.Formatter):
+    def format(self, record):
+        record.msg = self.remove_markup(record.msg)
+        return super().format(record)
+
+    def remove_markup(self, text):
+        pattern = r'\[link=[^\]]*\]|(\[green\])|(\[\/\])'
+        return re.sub(pattern, '', text)


### PR DESCRIPTION
Removes rich markups __link__ and __green__ (used for titles) in logfile (keep them in console log) because it makes logfile unreadable.
Feature added in #1447 version `0.26.1`


Logfile before this PR:
```
2023-05-12 04:20:11,431 INFO[PlexTraktSync]:Sync Show sections: ['[link=https꞉//app.plex.tv/desktop/#!/media/3f48753c4e05fda84b1316596945dd36194e4/com.plexapp.plugins.library?source=2][green]TV Shows[/][/]']
2023-05-12 04:21:01,117 INFO[PlexTraktSync]:Marking as watched in Plex: [link=https꞉//app.plex.tv/desktop/#!/server/3f48753c4e05fda84b1316596945dd36194e4/details?key=/library/metadata/5098][green]Breaking Bad/s01e04/Cancer Man (2008)[/][/]
2023-05-12 04:21:23,406 INFO[PlexTraktSync]:[link=https꞉//app.plex.tv/desktop/#!/media/3f48753c4e05fda84b1316596945dd36194e4/com.plexapp.plugins.library?source=2][green]TV Shows[/][/] processed in 1 min 5.3 seconds
```

Logfile after this PR:
```
2023-05-12 04:20:11,431 INFO[PlexTraktSync]:Sync Show sections: ['TV Shows']
2023-05-12 04:21:01,117 INFO[PlexTraktSync]:Marking as watched in Plex: Breaking Bad/s01e04/Cancer Man (2008)
2023-05-12 04:21:23,406 INFO[PlexTraktSync]:TV Shows processed in 1 min 5.3 seconds
```