### PR TITLE
Modify rating sync logic. Only rate items with missing rating. Don't overwrite existing ratings.

### DIFF
--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -134,12 +134,12 @@ class Sync:
         if m.plex_rating is m.trakt_rating:
             return
 
-        # If two-way rating sync, Plex rating takes precedence over Trakt rating
-        if m.plex_rating is not None and self.config.plex_to_trakt["ratings"]:
+        # If two-way rating sync, only rate items with missing rating
+        if m.plex_rating is not None and m.trakt_rating is None and self.config.plex_to_trakt["ratings"]:
             logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
             if not dry_run:
                 m.trakt_rate()
-        elif m.trakt_rating is not None and self.config.trakt_to_plex["ratings"]:
+        elif m.trakt_rating is not None and m.plex_rating is None and self.config.trakt_to_plex["ratings"]:
             logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
             if not dry_run:
                 m.plex_rate()


### PR DESCRIPTION
### Description:
Fix for issue: https://github.com/Taxel/PlexTraktSync/issues/1489. Small modification for rating sync logic in sync.py. Only rate items with missing rating. Don't overwrite existing ratings. I did some tests and this modification does seem to be working as intended.

### New Logic: 
If the Plex rating is set and the Trakt rating is not, the Plex rating is applied to Trakt. Similarly, if the Trakt rating is set and the Plex rating is not, the Trakt rating is applied to Plex.

### Old Logic:
Previously, if there was an existing rating for an item in Plex AND Trakt, the Plex rating would take precedence and the Trakt rating would be overwritten.

### Changes:
In the modified code, the additional conditions for `m.plex_rating is not None and m.trakt_rating is None` and `m.trakt_rating is not None and m.plex_rating is None` are added. Additionally, the comment line was modified to explain the new conditions.