### PR TITLE
Feature: Add support for optional rating priority config setting (none, trakt, or plex)

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -64,11 +64,12 @@ sync:
     # If you prefer to fetch trakt watchlist as a playlist instead of
     # plex watchlist, toggle this to true (is read only if watchlist=true)
     watchlist_as_playlist: false
-  # Setting for whether or not ratings from one platform should have priority. Valid values are trakt, plex or none. (default: none)
+  # Setting for whether ratings from one platform should have priority.
+  # Valid values are trakt, plex or none. (default: plex)
   # none - No rating priority. Existing ratings are not overwritten.
   # trakt - Trakt ratings have priority. Existing Plex ratings are overwritten.
   # plex - Plex ratings have priority. Existing Trakt ratings are overwritten.
-  rating_priority: none
+  rating_priority: plex
 
 # settings for 'watch' command
 watch:

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -56,7 +56,6 @@ sync:
     watchlist: true
   trakt_to_plex:
     liked_lists: true
-    # If two-way rating sync, Plex rating takes precedence over Trakt rating
     ratings: true
     watched_status: true
     # If trakt_to_plex watchlist=false and plex_to_trakt watchlist=true
@@ -65,6 +64,11 @@ sync:
     # If you prefer to fetch trakt watchlist as a playlist instead of
     # plex watchlist, toggle this to true (is read only if watchlist=true)
     watchlist_as_playlist: false
+  # Setting for whether or not ratings from one platform should have priority. Valid values are trakt, plex or none. (default: none)
+  # none - No rating priority. Existing ratings are not overwritten.
+  # trakt - Trakt ratings have priority. Existing Plex ratings are overwritten.
+  # plex - Plex ratings have priority. Existing Trakt ratings are overwritten.
+  rating_priority: none
 
 # settings for 'watch' command
 watch:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -134,15 +134,40 @@ class Sync:
         if m.plex_rating is m.trakt_rating:
             return
 
-        # If two-way rating sync, Plex rating takes precedence over Trakt rating
-        if m.plex_rating is not None and self.config.plex_to_trakt["ratings"]:
-            logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
-            if not dry_run:
-                m.trakt_rate()
-        elif m.trakt_rating is not None and self.config.trakt_to_plex["ratings"]:
-            logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
-            if not dry_run:
-                m.plex_rate()
+        rating_priority = self.config["rating_priority"]
+
+        if rating_priority == "none":
+            # Only rate items with missing rating
+            if m.plex_rating is not None and m.trakt_rating is None and self.config.plex_to_trakt["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
+                if not dry_run:
+                    m.trakt_rate()
+            elif m.trakt_rating is not None and m.plex_rating is None and self.config.trakt_to_plex["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
+                if not dry_run:
+                    m.plex_rate()
+
+        elif rating_priority == "trakt":
+            # If two-way rating sync, Trakt rating takes precedence over Plex rating
+            if m.trakt_rating is not None and self.config.trakt_to_plex["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
+                if not dry_run:
+                    m.plex_rate()
+            elif m.plex_rating is not None and self.config.plex_to_trakt["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
+                if not dry_run:
+                    m.trakt_rate()
+
+        elif rating_priority == "plex":
+            # If two-way rating sync, Plex rating takes precedence over Trakt rating
+            if m.plex_rating is not None and self.config.plex_to_trakt["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
+                if not dry_run:
+                    m.trakt_rate()
+            elif m.trakt_rating is not None and self.config.trakt_to_plex["ratings"]:
+                logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
+                if not dry_run:
+                    m.plex_rate()
 
     def sync_watched(self, m: Media, dry_run=False):
         if not self.config.sync_watched_status:

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -163,12 +163,12 @@ class Sync:
                 rate = "plex"
 
         if rate == "trakt":
-            logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt", extra={"markup": True})
+            logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt ({m.trakt_rating})", extra={"markup": True})
             if not dry_run:
                 m.trakt_rate()
 
         elif rate == "plex":
-            logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex", extra={"markup": True})
+            logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex ({m.plex_rating})", extra={"markup": True})
             if not dry_run:
                 m.plex_rate()
 


### PR DESCRIPTION
## Description:
Fix for issue: https://github.com/Taxel/PlexTraktSync/issues/1489. Pull request adds support for optional rating priority config setting. Includes modifications for rating sync logic in `sync.py` and a new setting for `rating_priority` in `config.default.yml`.

## New Config Setting Options:
 Valid values for rating_priority are trakt, plex or none. (default: none)
- none - No rating priority. Existing ratings are not overwritten.
- trakt - Trakt ratings have priority. Existing Plex ratings are overwritten.
- plex - Plex ratings have priority. Existing Trakt ratings are overwritten.

## Old Logic:
Previously, if there was an existing rating for an item in Plex AND Trakt, the Plex rating would take precedence and the Trakt rating would be overwritten. 

## Testing
I have thoroughly tested these changes and have found no conflicts or errors. Everything seems to be working as intended.