### PR TITLE
Fix: Pass maxresults to section.fetchItems

### DIFF
--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -80,7 +80,7 @@ class PlexLibrarySection:
 
     @retry()
     def fetch_items(self, key: str, size: int, start: int):
-        return self.section.fetchItems(key, container_start=start, container_size=size)
+        return self.section.fetchItems(key, container_start=start, container_size=size, maxresults=size)
 
     def items(self, max_items: int):
         for item in self.all(max_items):


### PR DESCRIPTION
This is to avoid `section.fetchItems` returning already visited items

Refs:
- https://github.com/Taxel/PlexTraktSync/pull/1506#issuecomment-1605918667
- https://github.com/pkkid/python-plexapi/pull/1143#issuecomment-1605918687