### PR TITLE
Feature: Enable trogon tui for cli

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,8 +13,11 @@ charset-normalizer = "==3.2.0"
 click = "==8.1.7"
 deprecated = "==1.2.14"
 idna = {version="==3.4", python_version=">='3.5'"}
+importlib-metadata = {version="==6.8.0", python_version=">='3.8'"}
 inquirerpy = "==0.3.4"
+linkify-it-py = "==2.0.2"
 markdown-it-py = {version="==3.0.0", python_version=">='3.7'"}
+mdit-py-plugins = "==0.4.0"
 mdurl = {version="==0.1.2", python_version=">='3.7'"}
 oauthlib = "==3.2.2"
 pfzy = {version="==0.3.4", markers="python_version >= '3.7' and python_version < '4.0'"}
@@ -32,13 +35,17 @@ requests-cache = "==1.0.0b1"
 requests-oauthlib = {version="==1.3.1", python_version=">='3.4'"}
 rich = "==13.5.2"
 six = {version="==1.16.0", python_version=">='3.4'"}
+textual = {version="==0.35.1", markers="python_version >= '3.7' and python_version < '4.0'"}
 tqdm = "==4.66.1"
 trogon = "==0.5.0"
+typing-extensions = {version="==4.7.1", python_version=">='3.7'"}
+uc-micro-py = {version="==1.0.2", python_version=">='3.7'"}
 url-normalize = {version="==1.4.3", python_version=">='3.6'"}
 urllib3 = "==2.0.4"
 wcwidth = "==0.2.6"
 websocket-client = "==1.6.2"
 wrapt = {version="==1.15.0", python_version=">='3.5'"}
+zipp = {version="==3.16.2", python_version=">='3.8'"}
 
 [requires]
 python_version = "3"

--- a/Pipfile
+++ b/Pipfile
@@ -33,6 +33,7 @@ requests-oauthlib = {version="==1.3.1", python_version=">='3.4'"}
 rich = "==13.5.2"
 six = {version="==1.16.0", python_version=">='3.4'"}
 tqdm = "==4.66.1"
+trogon = "==0.5.0"
 url-normalize = {version="==1.4.3", python_version=">='3.6'"}
 urllib3 = "==2.0.4"
 wcwidth = "==0.2.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a7bea5eec2b9627dd6ae11e6042ebb3b9f317f3e499abc455da0bd0b440905ef"
+            "sha256": "811a3093a5e9f38c2dc609deaf34fd13e04def80b1fd65d610094d79921c660a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -152,6 +152,7 @@
                 "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
                 "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==6.8.0"
         },
@@ -168,6 +169,7 @@
                 "sha256:19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2",
                 "sha256:a3a24428f6c96f27370d7fe61d2ac0be09017be5190d68d8658233171f1b6541"
             ],
+            "index": "pypi",
             "version": "==2.0.2"
         },
         "markdown-it-py": {
@@ -184,6 +186,7 @@
                 "sha256:b51b3bb70691f57f974e257e367107857a93b36f322a9e6d44ca5bf28ec2def9",
                 "sha256:d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b"
             ],
+            "index": "pypi",
             "version": "==0.4.0"
         },
         "mdurl": {
@@ -370,6 +373,7 @@
                 "sha256:70ca0bfe582f96dfa10179a9ab71329b8b15e750e26b7cee1fb4a67a981bbf36",
                 "sha256:c4257ed3019cf8a2da2ac59ae59de5e66e04b95d482d065cfb3099f70fddd36f"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.35.1"
         },
@@ -394,6 +398,7 @@
                 "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
                 "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==4.7.1"
         },
@@ -402,6 +407,7 @@
                 "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54",
                 "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==1.0.2"
         },
@@ -525,6 +531,7 @@
                 "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
                 "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==3.16.2"
         }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a731a4f937e2f53c1b8e5b0c09393de926067dddab38bff577a59cecff4365c1"
+            "sha256": "a7bea5eec2b9627dd6ae11e6042ebb3b9f317f3e499abc455da0bd0b440905ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -147,6 +147,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
+                "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==6.8.0"
+        },
         "inquirerpy": {
             "hashes": [
                 "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e",
@@ -154,6 +162,13 @@
             ],
             "index": "pypi",
             "version": "==0.3.4"
+        },
+        "linkify-it-py": {
+            "hashes": [
+                "sha256:19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2",
+                "sha256:a3a24428f6c96f27370d7fe61d2ac0be09017be5190d68d8658233171f1b6541"
+            ],
+            "version": "==2.0.2"
         },
         "markdown-it-py": {
             "hashes": [
@@ -163,6 +178,13 @@
             "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
+        },
+        "mdit-py-plugins": {
+            "hashes": [
+                "sha256:b51b3bb70691f57f974e257e367107857a93b36f322a9e6d44ca5bf28ec2def9",
+                "sha256:d8ab27e9aed6c38aa716819fedfde15ca275715955f8a185a8e1cf90fb1d2c1b"
+            ],
+            "version": "==0.4.0"
         },
         "mdurl": {
             "hashes": [
@@ -343,6 +365,14 @@
             "markers": "python_version >= '3.4'",
             "version": "==1.16.0"
         },
+        "textual": {
+            "hashes": [
+                "sha256:70ca0bfe582f96dfa10179a9ab71329b8b15e750e26b7cee1fb4a67a981bbf36",
+                "sha256:c4257ed3019cf8a2da2ac59ae59de5e66e04b95d482d065cfb3099f70fddd36f"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.35.1"
+        },
         "tqdm": {
             "hashes": [
                 "sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386",
@@ -350,6 +380,30 @@
             ],
             "index": "pypi",
             "version": "==4.66.1"
+        },
+        "trogon": {
+            "hashes": [
+                "sha256:61a57f0f1a38227d90601cd020f46960be8e36947b5e56c6932c2e01ecc5042a",
+                "sha256:987d2195c1dd2f93c50e555063a9de57edbc5906ce20ee39081343ff194952c1"
+            ],
+            "index": "pypi",
+            "version": "==0.5.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.7.1"
+        },
+        "uc-micro-py": {
+            "hashes": [
+                "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54",
+                "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.2"
         },
         "url-normalize": {
             "hashes": [
@@ -465,6 +519,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==1.15.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
+                "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.16.2"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Commands:
   self-update        Update PlexTraktSync to the latest version using pipx
   sync               Perform sync between Plex and Trakt
   trakt-login        Log in to Trakt Account to obtain Access Token.
+  tui                Open Textual TUI.
   unmatched          List media that has no match in Trakt or Plex
   watch              Listen to events from Plex
   watched-shows      Print a table of watched shows

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -3,6 +3,7 @@ from os import environ
 
 import click
 from click import ClickException
+from trogon import tui
 
 from plextraktsync.factory import factory
 
@@ -38,6 +39,7 @@ def command():
     return decorator
 
 
+@tui()
 @click.group(invoke_without_command=True)
 @click.option("--version", is_flag=True, help="Print version and exit")
 @click.option("--no-cache", is_flag=True, help="Disable cache in for Trakt HTTP requests")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,11 @@ charset-normalizer==3.2.0
 click==8.1.7
 deprecated==1.2.14
 idna==3.4; python_version >= '3.5'
+importlib-metadata==6.8.0; python_version >= '3.8'
 inquirerpy==0.3.4
+linkify-it-py==2.0.2
 markdown-it-py==3.0.0; python_version >= '3.7'
+mdit-py-plugins==0.4.0
 mdurl==0.1.2; python_version >= '3.7'
 oauthlib==3.2.2
 pfzy==0.3.4; python_version >= '3.7' and python_version < '4.0'
@@ -32,9 +35,14 @@ requests-oauthlib==1.3.1; python_version >= '3.4'
 requests==2.31.0
 rich==13.5.2
 six==1.16.0; python_version >= '3.4'
+textual==0.35.1; python_version >= '3.7' and python_version < '4.0'
 tqdm==4.66.1
+trogon==0.5.0
+typing-extensions==4.7.1; python_version >= '3.7'
+uc-micro-py==1.0.2; python_version >= '3.7'
 url-normalize==1.4.3; python_version >= '3.6'
 urllib3==2.0.4
 wcwidth==0.2.6
 websocket-client==1.6.2
 wrapt==1.15.0; python_version >= '3.5'
+zipp==3.16.2; python_version >= '3.8'


### PR DESCRIPTION
Adds new subcommand `tui` to add nice text browser or all commands.

https://github.com/Textualize/trogon#custom-command-name-and-custom-help

requires python 3.8:
- https://github.com/Taxel/PlexTraktSync/pull/773

or we lack python 3.11 support:
- https://github.com/executablebooks/mdit-py-plugins/blob/v0.4.0/CHANGELOG.md#040---2023-06-05