### PR TITLE
Fetch episodes using library search to include guids without reloading

### DIFF
--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -86,7 +86,7 @@ class HttpCacheConfig:
         # reloads
         "*/library/metadata/*?*include*": DO_NOT_CACHE,
         # episodes
-        "*/library/metadata/*/allLeaves": DO_NOT_CACHE,
+        "*/library/sections/*/all?includeGuids=1&type=4*": DO_NOT_CACHE,
         # find_by_id
         "*/library/metadata/*": DO_NOT_CACHE,
         # mark played, mark unplayed

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -283,7 +283,7 @@ class PlexLibraryItem:
 
     @retry()
     def _get_episodes(self):
-        return self.item.episodes()
+        return self.library.search(libtype='episode', filters={'show.id': self.item.ratingKey})
 
     @cached_property
     def season_number(self):


### PR DESCRIPTION
## Description

Fetch episodes using library search to include guids without reloading every episode object. This should *significantly* increase the speed for syncing tv shows.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
