### PR TITLE
Build missing wheels only if needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ RUN \
 # Build missing wheels
 RUN \
 	--mount=type=cache,id=pip,target=/root/.cache/pip \
-	pip wheel $(ls /wheels/*.gz /wheels/*.zip 2>/dev/null) --wheel-dir=/wheels
+<<eot
+	set -- $(ls /wheels/*.gz /wheels/*.zip 2>/dev/null)
+	test -n "${1:-}" && pip wheel $(ls /wheels/*.gz /wheels/*.zip 2>/dev/null) --wheel-dir=/wheels
+eot
 
 # Install app dependencies
 FROM base AS build


### PR DESCRIPTION
Apparently there's wheel now for x86_64:
> PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl

- https://github.com/Taxel/PlexTraktSync/actions/runs/6037364156/job/16381489172?pr=1564#step:8:540