### PR TITLE
Feature: Add config support for servers.yml

### DIFF
--- a/plextraktsync/config/Config.py
+++ b/plextraktsync/config/Config.py
@@ -88,12 +88,6 @@ class Config(ChangeNotifier, ConfigMergeMixin, dict):
 
         return HttpCacheConfig(**cache)
 
-    @property
-    def sync(self):
-        from plextraktsync.config.SyncConfig import SyncConfig
-
-        return SyncConfig(self)
-
     def initialize(self):
         """
         Config load order:

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -21,3 +21,10 @@ class PlexServerConfig:
         del data["name"]
 
         return data
+
+    @property
+    def sync_config(self):
+        if self.config is None or "sync" not in self.config or self.config["sync"] is None:
+            return {}
+
+        return self.config["sync"]

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -14,6 +14,7 @@ class PlexServerConfig:
     urls: list[str]
     # The machineIdentifier value of this server
     id: str = None
+    config: dict = None
 
     def asdict(self):
         data = asdict(self)

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -5,11 +5,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from plextraktsync.config.Config import Config
+    from plextraktsync.config.PlexServerConfig import PlexServerConfig
 
 
 class SyncConfig:
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, server_config: PlexServerConfig):
         self.config = dict(config["sync"])
+        self.server_config = server_config.sync_config
 
     def __getitem__(self, key):
         return self.config[key]

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -20,6 +20,9 @@ class SyncConfig:
         return key in self.config
 
     def get(self, section, key):
+        if section in self.server_config and key in self.server_config[section]:
+            return self.server_config[section][key]
+
         return self[key] if key in self else self[section][key]
 
     @cached_property

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -11,7 +11,7 @@ from plextraktsync.trakt_list_util import TraktListUtil
 if TYPE_CHECKING:
     from typing import Iterable
 
-    from plextraktsync.config.Config import Config
+    from plextraktsync.config.SyncConfig import SyncConfig
     from plextraktsync.media import Media
     from plextraktsync.plex.PlexApi import PlexApi
     from plextraktsync.trakt.TraktApi import TraktApi
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
 
 
 class Sync:
-    def __init__(self, config: Config, plex: PlexApi, trakt: TraktApi):
-        self.config = config.sync
+    def __init__(self, config: SyncConfig, plex: PlexApi, trakt: TraktApi):
+        self.config = config
         self.plex = plex
         self.trakt = trakt
 

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -284,6 +284,12 @@ class Factory:
 
         return config
 
+    @property
+    def sync_config(self):
+        from plextraktsync.config.SyncConfig import SyncConfig
+
+        return SyncConfig(self.config)
+
     @cached_property
     def queue(self):
         from plextraktsync.queue.BackgroundTask import BackgroundTask

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -130,11 +130,10 @@ class Factory:
     def sync(self):
         from plextraktsync.sync import Sync
 
-        config = self.config
         plex = self.plex_api
         trakt = self.trakt_api
 
-        return Sync(config, plex, trakt)
+        return Sync(self.sync_config, plex, trakt)
 
     @cached_property
     def progressbar(self):

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -287,7 +287,7 @@ class Factory:
     def sync_config(self):
         from plextraktsync.config.SyncConfig import SyncConfig
 
-        return SyncConfig(self.config)
+        return SyncConfig(self.config, self.server_config)
 
     @cached_property
     def queue(self):


### PR DESCRIPTION
Currently only "sync" command reads "sync" settings.

```yml
servers:
  default:
    id: xxx
    token: xxx
    urls:
      - https://xxx.plex.direct:32400
    config:
      sync:
        plex_to_trakt:
          collection: true
        trakt_to_plex:
          liked_lists: false
```