### PR TITLE
Fix Plex login for users with 2FA enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Installing from GitHub is considered developer mode, and it's documented in
   Follow the instructions, your credentials and API keys will be stored in
   `.env`and `.pytrakt.json` files. Plex URL and token is stored in `servers.yml`.
 
-  If you have [2 Factor Authentication enabled on Plex][two-factor-authentication] you can append the code to your password.
+  If you have [2 Factor Authentication enabled on Plex][two-factor-authentication], input the code when prompted. If you don't have 2FA enabled, just leave the prompt blank and press Enter.
 
 [two-factor-authentication]: https://support.plex.tv/articles/two-factor-authentication/#toc-1:~:text=Old%20Third%2DParty%20Apps%20%26%20Tools
 

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -66,7 +66,7 @@ def myplex_login(username, password):
         password = Prompt.ask(PROMPT_PLEX_PASSWORD, password=True, default=password, show_default=False)
         code = Prompt.ask(PROMPT_PLEX_CODE)
         try:
-            return MyPlexAccount(username, password, code)
+            return MyPlexAccount(username=username, password=password, code=code)
         except Unauthorized as e:
             print(error(f"Log in to Plex failed: '{e}', Try again."), highlight=False)
         except BadRequest as e:

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -24,15 +24,12 @@ if TYPE_CHECKING:
 
 PROMPT_PLEX_PASSWORD = prompt("Please enter your Plex password")
 PROMPT_PLEX_USERNAME = prompt("Please enter your Plex username or e-mail")
+PROMPT_PLEX_CODE = prompt("Enter a 2FA code if enabled, or leave blank otherwise")
 PROMPT_PLEX_RELOGIN = prompt(
     "You already have Plex Access Token, do you want to log in again?"
 )
 SUCCESS_MESSAGE = success(
     "Plex Media Server Authentication Token and base URL have been added to servers.yml"
-)
-NOTICE_2FA_PASSWORD = comment(
-    "If you have 2 Factor Authentication enabled on Plex "
-    "you can append the code to your password below (eg. passwordCODE)"
 )
 CONFIG = factory.config
 
@@ -66,10 +63,10 @@ def server_urls(server: MyPlexResource):
 def myplex_login(username, password):
     while True:
         username = Prompt.ask(PROMPT_PLEX_USERNAME, default=username)
-        print(NOTICE_2FA_PASSWORD, highlight=False)
         password = Prompt.ask(PROMPT_PLEX_PASSWORD, password=True, default=password, show_default=False)
+        code = Prompt.ask(PROMPT_PLEX_CODE)
         try:
-            return MyPlexAccount(username, password)
+            return MyPlexAccount(username, password, code)
         except Unauthorized as e:
             print(error(f"Log in to Plex failed: '{e}', Try again."), highlight=False)
         except BadRequest as e:

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -14,7 +14,7 @@ from plexapi.myplex import MyPlexAccount
 from plextraktsync.config.ServerConfigFactory import ServerConfigFactory
 from plextraktsync.decorators.flatten import flatten_list
 from plextraktsync.factory import factory
-from plextraktsync.style import comment, error, prompt, success, title
+from plextraktsync.style import error, prompt, success, title
 from plextraktsync.util.local_url import local_url
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt


### PR DESCRIPTION
This should fix login for Plex users using 2FA.

Closes #1584 

TODO:
- [x] Test that it works
- [x] Test that commit doesn't break login for non-2FA users