### PR TITLE
Cleanup: Skip creating empty default server

### DIFF
--- a/plextraktsync/config/ServerConfigFactory.py
+++ b/plextraktsync/config/ServerConfigFactory.py
@@ -41,6 +41,10 @@ class ServerConfigFactory(ConfigMergeMixin):
     def migrate(self):
         from plextraktsync.factory import factory
         config = factory.config
+
+        if not config["PLEX_BASEURL"]:
+            return
+
         self.add_server(
             name="default",
             urls=[
@@ -52,6 +56,7 @@ class ServerConfigFactory(ConfigMergeMixin):
         self.save()
         config["PLEX_SERVER"] = "default"
         config.save()
+
         logger = factory.logger
         logger.warning(f"Added default server to {self.config_path}")
 


### PR DESCRIPTION
No need to convert servers config on the initial run, i.e. when PLEX_SERVER from .env is not initialized.

```
/app # plextraktsync
WARNING  plextraktsync without command is deprecated. Executing "plextraktsync sync"                                                     
INFO     PlexTraktSync [unknown]                                                                                                         
WARNING  Added default server to /app/config/servers.yml                                                                                 
Please enter your Plex username or e-mail: ^C
Aborted!

/app # cat /app/config/servers.yml
servers:
  default:
    token: null
    urls:
    - null
    - null
    id: null
    config: null
/app # 
```