### PR TITLE
Optimize: Disable includeGuids for ratings search

### DIFF
--- a/plextraktsync/plex/PlexRatings.py
+++ b/plextraktsync/plex/PlexRatings.py
@@ -64,5 +64,5 @@ class PlexRatings:
             ]
         }
 
-        for item in section.search(filters=filters):
+        for item in section.search(filters=filters, includeGuids=False):
             yield item.ratingKey, item.userRating


### PR DESCRIPTION
Using only `item.ratingKey`, `item.userRating` fields really.