### PR TITLE
Refactor: Move logging out of root import

### DIFF
--- a/plextraktsync/logger/init.py
+++ b/plextraktsync/logger/init.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from .factory import factory
+from plextraktsync.factory import factory
 
 
 def initialize(config):

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -222,7 +222,7 @@ class Factory:
     def logging(self):
         import logging
 
-        from plextraktsync.logging import initialize
+        from plextraktsync.logger.init import initialize
 
         config = self.config
         initialize(config)


### PR DESCRIPTION
This is to avoid confusing the import of the system and a local module.

_Extracted from https://github.com/Taxel/PlexTraktSync/pull/1654_