### PR TITLE
Feature: Retry movie search for mini series

### DIFF
--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -223,9 +223,8 @@ class TraktApi:
         else:
             tm = self.search_by_id(guid.id, id_type=guid.provider, media_type=guid.type)
             if tm is None and guid.type == "movie":
-                tm = self.search_by_id(guid.id, id_type=guid.provider, media_type="show")
-                if tm:
-                    logger.warning(f"Retied using show search: {guid.title_link}", extra={"markup": True})
+                if self.search_by_id(guid.id, id_type=guid.provider, media_type="show"):
+                    logger.warning(f"Found match using show search: {guid.title_link}", extra={"markup": True})
 
             return tm
 

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -221,7 +221,13 @@ class TraktApi:
 
                 return self.find_episode_guid(guid, lookup)
         else:
-            return self.search_by_id(guid.id, id_type=guid.provider, media_type=guid.type)
+            tm = self.search_by_id(guid.id, id_type=guid.provider, media_type=guid.type)
+            if tm is None and guid.type == "movie":
+                tm = self.search_by_id(guid.id, id_type=guid.provider, media_type="show")
+                if tm:
+                    logger.warning(f"Retied using show search: {guid.title_link}", extra={"markup": True})
+
+            return tm
 
     @rate_limit()
     @retry()


### PR DESCRIPTION
Quite typical to put mini-series as movie to the library, as plex recognizes both. but trakt only has them as tv series.

If the match is not found,  try a tv series and print warning if found, so users would know to fix this.