### PR TITLE
Improve tvdb does not support movie provider debug message

### DIFF
--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -235,7 +235,7 @@ class TraktApi:
             # Skip invalid search.
             # The Trakt API states that tvdb is only for shows and episodes:
             # https://trakt.docs.apiary.io/#reference/search/id-lookup/get-id-lookup-results
-            logger.debug("tvdb does not support movie provider")
+            logger.debug(f"search_by_id: tvdb does not support movie provider, skip {id_type}/{media_type}/{media_id}")
             return None
         if media_type == "season":
             # Search by season is missing

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -258,7 +258,7 @@ class TraktApi:
             logger.debug(f"search_by_id({media_id}, {id_type}, {media_type}) got {len(search)} results, taking first one")
             logger.debug([pm.to_json() for pm in search])
 
-        # TODO: sort by "scrore"?
+        # TODO: sort by "score"?
         return search[0]
 
     @staticmethod


### PR DESCRIPTION
There's such item in media library

```
Guids:
  Guid: <PlexGuid:tmdb://1123257>, Id: 1123257, Provider: 'tmdb'
  Guid: <PlexGuid:tvdb://346000>, Id: 346000, Provider: 'tvdb'
  Guid: <PlexGuid:imdb://tt27430909>, Id: tt27430909, Provider: 'imdb'
```

and it behaves really oddly.

later it appeared the tmdb id is deleted, new id is 1201008

```
Guids:
  Guid: <PlexGuid:tmdb://1201008>, Id: 1201008, Provider: 'tmdb'
  Guid: <PlexGuid:tvdb://346000>, Id: 346000, Provider: 'tvdb'
  Guid: <PlexGuid:imdb://tt27430909>, Id: tt27430909, Provider: 'imdb'
```

but having no match in tvdb, it was confusing why tvdb wasn't consulted. no request made, nothing in logs.

so now at least prepping logs for 346000 will give some match.

while the site has the id present:
- https://thetvdb.com/movies/louis-ck-at-the-dolby

trakt api gives 500:

```
✖ ./trakt-api.sh 'https://api-v2launch.trakt.tv/search/tvdb/346000?type=movie'
curl: (22) The requested URL returned error: 500
```