### PR TITLE
CI: Add release environment for pypi job

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,6 +19,9 @@ jobs:
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/plextraktsync
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Taking from pipx:
- https://github.com/pypa/pipx/blob/81c2fa509768715de24a3ba10d46596de980052f/.github/workflows/tests.yml#L91-L93

Should appear something like this:
- https://github.com/pypa/pipx/deployments/release