### PR TITLE
Update trakt baseurl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ curl -sSf \
 ```
 
 ```
-$ ./trakt-api.sh "https://api-v2launch.trakt.tv/users/me" | jq -C | less
+$ ./trakt-api.sh "https://api.trakt.tv/users/me" | jq -C | less
 ```
 
 ## Sharing Plex Media Server Database


### PR DESCRIPTION
Updates trakt baseurl because old one is deprecated.

According to [Trakt API](https://twitter.com/traktapi/status/1742976564567106019) :

> The API host name [http://api-v2launch.trakt.tv](https://t.co/9TYHCeYzjb) will be removed on February 1. 
>
>This has been deprecated since 2017. This will only affect very old apps and they need to use [http://api.trakt.tv](https://t.co/0mENbHo7Uq) to continue working beyond February 1.