### PR TITLE
Fix: Make inspect work for discover urls

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -20,7 +20,7 @@ def inspect_media(plex_id: PlexId):
     print = factory.print
 
     print("")
-    pm: PlexLibraryItem = plex.fetch_item(plex_id.key)
+    pm: PlexLibraryItem = plex.fetch_item(plex_id)
     if not pm:
         print(f"Inspecting {plex_id}: Not found from {plex}")
         return

--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -77,8 +77,9 @@ def inspect_media(plex_id: PlexId):
     print(f"Metadata: {pm.to_json()}")
     print(f"Watched on Plex: {pm.is_watched}")
 
+    history = plex.history(media, device=True, account=True) if not pm.is_discover else []
     print("Plex play history:")
-    for h in plex.history(media, device=True, account=True):
+    for h in history:
         d = h.device
         # handle cases like "local" for offline plays
         if d.name == '' and d.platform == '':


### PR DESCRIPTION
1. did not parse url well
2. history results exception

```
$ plextraktsync inspect "https://app.plex.tv/desktop/#!/provider/tv.plex.provider.discover/details?key=/library/metadata/5d7769ed9ab54400214f8ad9"
```