### PR TITLE
Refactor: Use RichProgressBar class

### DIFF
--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -109,7 +109,7 @@ class Walker(SetWindowTitle):
     def walk_shows(self, shows: set[Media], title="Processing Shows"):
         if not shows:
             return
-        yield from self.progressbar(shows, desc=title)
+        yield from self.progressbar(shows, desc=title, total=len(shows))
 
     def get_plex_episodes(self, episodes: list[Episode]) -> Generator[Media, Any, None]:
         it = self.progressbar(episodes, desc="Processing episodes")

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -3,7 +3,7 @@ from functools import cached_property
 
 class RichProgressBar:
     def __init__(self, iterable, total, options=None, desc=""):
-        self.iter = iterable
+        self.iter = iter(iterable)
         self.options = options or {}
         self.desc = desc
         self.total = total

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -7,16 +7,15 @@ class RichProgressBar:
         self.options = options or {}
         self.desc = desc
         self.total = total
+        self.i = 0
 
     def __iter__(self):
-        p = self.progress
-        task_id = p.add_task(self.desc, total=self.total)
+        return self
 
-        i = 0
-        for it in self.iter:
-            yield it
-            i += 1
-            p.update(task_id, completed=i)
+    def __next__(self):
+        res = self.iter.__next__()
+        self.update()
+        return res
 
     def __enter__(self):
         self.progress.__enter__()
@@ -24,6 +23,14 @@ class RichProgressBar:
 
     def __exit__(self, *exc):
         self.progress.__exit__(*exc)
+
+    def update(self):
+        self.i += 1
+        self.progress.update(self.task_id, completed=self.i)
+
+    @cached_property
+    def task_id(self):
+        return self.progress.add_task(self.desc, total=self.total)
 
     @cached_property
     def progress(self):

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -27,6 +27,31 @@ class RichProgressBar:
 
     @cached_property
     def progress(self):
-        from rich.progress import Progress
+        from tqdm.rich import FractionColumn, RateColumn
 
-        return Progress(**self.options)
+        from rich.progress import (BarColumn, Progress, TimeElapsedColumn,
+                                   TimeRemainingColumn)
+
+        args = (
+            "[progress.description]{task.description}"
+            "[progress.percentage]{task.percentage:>4.0f}%",
+            BarColumn(bar_width=None),
+            FractionColumn(
+                unit_scale=False,
+                unit_divisor=1000,
+            ),
+            "[",
+            TimeElapsedColumn(),
+            "<",
+            TimeRemainingColumn(),
+            ",",
+            RateColumn(
+                unit="it",
+                unit_scale=False,
+                unit_divisor=1000,
+            ),
+            "]"
+        )
+        progress = Progress(*args, **self.options)
+
+        return progress

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -1,0 +1,32 @@
+from functools import cached_property
+
+
+class RichProgressBar:
+    def __init__(self, iterable, total, options=None, desc=""):
+        self.iter = iterable
+        self.options = options or {}
+        self.desc = desc
+        self.total = total
+
+    def __iter__(self):
+        p = self.progress
+        task_id = p.add_task(self.desc, total=self.total)
+
+        i = 0
+        for it in self.iter:
+            yield it
+            i += 1
+            p.update(task_id, completed=i)
+
+    def __enter__(self):
+        self.progress.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        self.progress.__exit__(*exc)
+
+    @cached_property
+    def progress(self):
+        from rich.progress import Progress
+
+        return Progress(**self.options)

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -140,23 +140,11 @@ class Factory:
         if not self.run_config.progressbar:
             return None
 
-        import warnings
         from functools import partial
 
-        from tqdm import TqdmExperimentalWarning
-        from tqdm.rich import tqdm
+        from plextraktsync.rich.RichProgressBar import RichProgressBar
 
-        warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
-
-        # Monkeypatch https://github.com/tqdm/tqdm/pull/1395
-        class Tqdm(tqdm):
-            def close(self):
-                if self.disable:
-                    return
-                self.display()
-                super().close()
-
-        return partial(Tqdm, options={'console': self.console})
+        return partial(RichProgressBar, options={'console': self.console})
 
     @cached_property
     def run_config(self):


### PR DESCRIPTION
Get rid of tqdm rich wrapper.

Needed for:
- https://github.com/Taxel/PlexTraktSync/pull/563

and tqdm upstream unresponsive:
- https://github.com/tqdm/tqdm/pull/1395

note: `tqdm` still in use:
1. `from tqdm.rich import FractionColumn, RateColumn`
2. plex downloader