### PR TITLE
Feature: Add library config to server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,44 @@ seconds, second run - 111 seconds
 You can view sync progress in the `plextraktsync.log` file which will be
 created.
 
+### Libraries
+
+By default, all libraries are processed. You can disable libraries by name by
+changing `excluded-libraries` in `config.yml`.
+
+You can also set `excluded-libraries` per server in `servers.yml`:
+
+```yml
+  Example1:
+    token: ~
+    urls:
+      - http://localhost:32400
+    config:
+      excluded-libraries:
+        - "Family Movies"
+```
+
+Additionally, you can list only libraries to be processed, in this case global
+`excluded-libraries` will not be used for this server.
+
+```yml
+  Example1:
+    token: ~
+    urls:
+      - http://localhost:32400
+    config:
+      libraries:
+        - "Movies"
+        - "TV Shows"
+```
+
+you can see the final list of libraries with info command:
+
+```commandline
+$ plextraktsync --server=Example1 info
+INFO     Enabled 2 libraries in Plex Server: ['Movies', 'TV Shows']
+```
+
 ### Logging
 
 The logging level by default is `INFO`. This can be changed to DEBUG by editing

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ services:
       - ./config:/app/config
 ```
 
-## Sync settings
+## Configuration
 
 To disable parts of the functionality of this software, look no further than
 `config.yml`. At first run, the script will create `config.yml` based on

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -1,6 +1,8 @@
 cache:
   path: $PTS_CACHE_DIR/trakt_cache
 
+# You may want to use per server libraries config instead:
+# - https://github.com/Taxel/PlexTraktSync#libraries
 excluded-libraries:
   - Private
   - Family Holidays

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -28,3 +28,17 @@ class PlexServerConfig:
             return {}
 
         return self.config["sync"]
+
+    @property
+    def libraries(self):
+        if self.config is None or "libraries" not in self.config:
+            return None
+
+        return self.config["libraries"]
+
+    @property
+    def excluded_libraries(self):
+        if self.config is None or "excluded-libraries" not in self.config:
+            return None
+
+        return self.config["excluded-libraries"]

--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -34,7 +34,7 @@ class PlexApi:
     def __init__(
             self,
             server: PlexServer,
-            config: PlexServerConfig = None,
+            config: PlexServerConfig,
     ):
         self.server = server
         self.config = config

--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -109,10 +109,22 @@ class PlexApi:
     @cached_property
     @flatten_dict
     def library_sections(self) -> dict[int, PlexLibrarySection]:
-        excluded_libraries = factory.config["excluded-libraries"]
+        enabled_libraries = self.config.libraries
+
+        # If server has defined libraries, ignore global "excluded libraries"
+        # otherwise merge server excluded libraries with global excluded libraries
+        if enabled_libraries is not None:
+            excluded_libraries = self.config.excluded_libraries or []
+        else:
+            excluded_libraries = factory.config["excluded-libraries"] + (self.config.excluded_libraries or [])
+
         for section in self.server.library.sections():
+            if enabled_libraries is not None:
+                if section.title not in enabled_libraries:
+                    continue
             if section.title in excluded_libraries:
                 continue
+
             yield section.key, PlexLibrarySection(section, plex=self)
 
     @memoize


### PR DESCRIPTION
Requires:
- [x] https://github.com/Taxel/PlexTraktSync/pull/1695

allows configuring per server libraries:
1. "libraries" -> use only these libraries. global "excluded-libraries" will be ignored if this is set
2. "exclude-libraries" -> per server libraries to exclude

example 1: process only libraries "Movies" and "TV Shows"

```yml
  Example1:
    token: ~
    urls:
      - http://localhost:32400
    config:
      libraries:
        - "Movies"
        - "TV Shows"
```

example 2: exclude "Family Movies" library for specific server only

```yml
  Example1:
    token: ~
    urls:
      - http://localhost:32400
    config:
      excluded-libraries:
        - "Family Movies"
```

you can see the final list of libraries with `info` command:

```
$ plextraktsync  --server=Example1 info  
INFO     Enabled 2 libraries in Plex Server: ['Movies', 'TV Shows']           
```