### PR TITLE
Fix trakt-api.sh shellcheck SC2223 warning

### DIFF
--- a/trakt-api.sh
+++ b/trakt-api.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-: ${TRAKT_API_KEY=$(jq -r .CLIENT_ID < .pytrakt.json)}
-: ${TRAKT_AUTHORIZATION=Bearer $(jq -r .OAUTH_TOKEN < .pytrakt.json)}
+: "${TRAKT_API_KEY=$(jq -r .CLIENT_ID < .pytrakt.json)}"
+: "${TRAKT_AUTHORIZATION=Bearer $(jq -r .OAUTH_TOKEN < .pytrakt.json)}"
 
 curl -sSf \
      --header "Content-Type: application/json" \


### PR DESCRIPTION
This default assignment may cause DoS due to globbing. Quote it.

See SC2223:
- https://github.com/koalaman/shellcheck/wiki/SC2223