### PR TITLE
Fix: Use trakt slug for trakt_url

### DIFF
--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -82,7 +82,9 @@ class Media:
 
     @property
     def trakt_url(self):
-        return f"https://trakt.tv/{self.media_type}/{self.trakt.slug}"
+        path = self.trakt.slug if self.trakt.slug else self.trakt_id
+
+        return f"https://trakt.tv/{self.media_type}/{path}"
 
     @property
     def show(self) -> Media | None:

--- a/plextraktsync/media.py
+++ b/plextraktsync/media.py
@@ -82,7 +82,7 @@ class Media:
 
     @property
     def trakt_url(self):
-        return f"https://trakt.tv/{self.media_type}/{self.trakt_id}"
+        return f"https://trakt.tv/{self.media_type}/{self.trakt.slug}"
 
     @property
     def show(self) -> Media | None:


### PR DESCRIPTION
The redirect by id may get to incorrect place:

- https://trakt.tv/movies/96

Redirects wrongly:
- https://trakt.tv/movies/96-2018

Should be:
- https://trakt.tv/movies/princess-mononoke-1997