### PR TITLE
Feature: Add plex-api.sh helper script

### DIFF
--- a/plex-api.sh
+++ b/plex-api.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Get PLEX_SERVER value from .env
+get_plex_server() {
+	awk -F= '$1 == "PLEX_SERVER" {print $2}' .env
+}
+
+load_servers() {
+	python -c 'import yaml; import json; fp=open("servers.yml"); print(json.dumps(yaml.safe_load(fp)["servers"]))'
+}
+
+get_server() {
+	local name="$1"
+
+	load_servers | jq ".$name"
+}
+
+get_plex_token() {
+	local name server
+
+	name=${PLEX_SERVER:-$(get_plex_server)}
+	server=$(get_server "$name")
+
+	echo "$server" | jq -r ".token"
+}
+
+: "${PLEX_TOKEN=$(get_plex_token)}"
+
+curl -sSf \
+	 --header "X-Plex-Token: $PLEX_TOKEN" \
+	 "$@"


### PR DESCRIPTION
Similarly to https://github.com/Taxel/PlexTraktSync/pull/1638 add `plex-api.sh` to help debugging plex urls

Expects `PLEX_TOKEN` env variable, or reads itself value from `.env` and `servers.yml`