### PR TITLE
Fix: Calculate RichProgressBar length automatically

### DIFF
--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -109,7 +109,7 @@ class Walker(SetWindowTitle):
     def walk_shows(self, shows: set[Media], title="Processing Shows"):
         if not shows:
             return
-        yield from self.progressbar(shows, desc=title, total=len(shows))
+        yield from self.progressbar(shows, desc=title)
 
     def get_plex_episodes(self, episodes: list[Episode]) -> Generator[Media, Any, None]:
         it = self.progressbar(episodes, desc="Processing episodes")

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -2,10 +2,12 @@ from functools import cached_property
 
 
 class RichProgressBar:
-    def __init__(self, iterable, total, options=None, desc=""):
+    def __init__(self, iterable, total=None, options=None, desc=""):
         self.iter = iter(iterable)
         self.options = options or {}
         self.desc = desc
+        if total is None:
+            total = len(iterable)
         self.total = total
         self.i = 0
 


### PR DESCRIPTION
```
TypeError: RichProgressBar.__init__() missing 1 required positional argument: 'total'
```