### PR TITLE
Revert "Add implicit typing for TraktRatingCollection"

### DIFF
--- a/plextraktsync/trakt/TraktRatingCollection.py
+++ b/plextraktsync/trakt/TraktRatingCollection.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from plextraktsync.trakt.TraktApi import TraktApi
 
 
-class TraktRatingCollection(dict[str, dict[int, int]]):
+class TraktRatingCollection(dict):
     """
     A dictionary of:
     ["movies", "shows", "episodes"] => {


### PR DESCRIPTION
This reverts commit 13237f8784d754b5162224ca3b9f18cfa09979fe.

Revert, because it breaks Python 3.8

Fixes #1723