### PR TITLE
Refactor: Rename PlexShowSectionPager to PlexSectionPager

### DIFF
--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -146,10 +146,8 @@ class Walker(SetWindowTitle):
         for section in sections:
             with measure_time(f"{section.title_link} processed", extra={"markup": True}):
                 self.set_window_title(f"Processing {section.title}")
-                total = len(section)
                 it = self.progressbar(
-                    section.items(total),
-                    total=total,
+                    section.pager(),
                     desc=f"Processing {section.title_link}",
                 )
                 yield from it
@@ -158,10 +156,8 @@ class Walker(SetWindowTitle):
         for section in sections:
             with measure_time(f"{section.title_link} processed", extra={"markup": True}):
                 self.set_window_title(f"Processing {section.title}")
-                items = section.search_episodes()
                 it = self.progressbar(
-                    items,
-                    total=len(items),
+                    section.pager("episode"),
                     desc=f"Processing {section.title_link}",
                 )
                 yield from it

--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from plexapi import X_PLEX_CONTAINER_SIZE
 from plexapi.exceptions import NotFound
 
-from plextraktsync.decorators.retry import retry
 from plextraktsync.mixin.RichMarkup import RichMarkup
-from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -61,39 +58,6 @@ class PlexLibrarySection(RichMarkup):
             return self.section.fetchItem(int(id))
         except NotFound:
             return None
-
-    def search_episodes(self):
-        if self.section.type == "show":
-            from plextraktsync.plex.PlexSectionPager import PlexSectionPager
-
-            return PlexSectionPager(section=self.section, plex=self.plex)
-
-        return None
-
-    def all(self, max_items: int):
-        libtype = self.section.TYPE
-        key = self.section._buildSearchKey(libtype=libtype, returnKwargs=False)
-        start = 0
-        size = X_PLEX_CONTAINER_SIZE
-
-        while True:
-            items = self.fetch_items(key, size, start)
-            if not len(items):
-                break
-
-            yield from items
-
-            start += size
-            if start > max_items:
-                break
-
-    @retry()
-    def fetch_items(self, key: str, size: int, start: int):
-        return self.section.fetchItems(key, container_start=start, container_size=size, maxresults=size)
-
-    def items(self, max_items: int):
-        for item in self.all(max_items):
-            yield PlexLibraryItem(item, plex=self.plex)
 
     def __repr__(self):
         return f"<{self.__class__.__name__}:{self.type}:{self.title}>"

--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -23,12 +23,6 @@ class PlexLibrarySection(RichMarkup):
         self.section = section
         self.plex = plex
 
-    def __len__(self):
-        return self.section.totalSize
-
-    def __iter__(self):
-        return self.items(len(self))
-
     def pager(self, libtype: Literal["episode"] = None):
         from plextraktsync.plex.PlexSectionPager import PlexSectionPager
 

--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plexapi import X_PLEX_CONTAINER_SIZE
@@ -11,6 +10,8 @@ from plextraktsync.mixin.RichMarkup import RichMarkup
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from plexapi.library import MovieSection, ShowSection
 
     from plextraktsync.plex.PlexApi import PlexApi
@@ -28,11 +29,10 @@ class PlexLibrarySection(RichMarkup):
     def __iter__(self):
         return self.items(len(self))
 
-    @cached_property
-    def pager(self):
+    def pager(self, libtype: Literal["episode"] = None):
         from plextraktsync.plex.PlexSectionPager import PlexSectionPager
 
-        return PlexSectionPager(section=self.section, plex=self.plex)
+        return PlexSectionPager(section=self.section, plex=self.plex, libtype=libtype)
 
     @property
     def type(self):

--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plexapi import X_PLEX_CONTAINER_SIZE
@@ -26,6 +27,12 @@ class PlexLibrarySection(RichMarkup):
 
     def __iter__(self):
         return self.items(len(self))
+
+    @cached_property
+    def pager(self):
+        from plextraktsync.plex.PlexSectionPager import PlexSectionPager
+
+        return PlexSectionPager(section=self.section, plex=self.plex)
 
     @property
     def type(self):

--- a/plextraktsync/plex/PlexLibrarySection.py
+++ b/plextraktsync/plex/PlexLibrarySection.py
@@ -63,10 +63,9 @@ class PlexLibrarySection(RichMarkup):
 
     def search_episodes(self):
         if self.section.type == "show":
-            from plextraktsync.plex.PlexShowSectionPager import \
-                PlexShowSectionPager
+            from plextraktsync.plex.PlexSectionPager import PlexSectionPager
 
-            return PlexShowSectionPager(section=self.section, plex=self.plex)
+            return PlexSectionPager(section=self.section, plex=self.plex)
 
         return None
 

--- a/plextraktsync/plex/PlexSectionPager.py
+++ b/plextraktsync/plex/PlexSectionPager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from plextraktsync.decorators.retry import retry
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 
 if TYPE_CHECKING:
@@ -24,6 +25,10 @@ class PlexSectionPager:
     def total_size(self):
         return self.section.totalViewSize(libtype=self.libtype, includeCollections=False)
 
+    @retry()
+    def fetch_items(self, start: int, size: int):
+        return self.section.search(libtype=self.libtype, container_start=start, container_size=size, maxresults=size)
+
     def __iter__(self):
         from plexapi import X_PLEX_CONTAINER_SIZE
 
@@ -32,7 +37,7 @@ class PlexSectionPager:
         size = X_PLEX_CONTAINER_SIZE
 
         while True:
-            items = self.section.searchEpisodes(container_start=start, container_size=size, maxresults=size)
+            items = self.fetch_items(start=start, size=size)
 
             if not len(items):
                 break

--- a/plextraktsync/plex/PlexSectionPager.py
+++ b/plextraktsync/plex/PlexSectionPager.py
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
 
 
 class PlexSectionPager:
-    def __init__(self, section: ShowSection | MovieSection, plex: PlexApi):
+    def __init__(self, section: ShowSection | MovieSection, plex: PlexApi, libtype: str = None):
         self.section = section
         self.plex = plex
-        self.libtype = "episode" if section.type == "show" else section.TYPE
+        self.libtype = libtype if libtype is not None else section.TYPE
 
     def __len__(self):
         return self.total_size

--- a/plextraktsync/plex/PlexSectionPager.py
+++ b/plextraktsync/plex/PlexSectionPager.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from plextraktsync.plex.PlexApi import PlexApi
 
 
-class PlexShowSectionPager:
+class PlexSectionPager:
     def __init__(self, section: ShowSection, plex: PlexApi):
         self.section = section
         self.plex = plex

--- a/plextraktsync/plex/PlexSectionPager.py
+++ b/plextraktsync/plex/PlexSectionPager.py
@@ -6,22 +6,23 @@ from typing import TYPE_CHECKING
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 
 if TYPE_CHECKING:
-    from plexapi.library import ShowSection
+    from plexapi.library import MovieSection, ShowSection
 
     from plextraktsync.plex.PlexApi import PlexApi
 
 
 class PlexSectionPager:
-    def __init__(self, section: ShowSection, plex: PlexApi):
+    def __init__(self, section: ShowSection | MovieSection, plex: PlexApi):
         self.section = section
         self.plex = plex
+        self.libtype = "episode" if section.type == "show" else section.TYPE
 
     def __len__(self):
         return self.total_size
 
     @cached_property
     def total_size(self):
-        return self.section.totalViewSize(libtype="episode", includeCollections=False)
+        return self.section.totalViewSize(libtype=self.libtype, includeCollections=False)
 
     def __iter__(self):
         from plexapi import X_PLEX_CONTAINER_SIZE

--- a/plextraktsync/rich/RichProgressBar.py
+++ b/plextraktsync/rich/RichProgressBar.py
@@ -3,7 +3,6 @@ from functools import cached_property
 
 class RichProgressBar:
     def __init__(self, iterable, total=None, options=None, desc=""):
-        self.iter = iter(iterable)
         self.options = options or {}
         self.desc = desc
         if total is None:
@@ -11,11 +10,16 @@ class RichProgressBar:
         self.total = total
         self.i = 0
 
+        if hasattr(iterable, "__next__"):
+            self.iterable_next = iterable.__next__
+        else:
+            self.iterable_next = iter(iterable).__next__
+
     def __iter__(self):
         return self
 
     def __next__(self):
-        res = self.iter.__next__()
+        res = self.iterable_next()
         self.update()
         return res
 


### PR DESCRIPTION
`PlexSectionPager` can now page all library types

Requires:
- https://github.com/Taxel/PlexTraktSync/pull/1736

This should have been cleaned up after:
- https://github.com/Taxel/PlexTraktSync/pull/1578