### PR TITLE
Refactor: Optimize resolve_guid to check only once positive providers

### DIFF
--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -41,16 +41,21 @@ class MediaFactory:
         return None
 
     def resolve_guid(self, guid: PlexGuid, show: Media = None):
-        if guid.provider in ["youtube", "xmltv"]:
-            logger.debug(f"{guid.title_link}: Skipping {guid} because unsupported provider '{guid.provider}'", extra={"markup": True})
-            return None
+        if not guid.syncable:
+            error = f"{guid.title_link}: Skipping {guid} because"
 
-        if guid.provider in ["local", "none", "agents.none"]:
-            logger.warning(f"{guid.title_link}: Skipping {guid} because provider {guid.provider} has no external Id", extra={"markup": True})
-            return None
+            if guid.unsupported:
+                level = "debug"
+                reason = f"unsupported provider '{guid.provider}'"
+            elif guid.local:
+                level = "warning"
+                reason = f"provider '{guid.provider}' has no external Id"
+            else:
+                level = "error"
+                reason = "is not a valid provider"
 
-        if guid.provider not in ["imdb", "tmdb", "tvdb"]:
-            logger.error(f"{guid.title_link}: '{guid.provider}' is not valid provider from {guid}", extra={"markup": True})
+            getattr(logger, level)(f"{error} {reason}", extra={"markup": True})
+
             return None
 
         try:

--- a/plextraktsync/plex/PlexGuid.py
+++ b/plextraktsync/plex/PlexGuid.py
@@ -61,6 +61,21 @@ class PlexGuid(RichMarkup):
 
         return len(parts) == 3 and all(x.isnumeric() for x in parts)
 
+    @property
+    def syncable(self):
+        """Is the provider syncable with trakt"""
+        return self.provider in ["imdb", "tmdb", "tvdb"]
+
+    @property
+    def local(self):
+        """Is the provider local"""
+        return self.provider in ["local", "none", "agents.none"]
+
+    @property
+    def unsupported(self):
+        """Known providers that can't be synced"""
+        return self.provider in ["youtube", "xmltv"]
+
     @cached_property
     def show_id(self):
         if not self.is_episode:

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -142,7 +142,8 @@ class PlexLibraryItem(RichMarkup):
         if self.type == "episode":
             value = f"{self.item.grandparentTitle}/{self.item.seasonEpisode}/{value}"
 
-        value = f"{value} ({self.item.year})"
+        if self.item.year:
+            value = f"{value} ({self.item.year})"
 
         return value
 


### PR DESCRIPTION
The refactor checks provider only once for providers that exist, possible micro performance boost. For unmatched more checks are performed. Previously all checks were performed regardless if the result will fail. It also improves readability of the resolve_guid method and moves logic of deciding which provider is what to PlexGuid class for enculapsing logic there.

Requires:
- [ ] https://github.com/Taxel/PlexTraktSync/pull/777