### PR TITLE
Refactor: Add TraktScrobbleWorker worker

### DIFF
--- a/plextraktsync/queue/Queue.py
+++ b/plextraktsync/queue/Queue.py
@@ -29,6 +29,15 @@ class Queue:
     def add_to_history(self, data):
         self.add_queue("add_to_history", data)
 
+    def scrobble_update(self, data):
+        self.add_queue("scrobble_update", data)
+
+    def scrobble_pause(self, data):
+        self.add_queue("scrobble_pause", data)
+
+    def scrobble_stop(self, data):
+        self.add_queue("scrobble_stop", data)
+
     def add_queue(self, queue: str, data: Any):
         """
         Add "data" to "queue". Returns immediately

--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from plextraktsync.decorators.rate_limit import rate_limit
+from plextraktsync.decorators.retry import retry
+from plextraktsync.decorators.time_limit import time_limit
+from plextraktsync.factory import logging
+
+if TYPE_CHECKING:
+    from trakt.sync import Scrobbler
+
+    from plextraktsync.trakt.types import TraktPlayable
+
+
+class TraktScrobbleWorker:
+    # Queues this Worker can handle
+    QUEUES = (
+        "scrobble_update",
+        "scrobble_pause",
+        "scrobble_stop",
+    )
+
+    def __init__(self):
+        self.logger = logging.getLogger("PlexTraktSync.TraktScrobbleWorker")
+
+    def __call__(self, queues):
+        for name in self.QUEUES:
+            items = queues[name]
+            if not len(items):
+                continue
+            self.submit(name, items)
+            queues[name].clear()
+
+    def submit(self, name, items):
+        method = getattr(self, name)
+        results = []
+        for scrobbler, progress in self.normalize(items).items():
+            res = method(scrobbler, progress)
+            results.append(res)
+
+        if results:
+            self.logger.debug(f"Submitted {name}: {results}")
+
+    @rate_limit()
+    @time_limit()
+    @retry()
+    def scrobble_update(self, scrobbler: Scrobbler, progress: float):
+        return scrobbler.update(progress)
+
+    @rate_limit()
+    @time_limit()
+    @retry()
+    def scrobble_pause(self, scrobbler: Scrobbler, progress: float):
+        return scrobbler.update(progress)
+
+    @rate_limit()
+    @time_limit()
+    @retry()
+    def scrobble_stop(self, scrobbler: Scrobbler, progress: float):
+        return scrobbler.stop(progress)
+
+    @staticmethod
+    def normalize(items: list[TraktPlayable]):
+        result = {}
+        for (scrobbler, progress) in items:
+            result[scrobbler] = progress
+
+        return result

--- a/plextraktsync/trakt/ScrobblerProxy.py
+++ b/plextraktsync/trakt/ScrobblerProxy.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.rate_limit import rate_limit
-from plextraktsync.factory import logging
+from plextraktsync.factory import factory, logging
 
 if TYPE_CHECKING:
     from trakt.sync import Scrobbler
@@ -37,3 +38,7 @@ class ScrobblerProxy:
         else:
             self.logger.debug(f"pause({self.scrobbler.media}): {progress}")
             return self.scrobbler.pause(progress)
+
+    @cached_property
+    def queue(self):
+        return factory.queue

--- a/plextraktsync/trakt/ScrobblerProxy.py
+++ b/plextraktsync/trakt/ScrobblerProxy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.factory import factory, logging
 
 if TYPE_CHECKING:
@@ -12,7 +11,7 @@ if TYPE_CHECKING:
 
 class ScrobblerProxy:
     """
-    Proxy to Scrobbler that handles requests cache and rate limiting
+    Proxy to Scrobbler that queues requests to update trakt
     """
 
     def __init__(self, scrobbler: Scrobbler, threshold=80):
@@ -20,24 +19,21 @@ class ScrobblerProxy:
         self.threshold = threshold
         self.logger = logging.getLogger("PlexTraktSync.ScrobblerProxy")
 
-    @rate_limit(retries=2)
     def update(self, progress: float):
         self.logger.debug(f"update({self.scrobbler.media}): {progress}")
-        return self.scrobbler.update(progress)
+        self.queue.scrobble_update((self.scrobbler, progress))
 
-    @rate_limit(retries=2)
     def pause(self, progress: float):
         self.logger.debug(f"pause({self.scrobbler.media}): {progress}")
-        return self.scrobbler.pause(progress)
+        self.queue.scrobble_pause((self.scrobbler, progress))
 
-    @rate_limit(retries=2)
     def stop(self, progress: float):
         if progress >= self.threshold:
             self.logger.debug(f"stop({self.scrobbler.media}): {progress}")
-            return self.scrobbler.stop(progress)
+            self.queue.scrobble_stop((self.scrobbler, progress))
         else:
             self.logger.debug(f"pause({self.scrobbler.media}): {progress}")
-            return self.scrobbler.pause(progress)
+            self.queue.scrobble_pause((self.scrobbler, progress))
 
     @cached_property
     def queue(self):

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -293,10 +293,12 @@ class Factory:
         from plextraktsync.queue.TraktBatchWorker import TraktBatchWorker
         from plextraktsync.queue.TraktMarkWatchedWorker import \
             TraktMarkWatchedWorker
+        from plextraktsync.queue.TraktScrobbleWorker import TraktScrobbleWorker
 
         workers = [
             TraktBatchWorker(),
             TraktMarkWatchedWorker(),
+            TraktScrobbleWorker(),
         ]
         task = BackgroundTask(self.batch_delay_timer, *workers)
         queue = Queue(task)


### PR DESCRIPTION
Moves trakt scrobble api calls to worker. This offloads synchronous requests to background task, making main watch command more responsive. 

It will also aggregate results to update same media object, to submit only latest update for same id: 

```
trakt_id=1, percent=1.11
trakt_id=1, percent=1.23
trakt_id=1, percent=1.40
trakt_id=2, percent=19
```

will become:
```
trakt_id=1, percent=1.40
trakt_id=2, percent=19
```

additionally worker methods respect `@time_limit()`, so methods are not called more often than 1.1 seconds:
- https://github.com/Taxel/PlexTraktSync/blob/ef581d1c05c9f851692b448ada74c1f21e2abe21/plextraktsync/config/__init__.py#L9