### PR TITLE
Rename Watched to Played

### DIFF
--- a/plextraktsync/commands/inspect.py
+++ b/plextraktsync/commands/inspect.py
@@ -73,7 +73,7 @@ def inspect_media(plex_id: PlexId):
         print(f"  Guid: {guid}, Id: {guid.id}, Provider: '{guid.provider}'")
 
     print(f"Metadata: {pm.to_json()}")
-    print(f"Watched on Plex: {pm.is_watched}")
+    print(f"Played on Plex: {pm.is_watched}")
 
     history = plex.history(media, device=True, account=True) if not pm.is_discover else []
     print("Plex play history:")

--- a/plextraktsync/watch/WatchStateUpdater.py
+++ b/plextraktsync/watch/WatchStateUpdater.py
@@ -163,7 +163,7 @@ class WatchStateUpdater(SetWindowTitle):
         percent = m.plex.watch_progress(event.view_offset)
 
         self.logger.info(
-            f"on_play: {movie}: {percent:.6F}%, State: {event.state}, Watched: {movie.isPlayed}, LastViewed: {movie.lastViewedAt}"
+            f"on_play: {movie}: {percent:.6F}%, State: {event.state}, Played: {movie.isPlayed}, LastViewed: {movie.lastViewedAt}"
         )
         scrobbled = self.scrobble(m, percent, event)
         self.logger.debug(f"Scrobbled: {scrobbled}")


### PR DESCRIPTION
Some media may be without video (audio files).

TODO: Rename symbols internally. Note Plex already renamed to `isPlayed`:
- https://github.com/Taxel/PlexTraktSync/pull/1017