### PR TITLE
Fix: Use Prompt.ask rather click.prompt

### DIFF
--- a/plextraktsync/commands/trakt_login.py
+++ b/plextraktsync/commands/trakt_login.py
@@ -4,7 +4,7 @@ from json import JSONDecodeError
 from os.path import exists
 from typing import TYPE_CHECKING
 
-import click
+from rich.prompt import Prompt
 from trakt.errors import ForbiddenException
 
 from plextraktsync.factory import factory
@@ -37,8 +37,8 @@ def trakt_authenticate(api: TraktApi):
     print("")
 
     while True:
-        client_id = click.prompt(PROMPT_TRAKT_CLIENT_ID, type=str)
-        client_secret = click.prompt(PROMPT_TRAKT_CLIENT_SECRET, type=str)
+        client_id = Prompt.ask(PROMPT_TRAKT_CLIENT_ID)
+        client_secret = Prompt.ask(PROMPT_TRAKT_CLIENT_SECRET, password=True)
 
         print("Attempting to authenticate with Trakt")
         try:


### PR DESCRIPTION
Improve https://github.com/Taxel/PlexTraktSync/pull/1773, `click.prompt` used `Abort` rather `EOFError`, so it's prompts would not be caught.

Test

```
$ docker-compose run --no-TTY --interactive=false plextraktsync trakt-login
Sign in to Trakt
If you do not have a Trakt client ID and secret:
      1 - Open http://trakt.tv/oauth/applications on any computer
      2 - Login to your Trakt account
      3 - Press the NEW APPLICATION button
      4 - Set the NAME field = plex
      5 - Set the REDIRECT URL field = urn:ietf:wg:oauth:2.0:oob
      6 - Press the SAVE APP button

Please enter your client id: 
Error: Program requested terminal, No terminal is connected: EOF when reading a line
```

```
$ docker-compose run --no-TTY --interactive=false plextraktsync plex-login 
You already have Plex Access Token, do you want to log in again? [y/n] (y): 
Error: Program requested terminal, No terminal is connected: EOF when reading a line
```