### PR TITLE
Fix pausing of Trakt scrobbling

### DIFF
--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -52,7 +52,7 @@ class TraktScrobbleWorker:
     @time_limit()
     @retry()
     def scrobble_pause(self, scrobbler: Scrobbler, progress: float):
-        return scrobbler.update(progress)
+        return scrobbler.pause(progress)
 
     @rate_limit()
     @time_limit()


### PR DESCRIPTION
Fixes #1783

Updated `scrobble_pause` method to call `scrobbler.pause` in `plextraktsync/queue/TraktScrobbleWorker.py`