### PR TITLE
Fix TraktUserList load check

### DIFF
--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -20,8 +20,6 @@ class TraktUserList:
                  name: str = None,
                  items=None,
                  ):
-        if items is None:
-            items = []
         self.trakt_id = trakt_id
         self.name = name
         self._items = items
@@ -42,7 +40,7 @@ class TraktUserList:
 
     @property
     def items(self):
-        if not self._items:
+        if self._items is None:
             self.description, self._items = self.load_items()
         return self._items
 

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -54,7 +54,7 @@ class TraktUserList:
             for elem in list_items
             if elem[0] in ["movies", "episodes"]
         ]
-        self.logger.info(f"Downloaded Trakt list '{self.name}' https://trakt.tv/lists/{self.trakt_id}")
+        self.logger.info(f"Downloaded Trakt list '{self.name}' ({len(list_items)} items): https://trakt.tv/lists/{self.trakt_id}")
 
         return userlist.description, dict(zip(prelist, count(1)))
 


### PR DESCRIPTION
The self._items would evaluate False if it is an empty array:
- https://github.com/Taxel/PlexTraktSync/issues/1788