### PR TITLE
Bypass show when it doesn't exist in trakt db (ex. in tvdb only)

### DIFF
--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -215,9 +215,7 @@ class Media(RichMarkup):
 
     @cached_property
     def plex_rating(self):
-        if self.media_type == "episodes" and not self.plex.is_discover:
-            if not self.show:
-                raise RuntimeError(f"Need show attribute, but it is missing for {self}")
+        if self.media_type == "episodes" and not self.plex.is_discover and self.show:
             show_id = self.show.plex.item.ratingKey
         else:
             show_id = None

--- a/plextraktsync/sync.py
+++ b/plextraktsync/sync.py
@@ -84,7 +84,7 @@ class Sync:
                     if self.config.clear_collected:
                         episode_trakt_ids.add(episode.trakt_id)
 
-                if self.config.sync_ratings:
+                if self.config.sync_ratings and episode.show:
                     # collect shows for later ratings sync
                     shows.add(episode.show)
 


### PR DESCRIPTION
Some shows from TVDB do not exist in TMDB / Trakt database because TVDB sometimes splits a show in multiple shows.
Therefore, those shows cannot be rated separately and cannot be synced to Trakt.

Example :
TMDB has show A with 2 seasons.
TVDB has same show split in show A with 1 season and show B with 1 season.

Ids of show A correspond between TMDB and TVDB, so it can be synced.
Id of show B correspond to nothing in TMDB/Trakt, so it cannot be synced. We have to bypass it.

fixes #1785 