### PR TITLE
Refactor: Add Ratings class to support rated_at

### DIFF
--- a/plextraktsync/commands/imdb_import.py
+++ b/plextraktsync/commands/imdb_import.py
@@ -83,4 +83,4 @@ def imdb_import(input: PathLike, dry_run: bool):
             continue
         print(f"{'Would rate' if dry_run else 'Rating'} {m} with {r.rating} (was {rating})")
         if not dry_run:
-            trakt.rate(m, r.rating)
+            trakt.rate(m, r.rating, r.rate_date)

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -209,7 +209,7 @@ class Media(RichMarkup):
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)
 
-    @property
+    @cached_property
     def trakt_rating(self):
         return self.trakt_api.rating(self.trakt)
 

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -225,14 +225,13 @@ class Media(RichMarkup):
         rating = self.plex_rating
         if rating is None:
             return
-        rated_at = self.plex.item.lastRatedAt
-        self.trakt_api.rate(self.trakt, rating, rated_at)
+        self.trakt_api.rate(self.trakt, rating.rating, rating.rated_at)
 
     def plex_rate(self):
         rating = self.trakt_rating
         if rating is None:
             return
-        self.plex_api.rate(self.plex.item, rating)
+        self.plex_api.rate(self.plex.item, rating.rating)
 
     def plex_history(self, **kwargs):
         if self.plex.is_discover:

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -225,7 +225,8 @@ class Media(RichMarkup):
         rating = self.plex_rating
         if rating is None:
             return
-        self.trakt_api.rate(self.trakt, rating)
+        rated_at = self.plex.item.lastRatedAt
+        self.trakt_api.rate(self.trakt, rating, rated_at)
 
     def plex_rate(self):
         rating = self.trakt_rating

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -148,7 +148,6 @@ class PlexLibraryItem(RichMarkup):
 
         return value
 
-    @retry(retries=1)
     def rating(self, show_id: int = None):
         if not self.is_discover and self.plex is not None:
             return self.plex.ratings.get(self, show_id)

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -153,11 +153,7 @@ class PlexLibraryItem(RichMarkup):
         if not self.is_discover and self.plex is not None:
             return self.plex.ratings.get(self, show_id)
 
-        user_rating = self.item.userRating
-        if user_rating is None:
-            return None
-
-        return Rating.create(user_rating, self.item.lastRatedAt)
+        return Rating.create(self.item.userRating, self.item.lastRatedAt)
 
     @property
     def seen_date(self):

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -157,7 +157,7 @@ class PlexLibraryItem(RichMarkup):
         if user_rating is None:
             return None
 
-        return Rating(int(user_rating), self.item.lastRatedAt)
+        return Rating.create(user_rating, self.item.lastRatedAt)
 
     @property
     def seen_date(self):

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -10,6 +10,7 @@ from plextraktsync.decorators.retry import retry
 from plextraktsync.factory import factory
 from plextraktsync.mixin.RichMarkup import RichMarkup
 from plextraktsync.plex.PlexGuid import PlexGuid
+from plextraktsync.util.Rating import Rating
 
 if TYPE_CHECKING:
     from plexapi.media import MediaPart
@@ -156,7 +157,7 @@ class PlexLibraryItem(RichMarkup):
         if user_rating is None:
             return None
 
-        return int(user_rating)
+        return Rating(int(user_rating), self.item.lastRatedAt)
 
     @property
     def seen_date(self):

--- a/plextraktsync/plex/PlexRatings.py
+++ b/plextraktsync/plex/PlexRatings.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.flatten import flatten_dict
 from plextraktsync.decorators.memoize import memoize
+from plextraktsync.util.Rating import Rating
 
 if TYPE_CHECKING:
     from plextraktsync.plex.PlexApi import PlexApi
@@ -27,26 +28,22 @@ class PlexRatings:
 
         media_type = m.media_type
         section = self.plex.library_sections[section_id]
-        ratings = self.ratings(section, media_type)
+        ratings: dict[int, Rating] = self.ratings(section, media_type)
 
         if media_type in ["movies", "shows"]:
             # For movies and shows, just return from the dict
-            user_rating = (
-                ratings[m.item.ratingKey] if m.item.ratingKey in ratings else None
-            )
+            if m.item.ratingKey in ratings:
+                return ratings[m.item.ratingKey]
         elif media_type == "episodes":
             # For episodes the ratings is just (show_id, show_rating) tuples
             # if show id is not listed, return none, otherwise fetch from item itself
             if show_id not in ratings:
                 return None
-            user_rating = m.item.userRating
+            return Rating(m.item.userRating, m.item.lastRatedAt)
         else:
             raise RuntimeError(f"Unsupported media type: {media_type}")
 
-        if user_rating is None:
-            return None
-
-        return int(user_rating)
+        return None
 
     @staticmethod
     @memoize
@@ -65,4 +62,4 @@ class PlexRatings:
         }
 
         for item in section.search(filters=filters, includeGuids=False):
-            yield item.ratingKey, item.userRating
+            yield item.ratingKey, Rating(int(item.userRating), item.lastRatedAt)

--- a/plextraktsync/plex/PlexRatings.py
+++ b/plextraktsync/plex/PlexRatings.py
@@ -39,7 +39,7 @@ class PlexRatings:
             # if show id is not listed, return none, otherwise fetch from item itself
             if show_id not in ratings:
                 return None
-            return Rating(m.item.userRating, m.item.lastRatedAt)
+            return Rating.create(m.item.userRating, m.item.lastRatedAt)
         else:
             raise RuntimeError(f"Unsupported media type: {media_type}")
 
@@ -62,4 +62,4 @@ class PlexRatings:
         }
 
         for item in section.search(filters=filters, includeGuids=False):
-            yield item.ratingKey, Rating(int(item.userRating), item.lastRatedAt)
+            yield item.ratingKey, Rating.create(item.userRating, item.lastRatedAt)

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -122,7 +122,7 @@ class Sync:
         if not self.config.sync_ratings:
             return
 
-        if m.plex_rating is m.trakt_rating:
+        if m.plex_rating == m.trakt_rating:
             return
 
         rating_priority = self.config["rating_priority"]

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -160,8 +160,8 @@ class TraktApi:
     @rate_limit()
     @time_limit()
     @retry()
-    def rate(self, m: TraktMedia, rating: int):
-        m.rate(rating)
+    def rate(self, m: TraktMedia, rating: int, rate_date: datetime.datetime = None):
+        m.rate(rating, rate_date)
 
     @rate_limit()
     @time_limit()

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -22,6 +22,7 @@ from plextraktsync.path import pytrakt_file
 from plextraktsync.trakt.PartialTraktMedia import PartialTraktMedia
 from plextraktsync.trakt.TraktLookup import TraktLookup
 from plextraktsync.trakt.TraktRatingCollection import TraktRatingCollection
+from plextraktsync.util.Rating import Rating
 
 if TYPE_CHECKING:
     from trakt.movies import Movie
@@ -140,7 +141,7 @@ class TraktApi:
     def ratings(self):
         return TraktRatingCollection(self)
 
-    def rating(self, m) -> int | None:
+    def rating(self, m) -> Rating | None:
         """
         The trakt api (Python module) is inconsistent:
         - Movie has "rating" property, while TVShow does not

--- a/plextraktsync/trakt/TraktRatingCollection.py
+++ b/plextraktsync/trakt/TraktRatingCollection.py
@@ -30,4 +30,4 @@ class TraktRatingCollection(dict):
     def ratings(self, media_type: str):
         index = media_type.rstrip("s")
         for r in self.trakt.get_ratings(media_type):
-            yield r[index]["ids"]["trakt"], Rating(r["rating"], r["rated_at"])
+            yield r[index]["ids"]["trakt"], Rating.create(r["rating"], r["rated_at"])

--- a/plextraktsync/trakt/TraktRatingCollection.py
+++ b/plextraktsync/trakt/TraktRatingCollection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.flatten import flatten_dict
+from plextraktsync.util.Rating import Rating
 
 if TYPE_CHECKING:
     from plextraktsync.trakt.TraktApi import TraktApi
@@ -29,4 +30,4 @@ class TraktRatingCollection(dict):
     def ratings(self, media_type: str):
         index = media_type.rstrip("s")
         for r in self.trakt.get_ratings(media_type):
-            yield r[index]["ids"]["trakt"], r["rating"]
+            yield r[index]["ids"]["trakt"], Rating(r["rating"], r["rated_at"])

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -13,7 +13,7 @@ class Rating(NamedTuple):
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """
         if isinstance(other, (int, float)):
-            return self.rating == other
+            return self.rating == int(other)
 
         return self.rating == other.rating
 

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -15,6 +15,9 @@ class Rating(NamedTuple):
         if isinstance(other, (int, float)):
             return self.rating == int(other)
 
+        if other is None:
+            return False
+
         return self.rating == other.rating
 
     def __str__(self):

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -7,7 +7,7 @@ from trakt.utils import timestamp
 
 
 class Rating(NamedTuple):
-    rating: int | None
+    rating: int
     rated_at: datetime | None
 
     def __eq__(self, other):

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -5,15 +5,12 @@ from typing import NamedTuple
 
 
 class Rating(NamedTuple):
-    rating: int | float | None
-    rated_at: datetime | str | None
+    rating: int | None
+    rated_at: datetime | None
 
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """
-        if self.rating is None or other.rating is None:
-            return self.rating is other.rating
-
-        return int(self.rating) == int(other.rating)
+        return self.rating == other.rating
 
     @classmethod
     def create(cls, rating: int | float | None, rated_at: datetime | str | None):

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import NamedTuple
 
+from trakt.utils import timestamp
+
 
 class Rating(NamedTuple):
     rating: int | None
@@ -11,6 +13,9 @@ class Rating(NamedTuple):
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """
         return self.rating == other.rating
+
+    def __str__(self):
+        return f"Rating(rating={self.rating}, rated_at='{timestamp(self.rated_at)}')"
 
     @classmethod
     def create(cls, rating: int | float | None, rated_at: datetime | str | None):

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -14,8 +14,10 @@ class Rating(NamedTuple):
 
     @classmethod
     def create(cls, rating: int | float | None, rated_at: datetime | str | None):
-        if rating is not None:
-            rating = int(rating)
+        if rating is None:
+            return None
+
+        rating = int(rating)
         if isinstance(rated_at, str):
             rated_at = datetime.fromisoformat(rated_at)
 

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -7,3 +7,7 @@ from typing import NamedTuple
 class Rating(NamedTuple):
     rating: int
     rated_at: datetime
+
+    def __eq__(self, other):
+        """ Ratings are equal if their rating value is the same """
+        return self.rating == other.rating

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import NamedTuple
 
 
@@ -19,6 +19,12 @@ class Rating(NamedTuple):
 
         rating = int(rating)
         if isinstance(rated_at, str):
-            rated_at = datetime.fromisoformat(rated_at)
+            try:
+                rated_at = datetime.fromisoformat(rated_at)
+            except ValueError:
+                # Handle older Python < 3.11
+                rated_at = (datetime.strptime(rated_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+                            # https://stackoverflow.com/questions/3305413/how-to-preserve-timezone-when-parsing-date-time-strings-with-strptime/63988322#63988322
+                            .replace(tzinfo=timezone.utc))
 
         return cls(rating, rated_at)

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -12,6 +12,9 @@ class Rating(NamedTuple):
 
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """
+        if isinstance(other, (int, float)):
+            return self.rating == other
+
         return self.rating == other.rating
 
     def __str__(self):

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -5,8 +5,8 @@ from typing import NamedTuple
 
 
 class Rating(NamedTuple):
-    rating: int
-    rated_at: datetime
+    rating: int | float | None
+    rated_at: datetime | str | None
 
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import NamedTuple
+
+
+class Rating(NamedTuple):
+    rating: int
+    rated_at: datetime

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -14,3 +14,12 @@ class Rating(NamedTuple):
             return self.rating is other.rating
 
         return int(self.rating) == int(other.rating)
+
+    @classmethod
+    def create(cls, rating: int | float | None, rated_at: datetime | str | None):
+        if rating is not None:
+            rating = int(rating)
+        if isinstance(rated_at, str):
+            rated_at = datetime.fromisoformat(rated_at)
+
+        return cls(rating, rated_at)

--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -10,4 +10,7 @@ class Rating(NamedTuple):
 
     def __eq__(self, other):
         """ Ratings are equal if their rating value is the same """
-        return self.rating == other.rating
+        if self.rating is None or other.rating is None:
+            return self.rating is other.rating
+
+        return int(self.rating) == int(other.rating)

--- a/tests/test_rating.py
+++ b/tests/test_rating.py
@@ -5,6 +5,9 @@ from plextraktsync.util.Rating import Rating
 
 
 def test_rating():
+    r = Rating.create(None, datetime(2024, 1, 17, 2, 38, 49))
+    assert r is None
+
     r = Rating.create(1.0, datetime(2024, 1, 17, 2, 38, 49))
     assert r.rating == 1
     assert r.rated_at == datetime(2024, 1, 17, 2, 38, 49)

--- a/tests/test_rating.py
+++ b/tests/test_rating.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3 -m pytest
+from datetime import datetime
+
+from plextraktsync.util.Rating import Rating
+
+
+def test_rating():
+    r = Rating.create(1.0, datetime(2024, 1, 17, 2, 38, 49))
+    assert r.rating == 1
+    assert r.rated_at == datetime(2024, 1, 17, 2, 38, 49)

--- a/tests/test_rating.py
+++ b/tests/test_rating.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3 -m pytest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from plextraktsync.util.Rating import Rating
 
@@ -11,3 +11,7 @@ def test_rating():
     r = Rating.create(1.0, datetime(2024, 1, 17, 2, 38, 49))
     assert r.rating == 1
     assert r.rated_at == datetime(2024, 1, 17, 2, 38, 49)
+
+    r = Rating.create(1.2, "2024-02-21T21:36:31.000Z")
+    assert r.rating == 1
+    assert r.rated_at == datetime(2024, 2, 21, 21, 36, 31, tzinfo=timezone.utc)


### PR DESCRIPTION
Requires:
- https://github.com/glensc/python-pytrakt/pull/41 (pytrakt dependency)

NOTE: Plex does not support setting `rated_at` timestamp, but it provides `lastRatedAt` attribute.

Fixes https://github.com/Taxel/PlexTraktSync/issues/1805