### PR TITLE
Refactor: Use named loggers everywhere

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -27,12 +27,14 @@ def command():
             except EOFError as e:
                 raise ClickException(f"Program requested terminal, No terminal is connected: {e}")
             except ClickException as e:
-                from plextraktsync.factory import logger
+                from plextraktsync.factory import logging
 
+                logger = logging.getLogger(__name__)
                 logger.fatal(f"Error running {name} command: {str(e)}")
             except Exception as e:
-                from plextraktsync.factory import logger
+                from plextraktsync.factory import logging
 
+                logger = logging.getLogger(__name__)
                 logger.exception(e)
 
                 raise ClickException(f"Error running {name} command: {str(e)}")

--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from plextraktsync.commands.login import ensure_login
 from plextraktsync.decorators.measure_time import measure_time
-from plextraktsync.factory import factory, logger
+from plextraktsync.factory import factory, logging
+
+logger = logging.getLogger(__name__)
 
 
 def sync(

--- a/plextraktsync/decorators/measure_time.py
+++ b/plextraktsync/decorators/measure_time.py
@@ -1,8 +1,9 @@
-import logging
 from contextlib import contextmanager
 from time import time
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager

--- a/plextraktsync/decorators/rate_limit.py
+++ b/plextraktsync/decorators/rate_limit.py
@@ -4,7 +4,9 @@ from time import sleep
 from click import ClickException
 from trakt.errors import RateLimitException
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
+
+logger = logging.getLogger(__name__)
 
 
 # https://trakt.docs.apiary.io/#introduction/rate-limiting

--- a/plextraktsync/decorators/retry.py
+++ b/plextraktsync/decorators/retry.py
@@ -7,7 +7,9 @@ from requests import ReadTimeout, RequestException
 from trakt.errors import (BadResponseException, TraktBadGateway,
                           TraktInternalException, TraktUnavailable)
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
+
+logger = logging.getLogger(__name__)
 
 
 def retry(retries=5):

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -6,7 +6,7 @@ from plexapi.exceptions import PlexApiException
 from requests import RequestException
 from trakt.errors import TraktException
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
 from plextraktsync.media.Media import Media
 
 if TYPE_CHECKING:
@@ -25,18 +25,19 @@ class MediaFactory:
     def __init__(self, plex: PlexApi, trakt: TraktApi):
         self.plex = plex
         self.trakt = trakt
+        self.logger = logging.getLogger(__name__)
 
     def resolve_any(self, pm: PlexLibraryItem, show: Media = None) -> Media | None:
         try:
             guids = pm.guids
         except (PlexApiException, RequestException) as e:
-            logger.error(f"Skipping {pm}: {e}")
+            self.logger.error(f"Skipping {pm}: {e}")
             return None
 
         for guid in guids:
             m = self.resolve_guid(guid, show)
             if m:
-                logger.debug(f"Resolved {guid} of {guid.pm} to {m}")
+                self.logger.debug(f"Resolved {guid} of {guid.pm} to {m}")
                 return m
 
         return None
@@ -55,7 +56,7 @@ class MediaFactory:
                 level = "error"
                 reason = "is not a valid provider"
 
-            getattr(logger, level)(f"{error} {reason}", extra={"markup": True})
+            getattr(self.logger, level)(f"{error} {reason}", extra={"markup": True})
 
             return None
 
@@ -65,11 +66,11 @@ class MediaFactory:
             else:
                 tm = self.trakt.find_by_guid(guid)
         except (TraktException, RequestException) as e:
-            logger.warning(f"{guid.title_link}: Skipping {guid}: Trakt errors: {e}", extra={"markup": True})
+            self.logger.warning(f"{guid.title_link}: Skipping {guid}: Trakt errors: {e}", extra={"markup": True})
             return None
 
         if tm is None:
-            logger.warning(f"{guid.title_link}: Skipping {guid} not found on Trakt", extra={"markup": True})
+            self.logger.warning(f"{guid.title_link}: Skipping {guid} not found on Trakt", extra={"markup": True})
             return None
 
         return self.make_media(guid.pm, tm)

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -21,11 +21,11 @@ class MediaFactory:
     """
     Class that is able to resolve Trakt media item from Plex media item and vice versa and return generic Media class
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self, plex: PlexApi, trakt: TraktApi):
         self.plex = plex
         self.trakt = trakt
-        self.logger = logging.getLogger(__name__)
 
     def resolve_any(self, pm: PlexLibraryItem, show: Media = None) -> Media | None:
         try:

--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -27,6 +27,7 @@ class Walker(SetWindowTitle):
     """
     Class dealing with finding and walking library, movies/shows, episodes
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(
         self,
@@ -41,7 +42,6 @@ class Walker(SetWindowTitle):
         self.trakt = trakt
         self.mf = mf
         self.config = config
-        self.logger = logging.getLogger(__name__)
 
     @cached_property
     def plan(self):

--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -41,7 +41,7 @@ class Walker(SetWindowTitle):
         self.trakt = trakt
         self.mf = mf
         self.config = config
-        self.logger = logging.getLogger("PlexTraktSync.Walker")
+        self.logger = logging.getLogger(__name__)
 
     @cached_property
     def plan(self):

--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -30,6 +30,7 @@ class PlexApi:
     """
     Plex API class abstracting common data access and dealing with requests cache.
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(
             self,
@@ -38,7 +39,6 @@ class PlexApi:
     ):
         self.server = server
         self.config = config
-        self.logger = logging.getLogger(__name__)
 
     def __str__(self):
         return str(self.server)

--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -12,7 +12,7 @@ from plexapi.server import SystemAccount, SystemDevice
 from plextraktsync.decorators.flatten import flatten_dict, flatten_list
 from plextraktsync.decorators.memoize import memoize
 from plextraktsync.decorators.retry import retry
-from plextraktsync.factory import factory, logger
+from plextraktsync.factory import factory, logging
 from plextraktsync.plex.PlexId import PlexId
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 from plextraktsync.plex.PlexLibrarySection import PlexLibrarySection
@@ -38,6 +38,7 @@ class PlexApi:
     ):
         self.server = server
         self.config = config
+        self.logger = logging.getLogger(__name__)
 
     def __str__(self):
         return str(self.server)
@@ -160,7 +161,7 @@ class PlexApi:
         try:
             history = m.history()
         except Unauthorized as e:
-            logger.debug(f"No permission to access play history: {e}")
+            self.logger.debug(f"No permission to access play history: {e}")
             return
 
         for h in history:
@@ -200,17 +201,17 @@ class PlexApi:
                 plex_owner_account = MyPlexAccount(token=plex_owner_token, session=factory.session)
                 return plex_owner_account.switchHomeUser(plex_username)
             except BadRequest as e:
-                logger.error(f"Error during {plex_username} account access: {e}")
+                self.logger.error(f"Error during {plex_username} account access: {e}")
         elif plex_account_token:
             try:
                 return MyPlexAccount(token=plex_account_token, session=factory.session)
             except BadRequest as e:
-                logger.error(f"Error during {plex_username} account access: {e}")
+                self.logger.error(f"Error during {plex_username} account access: {e}")
         else:
             try:
                 return self.server.myPlexAccount()
             except BadRequest as e:
-                logger.error(f"Error during {plex_username} account access: {e}")
+                self.logger.error(f"Error during {plex_username} account access: {e}")
         return None
 
     def watchlist(self, libtype=None) -> list[Movie | Show] | None:
@@ -225,20 +226,20 @@ class PlexApi:
         try:
             return self.account.watchlist(libtype=libtype, **params)
         except BadRequest as e:
-            logger.error(f"Error during {self.account.username} watchlist access: {e}")
+            self.logger.error(f"Error during {self.account.username} watchlist access: {e}")
             return None
 
     def add_to_watchlist(self, item):
         try:
             self.account.addToWatchlist(item)
         except BadRequest as e:
-            logger.error(f"Error when adding {item.title} to Plex watchlist: {e}")
+            self.logger.error(f"Error when adding {item.title} to Plex watchlist: {e}")
 
     def remove_from_watchlist(self, item):
         try:
             self.account.removeFromWatchlist(item)
         except BadRequest as e:
-            logger.error(f"Error when removing {item.title} from Plex watchlist: {e}")
+            self.logger.error(f"Error when removing {item.title} from Plex watchlist: {e}")
 
     @retry()
     def search_online(self, title: str, media_type: str):
@@ -247,7 +248,7 @@ class PlexApi:
         try:
             result = self.account.searchDiscover(title, libtype=media_type)
         except (BadRequest, Unauthorized) as e:
-            logger.error(f"{title}: Searching Plex Discover error: {e}")
+            self.logger.error(f"{title}: Searching Plex Discover error: {e}")
             return None
         except NotFound:
             return None
@@ -261,6 +262,6 @@ class PlexApi:
                 self.mark_unwatched(ep)
                 reset_count += 1
             else:
-                logger.debug(
+                self.logger.debug(
                     f"{show.title} {ep.seasonEpisode} watched at {ep.lastViewedAt} after reset date {reset_date}")
-        logger.debug(f"{show.title}: {reset_count} Plex episode(s) marked as unwatched.")
+        self.logger.debug(f"{show.title}: {reset_count} Plex episode(s) marked as unwatched.")

--- a/plextraktsync/plex/PlexPlaylist.py
+++ b/plextraktsync/plex/PlexPlaylist.py
@@ -19,7 +19,7 @@ class PlexPlaylist(RichMarkup):
     def __init__(self, server: PlexServer, name: str):
         self.server = server
         self.name = name
-        self.logger = logging.getLogger("PlexTraktSync.PlexPlaylist")
+        self.logger = logging.getLogger(__name__)
 
     def __iter__(self):
         return iter(self.items)

--- a/plextraktsync/plex/PlexPlaylist.py
+++ b/plextraktsync/plex/PlexPlaylist.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 
 class PlexPlaylist(RichMarkup):
+    logger = logging.getLogger(__name__)
+
     def __init__(self, server: PlexServer, name: str):
         self.server = server
         self.name = name
-        self.logger = logging.getLogger(__name__)
 
     def __iter__(self):
         return iter(self.items)

--- a/plextraktsync/plex/PlexServerConnection.py
+++ b/plextraktsync/plex/PlexServerConnection.py
@@ -14,7 +14,7 @@ from plextraktsync.factory import Factory, logging
 class PlexServerConnection:
     def __init__(self, factory: Factory):
         self.factory = factory
-        self.logger = logging.getLogger("PlexTraktSync.PlexServerConnection")
+        self.logger = logging.getLogger(__name__)
 
     @property
     def timeout(self):

--- a/plextraktsync/plex/PlexServerConnection.py
+++ b/plextraktsync/plex/PlexServerConnection.py
@@ -12,9 +12,10 @@ from plextraktsync.factory import Factory, logging
 
 
 class PlexServerConnection:
+    logger = logging.getLogger(__name__)
+
     def __init__(self, factory: Factory):
         self.factory = factory
-        self.logger = logging.getLogger(__name__)
 
     @property
     def timeout(self):

--- a/plextraktsync/queue/BackgroundTask.py
+++ b/plextraktsync/queue/BackgroundTask.py
@@ -22,7 +22,7 @@ class BackgroundTask:
         self.queues = defaultdict(list)
         self.timer = timer
         self.tasks = tasks
-        self.logger = logging.getLogger("PlexTraktSync.BackgroundTask")
+        self.logger = logging.getLogger(__name__)
 
     def check_timer(self):
         if not self.timer:

--- a/plextraktsync/queue/BackgroundTask.py
+++ b/plextraktsync/queue/BackgroundTask.py
@@ -17,12 +17,12 @@ class BackgroundTask:
     """
     Class to read events from queue and invoke them at tasks to flush them at interval set by the timer
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self, timer: Timer = None, *tasks):
         self.queues = defaultdict(list)
         self.timer = timer
         self.tasks = tasks
-        self.logger = logging.getLogger(__name__)
 
     def check_timer(self):
         if not self.timer:

--- a/plextraktsync/queue/TraktBatchWorker.py
+++ b/plextraktsync/queue/TraktBatchWorker.py
@@ -17,9 +17,7 @@ class TraktBatchWorker:
         "add_to_watchlist",
         "remove_from_watchlist",
     )
-
-    def __init__(self):
-        self.logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         for name in self.QUEUES:

--- a/plextraktsync/queue/TraktBatchWorker.py
+++ b/plextraktsync/queue/TraktBatchWorker.py
@@ -19,7 +19,7 @@ class TraktBatchWorker:
     )
 
     def __init__(self):
-        self.logger = logging.getLogger("PlexTraktSync.TraktBatchWorker")
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         for name in self.QUEUES:

--- a/plextraktsync/queue/TraktMarkWatchedWorker.py
+++ b/plextraktsync/queue/TraktMarkWatchedWorker.py
@@ -14,9 +14,7 @@ from plextraktsync.util.remove_empty_values import remove_empty_values
 class TraktMarkWatchedWorker:
     # Queue this Worker can handle
     QUEUE = "add_to_history"
-
-    def __init__(self):
-        self.logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         items = queues[self.QUEUE]

--- a/plextraktsync/queue/TraktMarkWatchedWorker.py
+++ b/plextraktsync/queue/TraktMarkWatchedWorker.py
@@ -16,7 +16,7 @@ class TraktMarkWatchedWorker:
     QUEUE = "add_to_history"
 
     def __init__(self):
-        self.logger = logging.getLogger("PlexTraktSync.TraktMarkWatchedWorker")
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         items = queues[self.QUEUE]

--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -22,7 +22,7 @@ class TraktScrobbleWorker:
     )
 
     def __init__(self):
-        self.logger = logging.getLogger("PlexTraktSync.TraktScrobbleWorker")
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         for name in self.QUEUES:

--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -20,9 +20,7 @@ class TraktScrobbleWorker:
         "scrobble_pause",
         "scrobble_stop",
     )
-
-    def __init__(self):
-        self.logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
     def __call__(self, queues):
         for name in self.QUEUES:

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -4,7 +4,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.measure_time import measure_time
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
 from plextraktsync.trakt.TraktUserListCollection import TraktUserListCollection
 
 if TYPE_CHECKING:
@@ -23,6 +23,7 @@ class Sync:
         self.config = config
         self.plex = plex
         self.trakt = trakt
+        self.logger = logging.getLogger(__name__)
 
     @cached_property
     def plex_wl(self):
@@ -45,17 +46,17 @@ class Sync:
         is_partial = walker.is_partial and not dry_run
 
         if is_partial and self.config.clear_collected:
-            logger.warning("Running partial library sync. Clear collected will be disabled.")
+            self.logger.warning("Running partial library sync. Clear collected will be disabled.")
 
         if self.config.update_plex_wl_as_pl:
             if is_partial:
-                logger.warning("Running partial library sync. Watchlist as playlist won't update because it needs full library sync.")
+                self.logger.warning("Running partial library sync. Watchlist as playlist won't update because it needs full library sync.")
             else:
                 trakt_lists.add_watchlist(self.trakt.watchlist_movies)
 
         if self.config.sync_liked_lists:
             if is_partial:
-                logger.warning("Partial walk, disabling liked lists updating. Liked lists won't update because it needs full library sync.")
+                self.logger.warning("Partial walk, disabling liked lists updating. Liked lists won't update because it needs full library sync.")
             else:
                 trakt_lists.load_lists(self.trakt.liked_lists)
 
@@ -96,7 +97,7 @@ class Sync:
 
         if self.config.update_plex_wl_as_pl or self.config.sync_liked_lists:
             if is_partial:
-                logger.warning("Running partial library sync. Liked lists won't update because it needs full library sync.")
+                self.logger.warning("Running partial library sync. Liked lists won't update because it needs full library sync.")
             else:
                 if not dry_run:
                     with measure_time("Updated liked list"):
@@ -113,7 +114,7 @@ class Sync:
         if m.is_collected:
             return
 
-        logger.info(f"Adding to collection: {m.title_link}", extra={"markup": True})
+        self.logger.info(f"Adding to collection: {m.title_link}", extra={"markup": True})
 
         if not dry_run:
             m.add_to_collection()
@@ -154,12 +155,12 @@ class Sync:
                 rate = "plex"
 
         if rate == "trakt":
-            logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt (was {m.trakt_rating})", extra={"markup": True})
+            self.logger.info(f"Rating {m.title_link} with {m.plex_rating} on Trakt (was {m.trakt_rating})", extra={"markup": True})
             if not dry_run:
                 m.trakt_rate()
 
         elif rate == "plex":
-            logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex (was {m.plex_rating})", extra={"markup": True})
+            self.logger.info(f"Rating {m.title_link} with {m.trakt_rating} on Plex (was {m.plex_rating})", extra={"markup": True})
             if not dry_run:
                 m.plex_rate()
 
@@ -176,27 +177,27 @@ class Sync:
 
             if m.is_episode and m.watched_before_reset:
                 show = m.plex.item.show()
-                logger.info(f"Show '{show.title}' has been reset in trakt at {m.show_reset_at}.")
-                logger.info(f"Marking '{show.title}' as unwatched in Plex.")
+                self.logger.info(f"Show '{show.title}' has been reset in trakt at {m.show_reset_at}.")
+                self.logger.info(f"Marking '{show.title}' as unwatched in Plex.")
                 if not dry_run:
                     m.reset_show()
             else:
-                logger.info(f"Marking as watched in Trakt: {m.title_link}", extra={"markup": True})
+                self.logger.info(f"Marking as watched in Trakt: {m.title_link}", extra={"markup": True})
                 if not dry_run:
                     m.mark_watched_trakt()
         elif m.watched_on_trakt:
             if not self.config.trakt_to_plex["watched_status"]:
                 return
-            logger.info(f"Marking as watched in Plex: {m.title_link}", extra={"markup": True})
+            self.logger.info(f"Marking as watched in Plex: {m.title_link}", extra={"markup": True})
             if not dry_run:
                 m.mark_watched_plex()
 
     def watchlist_sync_item(self, m: Media, dry_run=False):
         if m.plex is None:
             if self.config.update_plex_wl:
-                logger.info(f"Skipping {m.title_link} from Trakt watchlist because not found in Plex Discover", extra={"markup": True})
+                self.logger.info(f"Skipping {m.title_link} from Trakt watchlist because not found in Plex Discover", extra={"markup": True})
             elif self.config.update_trakt_wl:
-                logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
+                self.logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
                 if not dry_run:
                     m.remove_from_trakt_watchlist()
             return
@@ -204,11 +205,11 @@ class Sync:
         if m in self.plex_wl:
             if m not in self.trakt_wl:
                 if self.config.update_trakt_wl:
-                    logger.info(f"Adding {m.title_link} to Trakt watchlist", extra={"markup": True})
+                    self.logger.info(f"Adding {m.title_link} to Trakt watchlist", extra={"markup": True})
                     if not dry_run:
                         m.add_to_trakt_watchlist()
                 else:
-                    logger.info(f"Removing {m.title_link} from Plex watchlist", extra={"markup": True})
+                    self.logger.info(f"Removing {m.title_link} from Plex watchlist", extra={"markup": True})
                     if not dry_run:
                         m.remove_from_plex_watchlist()
             else:
@@ -220,11 +221,11 @@ class Sync:
                 del self.trakt_wl[m]
         elif m in self.trakt_wl:
             if self.config.update_plex_wl:
-                logger.info(f"Adding {m.title_link} to Plex watchlist", extra={"markup": True})
+                self.logger.info(f"Adding {m.title_link} to Plex watchlist", extra={"markup": True})
                 if not dry_run:
                     m.add_to_plex_watchlist()
             else:
-                logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
+                self.logger.info(f"Removing {m.title_link} from Trakt watchlist", extra={"markup": True})
                 if not dry_run:
                     m.remove_from_trakt_watchlist()
 
@@ -248,6 +249,6 @@ class Sync:
 
         n = len(delete_ids)
         for i, tm in enumerate(delete_items, start=1):
-            logger.info(f"Remove from Trakt collection ({i}/{n}): {tm}")
+            self.logger.info(f"Remove from Trakt collection ({i}/{n}): {tm}")
             if not dry_run:
                 self.trakt.remove_from_collection(tm)

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -19,11 +19,12 @@ if TYPE_CHECKING:
 
 
 class Sync:
+    logger = logging.getLogger(__name__)
+
     def __init__(self, config: SyncConfig, plex: PlexApi, trakt: TraktApi):
         self.config = config
         self.plex = plex
         self.trakt = trakt
-        self.logger = logging.getLogger(__name__)
 
     @cached_property
     def plex_wl(self):

--- a/plextraktsync/trakt/ScrobblerProxy.py
+++ b/plextraktsync/trakt/ScrobblerProxy.py
@@ -17,7 +17,7 @@ class ScrobblerProxy:
     def __init__(self, scrobbler: Scrobbler, threshold=80):
         self.scrobbler = scrobbler
         self.threshold = threshold
-        self.logger = logging.getLogger("PlexTraktSync.ScrobblerProxy")
+        self.logger = logging.getLogger(__name__)
 
     def update(self, progress: float):
         self.logger.debug(f"update({self.scrobbler.media}): {progress}")

--- a/plextraktsync/trakt/ScrobblerProxy.py
+++ b/plextraktsync/trakt/ScrobblerProxy.py
@@ -13,11 +13,11 @@ class ScrobblerProxy:
     """
     Proxy to Scrobbler that queues requests to update trakt
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self, scrobbler: Scrobbler, threshold=80):
         self.scrobbler = scrobbler
         self.threshold = threshold
-        self.logger = logging.getLogger(__name__)
 
     def update(self, progress: float):
         self.logger.debug(f"update({self.scrobbler.media}): {progress}")

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -37,11 +37,11 @@ class TraktApi:
     """
     Trakt API class abstracting common data access and dealing with requests cache.
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self):
         trakt.core.CONFIG_PATH = pytrakt_file
         trakt.core.session = factory.session
-        self.logger = logging.getLogger(__name__)
 
     @staticmethod
     def device_auth(client_id: str, client_secret: str):

--- a/plextraktsync/trakt/TraktLookup.py
+++ b/plextraktsync/trakt/TraktLookup.py
@@ -4,7 +4,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plextraktsync.decorators.retry import retry
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
 
 EPISODES_ORDERING_WARNING = "episodes ordering is different in Plex and Trakt. " \
                             "Check your Plex media source, TMDB is recommended."
@@ -24,6 +24,7 @@ class TraktLookup:
         self.provider_table = {}
         self.tm = tm
         self.same_order = True
+        self.logger = logging.getLogger(__name__)
 
     @cached_property
     @retry()
@@ -53,7 +54,7 @@ class TraktLookup:
             for te in self.table[season].values():
                 table[str(te.ids.get(provider))] = te
         self.provider_table[provider] = table
-        logger.debug(f"{self.tm.title}: lookup table build with '{provider}' ids")
+        self.logger.debug(f"{self.tm.title}: lookup table build with '{provider}' ids")
 
     def from_guid(self, guid: PlexGuid):
         """
@@ -97,6 +98,6 @@ class TraktLookup:
         except KeyError:
             return None
         if self.same_order:
-            logger.warning(f"'{self.tm.title}' {EPISODES_ORDERING_WARNING}")
+            self.logger.warning(f"'{self.tm.title}' {EPISODES_ORDERING_WARNING}")
             self.same_order = False
         return ep

--- a/plextraktsync/trakt/TraktLookup.py
+++ b/plextraktsync/trakt/TraktLookup.py
@@ -19,12 +19,12 @@ class TraktLookup:
     """
     Trakt lookup table to find all Trakt episodes of a TVShow
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self, tm: TVShow):
         self.provider_table = {}
         self.tm = tm
         self.same_order = True
-        self.logger = logging.getLogger(__name__)
 
     @cached_property
     @retry()

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -25,7 +25,7 @@ class TraktUserList:
         self._items = items
         self.description = None
         self.plex_items = []
-        self.logger = logging.getLogger("PlexTraktSync.TraktUserList")
+        self.logger = logging.getLogger(__name__)
 
     def __iter__(self):
         return iter(self.items)

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 class TraktUserList:
     plex_items: list[tuple[int, PlexLibraryItem]]
+    logger = logging.getLogger(__name__)
 
     def __init__(self,
                  trakt_id: int = None,
@@ -25,7 +26,6 @@ class TraktUserList:
         self._items = items
         self.description = None
         self.plex_items = []
-        self.logger = logging.getLogger(__name__)
 
     def __iter__(self):
         return iter(self.items)

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -12,9 +12,7 @@ if TYPE_CHECKING:
 
 
 class TraktUserListCollection(UserList):
-    def __init__(self):
-        super().__init__()
-        self.logger = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
 
     def add_to_lists(self, m: Media):
         # Skip movie editions

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class TraktUserListCollection(UserList):
     def __init__(self):
         super().__init__()
-        self.logger = logging.getLogger("PlexTraktSync.TraktUserListCollection")
+        self.logger = logging.getLogger(__name__)
 
     def add_to_lists(self, m: Media):
         # Skip movie editions

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -228,18 +228,35 @@ class Factory:
 
     @cached_property
     def logger(self):
-        logger = self.logging.getLogger("PlexTraktSync")
+        logger = self.logging.getLogger("plextraktsync")
         config = self.config
         loggers = [
-            "PlexTraktSync",
-            "PlexTraktSync.BackgroundTask",
-            "PlexTraktSync.EventDispatcher",
-            "PlexTraktSync.PlexServerConnection",
-            "PlexTraktSync.ScrobblerProxy",
-            "PlexTraktSync.Timer",
-            "PlexTraktSync.TraktBatchWorker",
-            "PlexTraktSync.WatchStateUpdater",
-            "PlexTraktSync.WebSocketListener",
+            "plextraktsync",
+            "plextraktsync.cli",
+            "plextraktsync.commands.sync",
+            "plextraktsync.decorators.measure_time",
+            "plextraktsync.decorators.rate_limit",
+            "plextraktsync.decorators.retry",
+            "plextraktsync.media.MediaFactory",
+            "plextraktsync.plan.Walker",
+            "plextraktsync.plex.PlexApi",
+            "plextraktsync.plex.PlexPlaylist",
+            "plextraktsync.plex.PlexServerConnection",
+            "plextraktsync.queue.BackgroundTask",
+            "plextraktsync.queue.TraktBatchWorker",
+            "plextraktsync.queue.TraktMarkWatchedWorker",
+            "plextraktsync.queue.TraktScrobbleWorker",
+            "plextraktsync.sync",
+            "plextraktsync.trakt.ScrobblerProxy",
+            "plextraktsync.trakt.TraktApi",
+            "plextraktsync.trakt.TraktLookup",
+            "plextraktsync.trakt.TraktUserList",
+            "plextraktsync.trakt.TraktUserListCollection",
+            "plextraktsync.util.Factory",
+            "plextraktsync.util.Timer",
+            "plextraktsync.watch.EventDispatcher",
+            "plextraktsync.watch.WatchStateUpdater",
+            "plextraktsync.watch.WebSocketListener",
         ]
         loggers.extend(config["logging"]["filter_loggers"] or [])
 

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -224,11 +224,16 @@ class Factory:
         config = self.config
         initialize(config)
 
+        # Setup log filters
+        self.logger_filter_apply(logging.getLogger("plextraktsync"))
+
         return logging
 
     @cached_property
     def logger(self):
-        logger = self.logging.getLogger("plextraktsync")
+        return self.logging.getLogger("plextraktsync")
+
+    def logger_filter_apply(self, logger):
         config = self.config
         loggers = [
             "plextraktsync",
@@ -264,8 +269,9 @@ class Factory:
 
         filter = LoggerFilter(config["logging"]["filter"], logger)
 
+        import logging
         for name in loggers:
-            self.logging.getLogger(name).addFilter(filter)
+            logging.getLogger(name).addFilter(filter)
 
         return logger
 

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -233,6 +233,17 @@ class Factory:
     def logger(self):
         return self.logging.getLogger("plextraktsync")
 
+    @cached_property
+    def logger_filter(self):
+        import logging
+
+        from plextraktsync.logger.filter import LoggerFilter
+
+        config = self.config
+        logger = logging.getLogger("plextraktsync")
+
+        return LoggerFilter(config["logging"]["filter"], logger)
+
     def logger_filter_apply(self, logger):
         config = self.config
         loggers = [
@@ -265,13 +276,11 @@ class Factory:
         ]
         loggers.extend(config["logging"]["filter_loggers"] or [])
 
-        from plextraktsync.logger.filter import LoggerFilter
-
-        filter = LoggerFilter(config["logging"]["filter"], logger)
-
         import logging
+
+        logger_filter = self.logger_filter
         for name in loggers:
-            logging.getLogger(name).addFilter(filter)
+            logging.getLogger(name).addFilter(logger_filter)
 
         return logger
 

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -219,7 +219,6 @@ class Factory:
     def logging(self):
         import logging
 
-        from plextraktsync.decorators.memoize import memoize
         from plextraktsync.logger.init import initialize
 
         config = self.config
@@ -231,7 +230,6 @@ class Factory:
 
         class Logging:
             @staticmethod
-            @memoize
             def getLogger(name):
                 """ Wrap getLogger and add our filters """
                 logger = logging.getLogger(name)

--- a/plextraktsync/util/Timer.py
+++ b/plextraktsync/util/Timer.py
@@ -7,13 +7,13 @@ class Timer:
     """
     Class dealing with limiting that something is not called more often than {delay}
     """
+    logger = logging.getLogger(__name__)
 
     def __init__(self, delay: float):
         if delay <= 0:
             raise ValueError(f"Delay must be a positive number: {delay}")
         self.delay = delay
         self.last_time = None
-        self.logger = logging.getLogger(__name__)
 
     @property
     def time_remaining(self):

--- a/plextraktsync/util/Timer.py
+++ b/plextraktsync/util/Timer.py
@@ -13,7 +13,7 @@ class Timer:
             raise ValueError(f"Delay must be a positive number: {delay}")
         self.delay = delay
         self.last_time = None
-        self.logger = logging.getLogger("PlexTraktSync.Timer")
+        self.logger = logging.getLogger(__name__)
 
     @property
     def time_remaining(self):

--- a/plextraktsync/watch/EventDispatcher.py
+++ b/plextraktsync/watch/EventDispatcher.py
@@ -4,10 +4,11 @@ from plextraktsync.watch.events import Error, ServerStarted
 
 
 class EventDispatcher:
+    logger = logging.getLogger(__name__)
+
     def __init__(self):
         self.event_listeners = []
         self.event_factory = EventFactory()
-        self.logger = logging.getLogger(__name__)
 
     def on(self, event_type, listener, **kwargs):
         self.event_listeners.append(

--- a/plextraktsync/watch/EventDispatcher.py
+++ b/plextraktsync/watch/EventDispatcher.py
@@ -7,7 +7,7 @@ class EventDispatcher:
     def __init__(self):
         self.event_listeners = []
         self.event_factory = EventFactory()
-        self.logger = logging.getLogger("PlexTraktSync.EventDispatcher")
+        self.logger = logging.getLogger(__name__)
 
     def on(self, event_type, listener, **kwargs):
         self.event_listeners.append(

--- a/plextraktsync/watch/WatchStateUpdater.py
+++ b/plextraktsync/watch/WatchStateUpdater.py
@@ -29,7 +29,7 @@ class WatchStateUpdater(SetWindowTitle):
         self.plex = plex
         self.trakt = trakt
         self.mf = mf
-        self.logger = logging.getLogger("PlexTraktSync.WatchStateUpdater")
+        self.logger = logging.getLogger(__name__)
         self.config = config
         self.remove_collection = config["watch"]["remove_collection"]
         self.add_collection = config["watch"]["add_collection"]

--- a/plextraktsync/watch/WatchStateUpdater.py
+++ b/plextraktsync/watch/WatchStateUpdater.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class WatchStateUpdater(SetWindowTitle):
+    logger = logging.getLogger(__name__)
+
     def __init__(
             self,
             plex: PlexApi,
@@ -29,7 +31,6 @@ class WatchStateUpdater(SetWindowTitle):
         self.plex = plex
         self.trakt = trakt
         self.mf = mf
-        self.logger = logging.getLogger(__name__)
         self.config = config
         self.remove_collection = config["watch"]["remove_collection"]
         self.add_collection = config["watch"]["add_collection"]

--- a/plextraktsync/watch/WebSocketListener.py
+++ b/plextraktsync/watch/WebSocketListener.py
@@ -12,12 +12,13 @@ if TYPE_CHECKING:
 
 
 class WebSocketListener:
+    logger = logging.getLogger(__name__)
+
     def __init__(self, plex: PlexServer, poll_interval=5, restart_interval=15):
         self.plex = plex
         self.poll_interval = poll_interval
         self.restart_interval = restart_interval
         self.dispatcher = EventDispatcher()
-        self.logger = logging.getLogger(__name__)
 
     def on(self, event_type, listener, **kwargs):
         self.dispatcher.on(event_type, listener, **kwargs)

--- a/plextraktsync/watch/WebSocketListener.py
+++ b/plextraktsync/watch/WebSocketListener.py
@@ -17,7 +17,7 @@ class WebSocketListener:
         self.poll_interval = poll_interval
         self.restart_interval = restart_interval
         self.dispatcher = EventDispatcher()
-        self.logger = logging.getLogger("PlexTraktSync.WebSocketListener")
+        self.logger = logging.getLogger(__name__)
 
     def on(self, event_type, listener, **kwargs):
         self.dispatcher.on(event_type, listener, **kwargs)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3 -m pytest
 
-from plextraktsync.factory import logger
+from plextraktsync.factory import logging
 
 
 def test_logger():
+    logger = logging.getLogger(__name__)
     logger.info("Log plain text")
     logger.info(["log object"])
     logger.info([{"a": "some object"}])


### PR DESCRIPTION
NOTYET: In the future drop also:

```py
logger = factory.logger
```

Also, setup log filters on demand on first access to `logging.getLogger(__name__)`.