### PR TITLE
Add sync/*.py exception in docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@
 !/plextraktsync/plex/*.py
 !/plextraktsync/queue/*.py
 !/plextraktsync/rich/*.py
+!/plextraktsync/sync/*.py
 !/plextraktsync/trakt/*.py
 !/plextraktsync/util/*.py
 !/plextraktsync/watch/*.py


### PR DESCRIPTION
Sync.py missing in docker container because of `.dockerignore` not updated after 1b58921f34d27920f56c6edb536ab25fd7c7bd58

fixes #1828