### PR TITLE
Feature: Add keep watched to liked lists

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -81,6 +81,11 @@ liked_lists:
   # Whether to keep watched items in the list
   keep_watched: true
 
+# Configuration override for specific lists
+#liked_list:
+#  "Saw Collection":
+#    keep_watched: true
+
 # settings for 'watch' command
 watch:
   add_collection: false

--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -76,6 +76,11 @@ sync:
     # Sync Play Progress from Trakt to Plex
     playback_status: false
 
+# Configuration for liked lists
+liked_lists:
+  # Whether to keep watched items in the list
+  keep_watched: true
+
 # settings for 'watch' command
 watch:
   add_collection: false

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -70,6 +70,10 @@ class SyncConfig:
     def liked_lists_keep_watched(self):
         return self.liked_lists["keep_watched"]
 
+    @property
+    def liked_lists_overrides(self):
+        return self.liked_lists.get("overrides", {})
+
     @cached_property
     def sync_playback_status(self):
         return self["trakt_to_plex"]["playback_status"]

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -4,11 +4,15 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from plextraktsync.config.Config import Config
     from plextraktsync.config.PlexServerConfig import PlexServerConfig
 
 
 class SyncConfig:
+    config: dict[str, Any]
+
     def __init__(self, config: Config, server_config: PlexServerConfig):
         self.config = dict(config["sync"])
         self.server_config = server_config.sync_config

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -16,6 +16,7 @@ class SyncConfig:
     def __init__(self, config: Config, server_config: PlexServerConfig):
         self.config = dict(config["sync"])
         self.liked_lists = config["liked_lists"]
+        self.liked_lists_overrides = config["liked_list"] or {}
         self.server_config = server_config.sync_config
 
     def __getitem__(self, key):
@@ -69,10 +70,6 @@ class SyncConfig:
     @property
     def liked_lists_keep_watched(self):
         return self.liked_lists["keep_watched"]
-
-    @property
-    def liked_lists_overrides(self):
-        return self.liked_lists.get("overrides", {})
 
     @cached_property
     def sync_playback_status(self):

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -15,6 +15,7 @@ class SyncConfig:
 
     def __init__(self, config: Config, server_config: PlexServerConfig):
         self.config = dict(config["sync"])
+        self.liked_lists = config["liked_lists"]
         self.server_config = server_config.sync_config
 
     def __getitem__(self, key):
@@ -64,6 +65,10 @@ class SyncConfig:
         return (
             self.trakt_to_plex["watched_status"] or self.plex_to_trakt["watched_status"]
         )
+
+    @property
+    def liked_lists_keep_watched(self):
+        return self.liked_lists["keep_watched"]
 
     @cached_property
     def sync_playback_status(self):

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -24,7 +24,10 @@ class Sync:
 
     @cached_property
     def trakt_lists(self):
-        return TraktUserListCollection()
+        return TraktUserListCollection(
+            self.config.liked_lists_keep_watched,
+            self.config.liked_lists_overrides,
+        )
 
     @cached_property
     def pm(self):

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -24,7 +24,7 @@ class Sync:
 
     @cached_property
     def trakt_lists(self):
-        return TraktUserListCollection(self.config.liked_lists_keep_watched)
+        return TraktUserListCollection()
 
     @cached_property
     def pm(self):

--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -24,7 +24,7 @@ class Sync:
 
     @cached_property
     def trakt_lists(self):
-        return TraktUserListCollection()
+        return TraktUserListCollection(self.config.liked_lists_keep_watched)
 
     @cached_property
     def pm(self):

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -53,7 +53,7 @@ class TraktListsPlugin:
 
         with measure_time("Updated Trakt Lists"):
             for tl in self.trakt_lists:
-                updated = tl.plex_list.update(tl.plex_items_sorted)
+                updated = tl.plex_list.update(tl.plex_items_sorted(self.keep_watched))
                 if not updated:
                     continue
                 self.logger.info(

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -63,8 +63,14 @@ class TraktListsPlugin:
 
     @hookimpl
     async def walk_movie(self, movie: Media):
+        if not self.keep_watched and movie.plex.is_watched:
+            return
+
         self.trakt_lists.add_to_lists(movie)
 
     @hookimpl
     async def walk_episode(self, episode: Media):
+        if not self.keep_watched and episode.plex.is_watched:
+            return
+
         self.trakt_lists.add_to_lists(episode)

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -17,8 +17,7 @@ class TraktListsPlugin:
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self, keep_watched: bool):
-        self.keep_watched = keep_watched
+    def __init__(self):
         self.trakt_lists = None
 
     @staticmethod
@@ -33,10 +32,8 @@ class TraktListsPlugin:
         )
 
     @classmethod
-    def factory(cls, sync: Sync):
-        return cls(
-            sync.config.liked_lists_keep_watched,
-        )
+    def factory(cls, sync):
+        return cls()
 
     @hookimpl(trylast=True)
     def init(self, pm: SyncPluginManager, sync: Sync):

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -52,8 +52,7 @@ class TraktListsPlugin:
 
         with measure_time("Updated Trakt Lists"):
             for tl in self.trakt_lists:
-                items = tl.plex_items_sorted()
-                updated = tl.plex_list.update(items)
+                updated = tl.plex_list.update(tl.plex_items_sorted)
                 if not updated:
                     continue
                 self.logger.info(

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -58,7 +58,8 @@ class TraktListsPlugin:
 
         with measure_time("Updated Trakt Lists"):
             for tl in self.trakt_lists:
-                updated = tl.plex_list.update(tl.plex_items_sorted(self.keep_watched))
+                items = tl.plex_items_sorted(self.list_keep_watched(tl))
+                updated = tl.plex_list.update(items)
                 if not updated:
                     continue
                 self.logger.info(

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -38,7 +38,7 @@ class TraktListsPlugin:
     def factory(cls, sync: Sync):
         return cls(
             sync.config.liked_lists_keep_watched,
-            sync.config.liked_lists.get("overrides", {}),
+            sync.config.liked_lists_overrides,
         )
 
     @hookimpl(trylast=True)

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -38,7 +38,7 @@ class TraktListsPlugin:
     def factory(cls, sync: Sync):
         return cls(
             sync.config.liked_lists_keep_watched,
-            sync.config.liked_lists,
+            sync.config.liked_lists.get("overrides", {}),
         )
 
     @hookimpl(trylast=True)

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -17,9 +17,10 @@ class TraktListsPlugin:
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self, keep_watched: bool):
+    def __init__(self, keep_watched: bool, trakt_lists_config=None):
         self.keep_watched = keep_watched
         self.trakt_lists = None
+        self.trakt_lists_config = trakt_lists_config or {}
 
     @staticmethod
     def enabled(config):
@@ -34,7 +35,10 @@ class TraktListsPlugin:
 
     @classmethod
     def factory(cls, sync: Sync):
-        return cls(sync.config.liked_lists_keep_watched)
+        return cls(
+            sync.config.liked_lists_keep_watched,
+            sync.config.liked_lists,
+        )
 
     @hookimpl(trylast=True)
     def init(self, pm: SyncPluginManager, sync: Sync):

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -17,7 +17,8 @@ class TraktListsPlugin:
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self):
+    def __init__(self, keep_watched: bool):
+        self.keep_watched = keep_watched
         self.trakt_lists = None
 
     @staticmethod
@@ -32,8 +33,8 @@ class TraktListsPlugin:
         )
 
     @classmethod
-    def factory(cls, sync):
-        return cls()
+    def factory(cls, sync: Sync):
+        return cls(sync.config.liked_lists_keep_watched)
 
     @hookimpl(trylast=True)
     def init(self, pm: SyncPluginManager, sync: Sync):

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -7,6 +7,7 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
+    from ..trakt.TraktUserList import TraktUserList
     from .plugin.SyncPluginInterface import Media, Sync, SyncPluginManager
 
 
@@ -64,6 +65,12 @@ class TraktListsPlugin:
                     f"Plex list {tl.title_link} ({len(tl.plex_items)} items) updated",
                     extra={"markup": True},
                 )
+
+    def list_keep_watched(self, tl: TraktUserList):
+        config = self.trakt_lists_config.get(tl.name)
+        if config is None:
+            return self.keep_watched
+        return config.get("keep_watched", self.keep_watched)
 
     @hookimpl
     async def walk_movie(self, movie: Media):

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -124,6 +124,7 @@ class TraktUserList:
     def title_link(self):
         return self.plex_list.title_link
 
+    @property
     def plex_items_sorted(self):
         """
         Returns items sorted by trakt rank

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -118,8 +118,7 @@ class TraktUserList:
     def title_link(self):
         return self.plex_list.title_link
 
-    @property
-    def plex_items_sorted(self):
+    def plex_items_sorted(self, keep_watched=True):
         """
         Returns items sorted by trakt rank
 
@@ -128,7 +127,14 @@ class TraktUserList:
         if len(self.plex_items) == 0:
             return []
 
-        plex_items = [(r, p.item) for (r, p) in self.plex_items]
+        plex_items = [
+            (r, p.item)
+            for (r, p) in self.plex_items
+            if keep_watched or (not keep_watched and not p.is_watched)
+        ]
+        if len(plex_items) == 0:
+            return []
+
         _, items = zip(*sorted(dict(reversed(plex_items)).items()))
 
         return items

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -120,7 +120,7 @@ class TraktUserList:
     def title_link(self):
         return self.plex_list.title_link
 
-    def plex_items_sorted(self, keep_watched=True):
+    def plex_items_sorted(self):
         """
         Returns items sorted by trakt rank
 
@@ -132,7 +132,7 @@ class TraktUserList:
         plex_items = [
             (r, p.item)
             for (r, p) in self.plex_items
-            if keep_watched or (not keep_watched and not p.is_watched)
+            if self.keep_watched or (not self.keep_watched and not p.is_watched)
         ]
         if len(plex_items) == 0:
             return []

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -66,8 +66,8 @@ class TraktUserList:
         return pl.description, self.build_dict(pl)
 
     @classmethod
-    def from_trakt_list(cls, list_id: int, list_name: str):
-        return cls(trakt_id=list_id, name=list_name)
+    def from_trakt_list(cls, list_id: int, list_name: str, keep_watched: bool):
+        return cls(trakt_id=list_id, name=list_name, keep_watched=keep_watched)
 
     @classmethod
     def from_watchlist(cls, items: list[TraktPlayable]):

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -23,12 +23,14 @@ class TraktUserList:
         trakt_id: int = None,
         name: str = None,
         items=None,
+        keep_watched: bool = None,
     ):
         self.trakt_id = trakt_id
         self.name = name
         self._items = items
         self.description = None
         self.plex_items = []
+        self.keep_watched = keep_watched
 
     def __iter__(self):
         return iter(self.items)

--- a/plextraktsync/trakt/TraktUserList.py
+++ b/plextraktsync/trakt/TraktUserList.py
@@ -100,6 +100,10 @@ class TraktUserList:
             # Already in the list
             return
 
+        if not self.keep_watched and m.plex.is_watched:
+            # Skip adding watched items
+            return
+
         self.logger.info(
             f"Adding {m.title_link} ({m.plex_key}) to Plex list {self.title_link}",
             extra={"markup": True},

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -14,10 +14,6 @@ if TYPE_CHECKING:
 class TraktUserListCollection(UserList):
     logger = logging.getLogger(__name__)
 
-    def __init__(self, keep_watched=True):
-        super().__init__()
-        self.keep_watched = keep_watched
-
     @property
     def is_empty(self):
         return not len(self)
@@ -26,8 +22,6 @@ class TraktUserListCollection(UserList):
         # Skip movie editions
         # https://support.plex.tv/articles/multiple-editions/#:~:text=Do%20Multiple%20Editions%20work%20with%20watch%20state%20syncing%3F
         if m.plex.edition_title is not None:
-            return
-        if not self.keep_watched and m.plex.is_watched:
             return
         for tl in self:
             tl.add(m)

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 class TraktUserListCollection(UserList):
     logger = logging.getLogger(__name__)
 
+    def __init__(self, keep_watched: bool, trakt_lists_overrides: dict):
+        super().__init__()
+        self.keep_watched = keep_watched
+        self.trakt_lists_overrides = trakt_lists_overrides
+
     @property
     def is_empty(self):
         return not len(self)

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -41,6 +41,8 @@ class TraktUserListCollection(UserList):
         return tl
 
     def add_list(self, list_id: int, list_name: str):
-        tl = TraktUserList.from_trakt_list(list_id, list_name)
+        list_config = self.trakt_lists_overrides.get(list_name, {})
+        keep_watched = list_config.get("keep_watched", self.keep_watched)
+        tl = TraktUserList.from_trakt_list(list_id, list_name, keep_watched)
         self.append(tl)
         return tl

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -45,13 +45,3 @@ class TraktUserListCollection(UserList):
         tl = TraktUserList.from_trakt_list(list_id, list_name)
         self.append(tl)
         return tl
-
-    def sync(self):
-        for tl in self:
-            updated = tl.plex_list.update(tl.plex_items_sorted(self.keep_watched))
-            if not updated:
-                continue
-            self.logger.info(
-                f"Plex list {tl.title_link} ({len(tl.plex_items)} items) updated",
-                extra={"markup": True},
-            )

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
 class TraktUserListCollection(UserList):
     logger = logging.getLogger(__name__)
 
+    def __init__(self, keep_watched=True):
+        super().__init__()
+        self.keep_watched = keep_watched
+
     @property
     def is_empty(self):
         return not len(self)

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -27,6 +27,8 @@ class TraktUserListCollection(UserList):
         # https://support.plex.tv/articles/multiple-editions/#:~:text=Do%20Multiple%20Editions%20work%20with%20watch%20state%20syncing%3F
         if m.plex.edition_title is not None:
             return
+        if not self.keep_watched and m.plex.is_watched:
+            return
         for tl in self:
             tl.add(m)
 
@@ -43,3 +45,13 @@ class TraktUserListCollection(UserList):
         tl = TraktUserList.from_trakt_list(list_id, list_name)
         self.append(tl)
         return tl
+
+    def sync(self):
+        for tl in self:
+            updated = tl.plex_list.update(tl.plex_items_sorted(self.keep_watched))
+            if not updated:
+                continue
+            self.logger.info(
+                f"Plex list {tl.title_link} ({len(tl.plex_items)} items) updated",
+                extra={"markup": True},
+            )


### PR DESCRIPTION
Also adds new config:

```yml
# Configuration for liked lists
liked_lists:
  # Whether to keep watched items in the list
  keep_watched: false
```

You can also override `keep_watched` per list:

```yml
# Configuration override for specific lists
liked_list:
  "Saw Collection":
    keep_watched: true
```

Refs:
- https://github.com/Taxel/PlexTraktSync/issues/1494#issuecomment-1952495773