### PR TITLE
Update HttpCache rules

### DIFF
--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -43,9 +43,12 @@ class HttpCacheConfig:
         # Trakt search urls
         "api.trakt.tv/search/imdb/tt*?type=movie": "1d",
         "api.trakt.tv/search/imdb/tt*?type=show": "1d",
+        "api.trakt.tv/search/imdb/tt*?type=episode": "1d",
         "api.trakt.tv/search/tmdb/*?type=movie": "1d",
         "api.trakt.tv/search/tmdb/*?type=show": "1d",
+        "api.trakt.tv/search/tmdb/*?type=episode": "1d",
         "api.trakt.tv/search/tvdb/*?type=show": "1d",
+        "api.trakt.tv/search/tvdb/*?type=episode": "1d",
         # Keep watched status cached, but fresh
         "api.trakt.tv/sync/watched/shows": "1s",
         "api.trakt.tv/users/*/watched/movies": "1s",

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -56,6 +56,8 @@ class HttpCacheConfig:
         "metadata.provider.plex.tv/library/sections/watchlist/all": "1s",
         "api.trakt.tv/users/likes/lists": DO_NOT_CACHE,
         "api.trakt.tv/users/me": DO_NOT_CACHE,
+        # Public Lists
+        "api.trakt.tv/lists/*": "1d",
         # Online Plex patterns
         "metadata.provider.plex.tv/library/metadata/*/userState": DO_NOT_CACHE,
         "metadata.provider.plex.tv/library/metadata/*?*includeUserState=1": DO_NOT_CACHE,

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -70,6 +70,7 @@ class HttpCacheConfig:
         # Plex account
         # Cache for some time, this activates 304 responses
         "plex.tv/users/account": "1m",
+        "plex.tv/api/v2/user": "1m",
         # Plex patterns
         # Ratings search
         "*/library/sections/*/all?*userRating%3E%3E=-1*": DO_NOT_CACHE,


### PR DESCRIPTION
Walked all entries in my cache to see if some of them had missing match.

```py
#!/usr/bin/env python
import fnmatch
from glob import glob

from requests_cache import CachedSession, DO_NOT_CACHE
from requests_cache.policy.expiration import _url_match

from plextraktsync.config.HttpCacheConfig import LONG_EXPIRY
from plextraktsync.factory import factory


def get_cache():
    session: CachedSession = factory.session

    return session.cache.responses


def match_policy(policy, url):
    for pattern, v in policy.items():
        matching = _url_match(url, pattern)
        if matching:
            # print(k, v)
            if v == LONG_EXPIRY:
                v = "LONG_EXPIRY"
            if v == DO_NOT_CACHE:
                v = "DO_NOT_CACHE"
            return (pattern, v)

    return None


def test():
    session: CachedSession = factory.session
    http_cache = factory.config.http_cache
    policy = http_cache.default_policy

    for r in get_cache().values():
        matching = match_policy(policy, r.url)
        if matching:
            # print(r.url, ": ", matching)
            continue
        print(r.url, ": NO MATCH")


if __name__ == "__main__":
    test()
```