### PR TITLE
Feature: Add (per-server) ignore_ids support

### DIFF
--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -37,6 +37,10 @@ class PlexServerConfig:
         return self.get_section("libraries")
 
     @property
+    def ignore_ids(self):
+        return self.get_section("ignore_ids", [])
+
+    @property
     def excluded_libraries(self):
         return self.get_section("excluded-libraries")
 

--- a/plextraktsync/factory/Factory.py
+++ b/plextraktsync/factory/Factory.py
@@ -55,7 +55,8 @@ class Factory:
 
         trakt = self.trakt_api
         plex = self.plex_api
-        mf = MediaFactory(plex, trakt)
+        config = self.server_config
+        mf = MediaFactory(plex, trakt, server_config=config)
 
         return mf
 

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -36,6 +36,10 @@ class MediaFactory:
         return self.server_config.ignore_ids
 
     def resolve_any(self, pm: PlexLibraryItem, show: Media = None) -> Media | None:
+        if pm.key in self.ignore_ids:
+            self.logger.error(f"Skipping {pm} because listed in ignore_ids")
+            return None
+
         try:
             guids = pm.guids
         except (PlexApiException, RequestException) as e:

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -6,6 +6,7 @@ from plexapi.exceptions import PlexApiException
 from requests import RequestException
 from trakt.errors import TraktException
 
+from plextraktsync.config.PlexServerConfig import PlexServerConfig
 from plextraktsync.factory import logging
 from plextraktsync.media.Media import Media
 
@@ -24,9 +25,10 @@ class MediaFactory:
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self, plex: PlexApi, trakt: TraktApi):
+    def __init__(self, plex: PlexApi, trakt: TraktApi, server_config: PlexServerConfig):
         self.plex = plex
         self.trakt = trakt
+        self.server_config = server_config
 
     def resolve_any(self, pm: PlexLibraryItem, show: Media = None) -> Media | None:
         try:

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from plexapi.exceptions import PlexApiException
@@ -29,6 +30,10 @@ class MediaFactory:
         self.plex = plex
         self.trakt = trakt
         self.server_config = server_config
+
+    @cached_property
+    def ignore_ids(self):
+        return self.server_config.ignore_ids
 
     def resolve_any(self, pm: PlexLibraryItem, show: Media = None) -> Media | None:
         try:


### PR DESCRIPTION
Add to your server config (`servers.yml`):

```yml
servers:
  default:
    config:
      # Plex IDs to ignore
      # This is a workaround for broken sync if some items have unrecoverable errors
      ignore_ids:
        - "293454/5/2016-08-31"
```

To work around problems like:
- https://github.com/Taxel/PlexTraktSync/issues/1873
- https://github.com/Taxel/PlexTraktSync/issues/2025

