### PR TITLE
Catch timezone error for pre-epoch added_at on Windows

### DIFF
--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -353,8 +353,12 @@ class PlexLibraryItem(RichMarkup):
     def date_value(date) -> datetime.datetime | None:
         if not date:
             return None
-
-        return date.astimezone(datetime.timezone.utc)
+        try:
+            return date.astimezone(datetime.timezone.utc)
+        except OSError:
+            # python on Windows cannot find tz for pre-epoch dates
+            # https://github.com/python/cpython/issues/80940
+            return date
 
     @property
     def title_link(self):


### PR DESCRIPTION
astimezone() on Windows cannot handle pre-epoch dates (before 1970-01-01) and raises `OSError: [Errno 22] Invalid argument`

- https://github.com/python/cpython/issues/80940

fixes #1873