### PR TITLE
Linter: Update pre-commit hooks versions, add prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.1
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (Python)
@@ -32,7 +32,7 @@ repos:
       - id: rm-unneeded-f-str
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 
@@ -42,7 +42,7 @@ repos:
       - id: flynt
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
       - id: isort
         name: isort (Python)
 
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
     rev: v0.2.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+/Pipfile.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /Pipfile.lock
+/tests/mock_data/


### PR DESCRIPTION
https://github.com/requests-cache/requests-cache/blob/65ff40d6d29422b11c0694132f0ec50f575e5de0/.pre-commit-config.yaml

format commit already in HEAD: https://github.com/Taxel/PlexTraktSync/commit/dcb54fc91fc4d19c237b114252ac98593d45a358