### PR TITLE
Fix: Do not retry conflict errors in scrobble

### DIFF
--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -31,10 +31,10 @@ class TraktScrobbleWorker:
             queues[name].clear()
 
     def submit(self, name, items):
-        method = getattr(self, name)
+        name = name.replace("scrobble_", "")
         results = []
         for scrobbler, progress in self.normalize(items).items():
-            res = method(scrobbler, progress)
+            res = self.scrobble(scrobbler, name, progress)
             results.append(res)
 
         if results:
@@ -43,20 +43,9 @@ class TraktScrobbleWorker:
     @rate_limit()
     @time_limit()
     @retry()
-    def scrobble_update(self, scrobbler: Scrobbler, progress: float):
-        return scrobbler.update(progress)
-
-    @rate_limit()
-    @time_limit()
-    @retry()
-    def scrobble_pause(self, scrobbler: Scrobbler, progress: float):
-        return scrobbler.pause(progress)
-
-    @rate_limit()
-    @time_limit()
-    @retry()
-    def scrobble_stop(self, scrobbler: Scrobbler, progress: float):
-        return scrobbler.stop(progress)
+    def scrobble(self, scrobbler: Scrobbler, name: str, progress: float):
+        method = getattr(scrobbler, name)
+        return method(progress)
 
     @staticmethod
     def normalize(items: list[TraktPlayable]):

--- a/plextraktsync/queue/TraktScrobbleWorker.py
+++ b/plextraktsync/queue/TraktScrobbleWorker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from trakt.errors import ConflictException
+
 from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.decorators.retry import retry
 from plextraktsync.decorators.time_limit import time_limit
@@ -45,7 +47,10 @@ class TraktScrobbleWorker:
     @retry()
     def scrobble(self, scrobbler: Scrobbler, name: str, progress: float):
         method = getattr(scrobbler, name)
-        return method(progress)
+        try:
+            return method(progress)
+        except ConflictException:
+            return
 
     @staticmethod
     def normalize(items: list[TraktPlayable]):


### PR DESCRIPTION
I got same episode recorded as played around every hour because watch was retrying the error.

```
Mar 30 16:09:27 niblus plextraktsync[1680006]: ERROR    Got exception while working on
Mar 30 16:09:27 niblus plextraktsync[1680006]:          <plextraktsync.queue.TraktScrobbleWorker.TraktScrobbleWorker object at
Mar 30 16:09:27 niblus plextraktsync[1680006]:          0x7fff1eebab50>: Conflict - resource already created
Mar 30 16:09:32 niblus plextraktsync[1680006]: ERROR    Got exception while working on
Mar 30 16:09:32 niblus plextraktsync[1680006]:          <plextraktsync.queue.TraktScrobbleWorker.TraktScrobbleWorker object at
Mar 30 16:09:32 niblus plextraktsync[1680006]:          0x7fff1eebab50>: Conflict - resource already created
Mar 30 16:09:37 niblus plextraktsync[1680006]: ERROR    Got exception while working on
Mar 30 16:09:37 niblus plextraktsync[1680006]:          <plextraktsync.queue.TraktScrobbleWorker.TraktScrobbleWorker object at
Mar 30 16:09:37 niblus plextraktsync[1680006]:          0x7fff1eebab50>: Conflict - resource already created
```