### PR TITLE
Feature: Add --edit support to config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ seconds, second run - 111 seconds
 You can view sync progress in the `plextraktsync.log` file which will be
 created.
 
+You can use `--edit` or `--locate` flags to `config` command to open config
+file in editor or in file browser.
+
 ### Libraries
 
 By default, all libraries are processed. You can disable libraries by name by

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -333,6 +333,7 @@ def watched_shows():
 @command()
 @click.option("--urls-expire-after", is_flag=True, help="Print urls_expire_after configuration")
 @click.option("--edit", is_flag=True, help="Open config file in editor")
+@click.option("--locate", is_flag=True, help="Locate config file in file browser")
 def config():
     """
     Print user config for debugging and bug reports.

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -332,6 +332,7 @@ def watched_shows():
 
 @command()
 @click.option("--urls-expire-after", is_flag=True, help="Print urls_expire_after configuration")
+@click.option("--edit", is_flag=True, help="Open config file in editor")
 def config():
     """
     Print user config for debugging and bug reports.

--- a/plextraktsync/commands/config.py
+++ b/plextraktsync/commands/config.py
@@ -14,9 +14,14 @@ def dump(data, print=None):
     print(dump)
 
 
-def config(urls_expire_after: bool):
+def config(urls_expire_after: bool, edit: bool):
     config = factory.config
     print = factory.print
+
+    if edit:
+        import click
+        click.launch(config.config_yml)
+        return
 
     if urls_expire_after:
         print("# HTTP Cache")

--- a/plextraktsync/commands/config.py
+++ b/plextraktsync/commands/config.py
@@ -14,13 +14,13 @@ def dump(data, print=None):
     print(dump)
 
 
-def config(urls_expire_after: bool, edit: bool):
+def config(urls_expire_after: bool, edit: bool, locate: bool):
     config = factory.config
     print = factory.print
 
-    if edit:
+    if edit or locate:
         import click
-        click.launch(config.config_yml)
+        click.launch(config.config_yml, locate=locate)
         return
 
     if urls_expire_after:


### PR DESCRIPTION
```
$ plextraktsync config --help
Usage: plextraktsync config [OPTIONS]

  Print user config for debugging and bug reports.

Options:
  --urls-expire-after  Print urls_expire_after configuration
  --edit               Open config file in editor
  --locate             Locate config file in file browser
  --help               Show this message and exit.
```