### PR TITLE
Feature: Add watch progress syncing option

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -73,6 +73,8 @@ sync:
     # If you prefer to fetch trakt watchlist as a playlist instead of
     # plex watchlist, toggle this to true (is read only if watchlist=true)
     watchlist_as_playlist: false
+    # Sync Play Progress from Trakt to Plex
+    playback_status: false
 
 # settings for 'watch' command
 watch:

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -57,6 +57,10 @@ class SyncConfig:
         return self.trakt_to_plex["watched_status"] or self.plex_to_trakt["watched_status"]
 
     @cached_property
+    def sync_playback_status(self):
+        return self["trakt_to_plex"]["playback_status"]
+
+    @cached_property
     def update_plex_wl(self):
         return self.trakt_to_plex["watchlist"] and not self.trakt_to_plex["watchlist_as_playlist"]
 

--- a/plextraktsync/config/SyncConfig.py
+++ b/plextraktsync/config/SyncConfig.py
@@ -88,4 +88,5 @@ class SyncConfig:
             self.sync_ratings,
             self.plex_to_trakt["collection"],
             self.sync_liked_lists,
+            self.sync_playback_status,
         ])

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from trakt.sync import PlaybackEntry
 from trakt.tv import TVShow
 
 from plextraktsync.mixin.RichMarkup import RichMarkup
@@ -38,6 +39,12 @@ class Media(RichMarkup):
         self.plex = plex
         self.trakt = trakt
         self._show = None
+
+    def __eq__(self, other):
+        if isinstance(other, PlaybackEntry):
+            return self.type == other.type and self.trakt_id == other.trakt
+
+        return False
 
     @property
     def title(self):

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -46,6 +46,9 @@ class Media(RichMarkup):
 
         return False
 
+    def __hash__(self):
+        return hash((self.type, self.plex, self.trakt))
+
     @property
     def title(self):
         if self.plex:

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -314,6 +314,12 @@ class PlexLibraryItem(RichMarkup):
         percent = view_offset / self.item.duration * 100
         return percent
 
+    def progress_millis(self, percentage: float):
+        """
+        Get Movie progress from percentage to milliseconds
+        """
+        return int((percentage / 100) * self.item.duration)
+
     def episodes(self):
         for ep in self._get_episodes():
             yield PlexLibraryItem(ep, plex=self.plex)

--- a/plextraktsync/sync/WatchProgressPlugin.py
+++ b/plextraktsync/sync/WatchProgressPlugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from plextraktsync.factory import logging
@@ -43,8 +44,10 @@ class WatchProgressPlugin:
             self.logger.warning(f"{m.title_link}: Skip progress, setting to 0 will not work", extra={"markup": True})
             return
 
+        view_offset = timedelta(milliseconds=m.plex.item.viewOffset)
+        progress_offset = timedelta(milliseconds=progress)
         self.logger.info(
-            f"{m.title_link}: Set watch progress to {p.progress:.02F}%: {m.plex.item.viewOffset}ms -> {progress}ms",
+            f"{m.title_link}: Set watch progress to {p.progress:.02F}%: {view_offset} -> {progress_offset}",
             extra={"markup": True}
         )
         if not dry_run:

--- a/plextraktsync/sync/WatchProgressPlugin.py
+++ b/plextraktsync/sync/WatchProgressPlugin.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from plextraktsync.factory import logging
+from plextraktsync.media.Media import Media
+from plextraktsync.plugin import hookimpl
+
+if TYPE_CHECKING:
+    from plextraktsync.config.SyncConfig import SyncConfig
+    from plextraktsync.sync.Sync import Sync
+    from plextraktsync.trakt.TraktApi import TraktApi
+
+
+class WatchProgressPlugin:
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, trakt: TraktApi):
+        self.trakt = trakt
+
+    @staticmethod
+    def enabled(config: SyncConfig):
+        return config.sync_playback_status
+
+    @classmethod
+    def factory(cls, sync: Sync):
+        return cls(sync.trakt)
+
+    @hookimpl
+    def walk_movie(self, movie: Media, dry_run: bool):
+        self.sync_progress(movie, dry_run=dry_run)
+
+    @hookimpl
+    def walk_episode(self, episode: Media, dry_run: bool):
+        self.sync_progress(episode, dry_run=dry_run)
+
+    def sync_progress(self, m: Media, dry_run=False):
+        p = self.trakt.watch_progress.match(m)
+        if not p:
+            return
+        progress = m.plex.progress_millis(p.progress)
+        if progress == 0.0:
+            self.logger.warning(f"{m.title_link}: Skip progress, setting to 0 will not work", extra={"markup": True})
+            return
+
+        self.logger.info(
+            f"{m.title_link}: Set watch progress to {p.progress:.02F}%: {m.plex.item.viewOffset}ms -> {progress}ms",
+            extra={"markup": True}
+        )
+        if not dry_run:
+            m.plex.item.updateProgress(progress)

--- a/plextraktsync/sync/plugin/SyncPluginManager.py
+++ b/plextraktsync/sync/plugin/SyncPluginManager.py
@@ -35,12 +35,14 @@ class SyncPluginManager:
         from ..SyncRatingsPlugin import SyncRatingsPlugin
         from ..SyncWatchedPlugin import SyncWatchedPlugin
         from ..WatchListPlugin import WatchListPlugin
+        from ..WatchProgressPlugin import WatchProgressPlugin
         yield AddCollectionPlugin
         yield ClearCollectedPlugin
         yield LikedListsPlugin
         yield SyncRatingsPlugin
         yield SyncWatchedPlugin
         yield WatchListPlugin
+        yield WatchProgressPlugin
 
     def register_plugins(self, sync: Sync):
         for plugin in self.plugins:

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -22,6 +22,7 @@ from plextraktsync.path import pytrakt_file
 from plextraktsync.trakt.PartialTraktMedia import PartialTraktMedia
 from plextraktsync.trakt.TraktLookup import TraktLookup
 from plextraktsync.trakt.TraktRatingCollection import TraktRatingCollection
+from plextraktsync.trakt.WatchProgress import WatchProgress
 from plextraktsync.util.Rating import Rating
 
 if TYPE_CHECKING:
@@ -83,6 +84,12 @@ class TraktApi:
     @retry()
     def watched_movies(self):
         return set(map(lambda m: m.trakt, self.me.watched_movies))
+
+    @cached_property
+    @rate_limit()
+    @retry()
+    def watch_progress(self):
+        return WatchProgress(trakt.sync.get_playback())
 
     @cached_property
     @rate_limit()

--- a/plextraktsync/trakt/WatchProgress.py
+++ b/plextraktsync/trakt/WatchProgress.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from trakt.sync import PlaybackEntry
+
+
+class WatchProgress:
+    def __init__(self, progress: list[PlaybackEntry]):
+        self.progress = progress

--- a/plextraktsync/trakt/WatchProgress.py
+++ b/plextraktsync/trakt/WatchProgress.py
@@ -5,7 +5,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from trakt.sync import PlaybackEntry
 
+    from plextraktsync.media.Media import Media
+
 
 class WatchProgress:
     def __init__(self, progress: list[PlaybackEntry]):
         self.progress = progress
+
+    def match(self, m: Media):
+        p = [p for p in self.progress if p == m]
+        if not len(p):
+            return None
+        if len(p) != 1:
+            raise RuntimeError(f"Unexpected match count {len(p)}")
+        return p[0]


### PR DESCRIPTION
Add syncing watch progress:
- https://trakt.tv/users/me/progress
- https://trakt.docs.apiary.io/#reference/sync/playback/get-playback-progress

Feature request:
- https://github.com/Taxel/PlexTraktSync/discussions/1885

Features:
- [x] sync from trakt to plex
- [ ] sync from plex to trakt
- [ ] handle priorities: plex vs trakt or trakt vs plex

NOTE: Use tppm to manage entries at trakt.tv side, i.e. removing 0% items (not sure where same functionality is on trakt.tv site):
- https://sharkykh.github.io/tppm/

Requires:
- [x] https://github.com/glensc/python-pytrakt/pull/48
  - https://github.com/Taxel/PlexTraktSync/pull/1891