### PR TITLE
Build: Simplify setup.cfg not to include every module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,28 +26,12 @@ project_urls =
     Bug Tracker = https://github.com/Taxel/PlexTraktSync/issues
 
 [options]
-packages =
-    plextraktsync
-    plextraktsync.commands
-    plextraktsync.config
-    plextraktsync.decorators
-    plextraktsync.logger
-    plextraktsync.media
-    plextraktsync.mixin
-    plextraktsync.plan
-    plextraktsync.plex
-    plextraktsync.queue
-    plextraktsync.rich
-    plextraktsync.sync
-    plextraktsync.trakt
-    plextraktsync.util
-    plextraktsync.watch
+packages = find:
 python_requires = >=3.8
 include_package_data = True
 
 [options.packages.find]
-exclude =
-    tests
+include = plextraktsync
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
- https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
- https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

Extracted from https://github.com/Taxel/PlexTraktSync/pull/1894

NOTE: Doesn't work with pipx installing from pr:
- https://github.com/Taxel/PlexTraktSync/pull/1894