### PR TITLE
Performance: Remove reloads for episode ratings sync

### DIFF
--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -76,7 +76,7 @@ class HttpCacheConfig:
         "plex.tv/api/v2/user": "1m",
         # Plex patterns
         # Ratings search
-        "*/library/sections/*/all?*userRating%3E%3E=-1*": DO_NOT_CACHE,
+        "*/library/sections/*/all?*userRating%3E%3E=-1*": "1m",
         # len(PlexLibrarySection)
         "*/library/sections/*/all?includeCollections=0&X-Plex-Container-Size=0&X-Plex-Container-Start=0": DO_NOT_CACHE,
         # __iter__(PlexLibrarySection)

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -225,11 +225,7 @@ class Media(RichMarkup):
 
     @cached_property
     def plex_rating(self):
-        if self.media_type == "episodes" and not self.plex.is_discover and self.show:
-            show_id = self.show.plex.item.ratingKey
-        else:
-            show_id = None
-        return self.plex.rating(show_id)
+        return self.plex.rating()
 
     def trakt_rate(self):
         rating = self.plex_rating

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -155,9 +155,9 @@ class PlexLibraryItem(RichMarkup):
 
         return value
 
-    def rating(self, show_id: int = None):
+    def rating(self):
         if not self.is_discover and self.plex is not None:
-            return self.plex.ratings.get(self, show_id)
+            return self.plex.ratings.get(self)
 
         return Rating.create(self.item.userRating, self.item.lastRatedAt)
 


### PR DESCRIPTION
This will improve performance for episodes sync of shows where at least one episode was rated.

Along with https://github.com/Taxel/PlexTraktSync/pull/1899, this eliminates plex reloads in my libraries sync.