### PR TITLE
Refactor: Allow plugin to unregister itself

### DIFF
--- a/plextraktsync/sync/Sync.py
+++ b/plextraktsync/sync/Sync.py
@@ -30,7 +30,7 @@ class Sync:
         pm = SyncPluginManager()
         pm.register_plugins(self)
 
-        pm.hook.init(sync=self, trakt_lists=trakt_lists, is_partial=is_partial, dry_run=dry_run)
+        pm.hook.init(sync=self, pm=pm, trakt_lists=trakt_lists, is_partial=is_partial, dry_run=dry_run)
 
         if self.config.need_library_walk:
             for movie in walker.find_movies():

--- a/plextraktsync/sync/plugin/SyncPluginInterface.py
+++ b/plextraktsync/sync/plugin/SyncPluginInterface.py
@@ -7,6 +7,7 @@ from plextraktsync.plugin import hookspec
 if TYPE_CHECKING:
     from plextraktsync.media.Media import Media
     from plextraktsync.plan.Walker import Walker
+    from plextraktsync.sync.plugin import SyncPluginManager
     from plextraktsync.sync.Sync import Sync
     from plextraktsync.trakt.TraktUserListCollection import \
         TraktUserListCollection
@@ -16,7 +17,7 @@ class SyncPluginInterface:
     """A hook specification namespace."""
 
     @hookspec
-    def init(self, sync: Sync, trakt_lists: TraktUserListCollection, is_partial: bool, dry_run: bool):
+    def init(self, pm: SyncPluginManager, sync: Sync, trakt_lists: TraktUserListCollection, is_partial: bool, dry_run: bool):
         """Hook called at sync process initialization"""
 
     @hookspec

--- a/plextraktsync/sync/plugin/SyncPluginManager.py
+++ b/plextraktsync/sync/plugin/SyncPluginManager.py
@@ -27,6 +27,10 @@ class SyncPluginManager:
     def hook(self):
         return self.pm.hook
 
+    @cached_property
+    def unregister(self):
+        return self.pm.unregister
+
     @property
     def plugins(self):
         from ..AddCollectionPlugin import AddCollectionPlugin


### PR DESCRIPTION
Disable plugin if it would be not needed, i.e in partial mode disable clear collected plugin.