### PR TITLE
Refactor: Import types from SyncPluginInterface

### DIFF
--- a/plextraktsync/sync/AddCollectionPlugin.py
+++ b/plextraktsync/sync/AddCollectionPlugin.py
@@ -19,7 +19,7 @@ class AddCollectionPlugin:
         return config.plex_to_trakt["collection"]
 
     @classmethod
-    def factory(cls, sync: Sync):
+    def factory(cls, sync):
         return cls()
 
     @hookimpl

--- a/plextraktsync/sync/AddCollectionPlugin.py
+++ b/plextraktsync/sync/AddCollectionPlugin.py
@@ -6,9 +6,7 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.media.Media import Media
-    from plextraktsync.sync.Sync import Sync
+    from .plugin.SyncPluginInterface import Media, SyncConfig
 
 
 class AddCollectionPlugin:

--- a/plextraktsync/sync/ClearCollectedPlugin.py
+++ b/plextraktsync/sync/ClearCollectedPlugin.py
@@ -7,11 +7,10 @@ from plextraktsync.media.Media import Media
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.sync.plugin import SyncPluginManager
-    from plextraktsync.sync.Sync import Sync
     from plextraktsync.trakt.TraktApi import TraktApi
     from plextraktsync.trakt.types import TraktMedia
+
+    from .plugin.SyncPluginInterface import Sync, SyncConfig, SyncPluginManager
 
 
 class ClearCollectedPlugin:

--- a/plextraktsync/sync/LikedListsPlugin.py
+++ b/plextraktsync/sync/LikedListsPlugin.py
@@ -6,11 +6,10 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.sync.Sync import Sync
     from plextraktsync.trakt.TraktApi import TraktApi
-    from plextraktsync.trakt.TraktUserListCollection import \
-        TraktUserListCollection
+
+    from .plugin.SyncPluginInterface import (Sync, SyncConfig,
+                                             TraktUserListCollection)
 
 
 class LikedListsPlugin:

--- a/plextraktsync/sync/SyncRatingsPlugin.py
+++ b/plextraktsync/sync/SyncRatingsPlugin.py
@@ -6,10 +6,7 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.media.Media import Media
-    from plextraktsync.plan.Walker import Walker
-    from plextraktsync.sync.Sync import Sync
+    from .plugin.SyncPluginInterface import Media, Sync, SyncConfig, Walker
 
 
 class SyncRatingsPlugin:

--- a/plextraktsync/sync/SyncWatchedPlugin.py
+++ b/plextraktsync/sync/SyncWatchedPlugin.py
@@ -6,9 +6,7 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.media.Media import Media
-    from plextraktsync.sync.Sync import Sync
+    from .plugin.SyncPluginInterface import Media, Sync, SyncConfig
 
 
 class SyncWatchedPlugin:

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -25,12 +25,12 @@ class TraktListsPlugin:
         self.add_to_lists = None
 
     @staticmethod
-    def enabled(config: SyncConfig):
+    def enabled(config):
         # Use True for now, would need to keep in sync with other plugins
         return True
 
     @classmethod
-    def factory(cls, sync: Sync):
+    def factory(cls, sync):
         return cls()
 
     @hookimpl(trylast=True)

--- a/plextraktsync/sync/TraktListsPlugin.py
+++ b/plextraktsync/sync/TraktListsPlugin.py
@@ -7,11 +7,7 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.media.Media import Media
-    from plextraktsync.sync.Sync import Sync
-    from plextraktsync.trakt.TraktUserListCollection import \
-        TraktUserListCollection
+    from .plugin.SyncPluginInterface import Media, TraktUserListCollection
 
 
 class TraktListsPlugin:

--- a/plextraktsync/sync/WatchListPlugin.py
+++ b/plextraktsync/sync/WatchListPlugin.py
@@ -8,14 +8,11 @@ from plextraktsync.factory import logging
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.media.Media import Media
-    from plextraktsync.plan.Walker import Walker
     from plextraktsync.plex.PlexApi import PlexApi
-    from plextraktsync.sync.Sync import Sync
     from plextraktsync.trakt.TraktApi import TraktApi
-    from plextraktsync.trakt.TraktUserListCollection import \
-        TraktUserListCollection
+
+    from .plugin.SyncPluginInterface import (Media, Sync, SyncConfig,
+                                             TraktUserListCollection, Walker)
 
 
 class WatchListPlugin:

--- a/plextraktsync/sync/WatchProgressPlugin.py
+++ b/plextraktsync/sync/WatchProgressPlugin.py
@@ -8,9 +8,9 @@ from plextraktsync.media.Media import Media
 from plextraktsync.plugin import hookimpl
 
 if TYPE_CHECKING:
-    from plextraktsync.config.SyncConfig import SyncConfig
-    from plextraktsync.sync.Sync import Sync
     from plextraktsync.trakt.TraktApi import TraktApi
+
+    from .plugin.SyncPluginInterface import Sync, SyncConfig
 
 
 class WatchProgressPlugin:

--- a/plextraktsync/sync/plugin/SyncPluginInterface.py
+++ b/plextraktsync/sync/plugin/SyncPluginInterface.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from plextraktsync.plugin import hookspec
 
 if TYPE_CHECKING:
+    from plextraktsync.config.SyncConfig import SyncConfig  # noqa: F401
     from plextraktsync.media.Media import Media
     from plextraktsync.plan.Walker import Walker
     from plextraktsync.sync.plugin import SyncPluginManager


### PR DESCRIPTION
Make imports shorter, and also explicit that the same types are used in plugin definitions.