### PR TITLE
Feature: Add support for logger to measure_time

### DIFF
--- a/plextraktsync/decorators/measure_time.py
+++ b/plextraktsync/decorators/measure_time.py
@@ -1,3 +1,4 @@
+import inspect
 from contextlib import contextmanager
 from datetime import timedelta
 from time import monotonic
@@ -6,18 +7,25 @@ from humanize.time import precisedelta
 
 from plextraktsync.factory import logging
 
-logger = logging.getLogger(__name__)
+default_logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def measure_time(message, level=logging.INFO, **kwargs):
+def measure_time(message, *args, level=logging.INFO, logger=None, **kwargs):
     start = monotonic()
     yield
     delta = monotonic() - start
 
+    if inspect.ismethod(logger):
+        log = logger
+    else:
+        def log(*a, **kw):
+            (logger or default_logger).log(level, *a, **kw)
+
     minimum_unit = "microseconds" if delta < 1 else "seconds"
-    logger.log(
-        level,
-        f"{message} in " + precisedelta(timedelta(seconds=delta), minimum_unit=minimum_unit),
-        **kwargs
+    log(
+        f"{message} in %s",
+        precisedelta(timedelta(seconds=delta), minimum_unit=minimum_unit),
+        *args,
+        **kwargs,
     )

--- a/plextraktsync/sync/plugin/SyncPluginManager.py
+++ b/plextraktsync/sync/plugin/SyncPluginManager.py
@@ -57,7 +57,7 @@ class SyncPluginManager:
             self.logger.info(f"Enable sync plugin '{plugin.__name__}': {enabled}")
             if not enabled:
                 continue
-            with measure_time(f"Created '{plugin.__name__}' plugin", level=logging.DEBUG):
+            with measure_time(f"Created '{plugin.__name__}' plugin", logger=self.logger.debug):
                 p = plugin.factory(sync)
-            with measure_time(f"Registered '{plugin.__name__}' plugin", level=logging.DEBUG):
+            with measure_time(f"Registered '{plugin.__name__}' plugin", logger=self.logger.debug):
                 self.pm.register(p)


### PR DESCRIPTION
This allows passing logger and level, so that logger name would match caller.