### PR TITLE
Performance: Preload matches for shows

### DIFF
--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -104,14 +104,14 @@ class Walker(SetWindowTitle):
             yield from self.get_plex_episodes(self.plan.episodes)
 
         # Preload plex shows
-        plex_shows = {}
+        plex_shows: dict[int, PlexLibraryItem] = {}
 
         self.logger.info("Preload shows data")
         for show in self.get_plex_shows():
             plex_shows[show.key] = show
         self.logger.info(f"Preloaded shows data ({len(plex_shows)} shows)")
 
-        show_cache = {}
+        show_cache: dict[int, Media] = {}
         for ep in self.episodes_from_sections(self.plan.show_sections):
             show_id = ep.show_id
             ep.show = plex_shows[show_id]

--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -105,13 +105,19 @@ class Walker(SetWindowTitle):
 
         # Preload plex shows
         plex_shows: dict[int, PlexLibraryItem] = {}
-
         self.logger.info("Preload shows data")
         for show in self.get_plex_shows():
             plex_shows[show.key] = show
         self.logger.info(f"Preloaded shows data ({len(plex_shows)} shows)")
 
+        # Preload matches for shows
         show_cache: dict[int, Media] = {}
+        self.logger.info("Preload shows matches")
+        it = self.progressbar(plex_shows.items(), desc="Processing show matches")
+        for show_id, ps in it:
+            show_cache[show_id] = self.mf.resolve_any(ps)
+        self.logger.info(f"Preloaded shows matches ({len(show_cache)} shows)")
+
         for ep in self.episodes_from_sections(self.plan.show_sections):
             show_id = ep.show_id
             ep.show = plex_shows[show_id]


### PR DESCRIPTION
Extracted from https://github.com/Taxel/PlexTraktSync/pull/563, can't lazy load the show property in from async methods, so need to preload them.