### PR TITLE
Fix: Throw sync command out of async

### DIFF
--- a/plextraktsync/commands/sync.py
+++ b/plextraktsync/commands/sync.py
@@ -9,7 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 @coro
-async def sync(
+async def run_async(runner, **kwargs):
+    await runner.sync(**kwargs)
+
+
+def sync(
     sync_option: str,
     library: str,
     show: str,
@@ -69,4 +73,4 @@ async def sync(
             w.print_plan(print=logger.info)
         if dry_run:
             logger.info("Enabled dry-run mode: not making actual changes")
-        await runner.sync(walker=w, dry_run=config.dry_run)
+        run_async(runner, walker=w, dry_run=config.dry_run)


### PR DESCRIPTION
Apparently `inquirer.select().execute()` starts new async loop
and doesn't seems to be a way to pass it a loop.

So we just delay creating async loop in sync command.

Fixes https://github.com/Taxel/PlexTraktSync/issues/1938