### PR TITLE
Refactor: Use decorator package to make decorators

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ cattrs = {version="==23.2.3", python_version=">='3.7'"}
 certifi = "==2024.2.2"
 charset-normalizer = "==3.3.2"
 click = "==8.1.7"
+decorator = "==5.1.1"
 deprecated = "==1.2.14"
 humanize = "==4.9.0"
 idna = {version="==3.7", python_version=">='3.5'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -22,7 +22,6 @@
                 "sha256:fe66316ce1cdd9d7c406bd39582c267df5d6cf70b701bdbe9523d5efecd45308"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==0.9.4"
         },
         "attrs": {
@@ -31,7 +30,6 @@
                 "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==23.2.0"
         },
         "cattrs": {
@@ -39,7 +37,8 @@
                 "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108",
                 "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f"
             ],
-            "markers": "python_version >= '3.7' and python_version >= '3.8'",
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==23.2.3"
         },
         "certifi": {
@@ -48,7 +47,6 @@
                 "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==2024.2.2"
         },
         "charset-normalizer": {
@@ -145,7 +143,6 @@
                 "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.3.2"
         },
         "click": {
@@ -154,7 +151,6 @@
                 "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
         "decorator": {
@@ -162,7 +158,7 @@
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==5.1.1"
         },
         "deprecated": {
@@ -171,7 +167,6 @@
                 "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.14"
         },
         "exceptiongroup": {
@@ -179,7 +174,6 @@
                 "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
                 "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
             ],
-            "index": "pypi",
             "markers": "python_version < '3.11'",
             "version": "==1.2.1"
         },
@@ -189,7 +183,6 @@
                 "sha256:ce284a76d5b1377fd8836733b983bfb0b76f1aa1c090de2566fcf008d7f6ab16"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==4.9.0"
         },
         "idna": {
@@ -197,6 +190,7 @@
                 "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
                 "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==3.7"
         },
@@ -206,7 +200,6 @@
                 "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.3.4"
         },
         "markdown-it-py": {
@@ -214,7 +207,8 @@
                 "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
                 "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
             ],
-            "markers": "python_version >= '3.7' and python_version >= '3.8'",
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
         },
         "mdurl": {
@@ -222,6 +216,7 @@
                 "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
                 "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==0.1.2"
         },
@@ -231,7 +226,6 @@
                 "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==3.2.2"
         },
         "pfzy": {
@@ -239,6 +233,7 @@
                 "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96",
                 "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.3.4"
         },
@@ -248,7 +243,7 @@
                 "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.2.2"
         },
         "plexapi": {
@@ -266,7 +261,6 @@
                 "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.5.0"
         },
         "prompt-toolkit": {
@@ -275,7 +269,6 @@
                 "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.0.43"
         },
         "pygments": {
@@ -284,7 +277,6 @@
                 "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.18.0"
         },
         "python-dotenv": {
@@ -293,7 +285,6 @@
                 "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.0.1"
         },
         "python-git-info": {
@@ -375,7 +366,6 @@
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "requests": {
@@ -393,7 +383,6 @@
                 "sha256:db1c709ca343cc1cd5b6c8b1a5387298eceed02306a6040760db538c885e3838"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.2.0"
         },
         "requests-oauthlib": {
@@ -401,6 +390,7 @@
                 "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36",
                 "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.4'",
             "version": "==2.0.0"
         },
@@ -410,7 +400,6 @@
                 "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==13.7.1"
         },
         "six": {
@@ -418,7 +407,8 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version >= '3.4'",
+            "index": "pypi",
+            "markers": "python_version >= '3.4'",
             "version": "==1.16.0"
         },
         "tqdm": {
@@ -427,7 +417,6 @@
                 "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==4.66.4"
         },
         "types-decorator": {
@@ -443,7 +432,7 @@
                 "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
                 "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
-            "markers": "python_version < '3.9'",
+            "markers": "python_version < '3.11'",
             "version": "==4.11.0"
         },
         "url-normalize": {
@@ -451,7 +440,8 @@
                 "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2",
                 "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version >= '3.6'",
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==1.4.3"
         },
         "urllib3": {
@@ -460,7 +450,6 @@
                 "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==2.2.1"
         },
         "wcwidth": {
@@ -477,7 +466,6 @@
                 "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.8.0"
         },
         "wrapt": {
@@ -553,7 +541,8 @@
                 "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
                 "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
             ],
-            "markers": "python_version >= '3.5' and python_version >= '3.6'",
+            "index": "pypi",
+            "markers": "python_version >= '3.5'",
             "version": "==1.16.0"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e88cb608a6a0ce55ec8b9f2cb0cc5772877c559fed889d39dd214e700135dcb7"
+            "sha256": "2787d734ebdaefc5b4710fb2dd40c56d92f4f0b1873b452c4f5af8fbe4f2e301"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/plextraktsync/decorators/coro.py
+++ b/plextraktsync/decorators/coro.py
@@ -1,15 +1,13 @@
 import asyncio
-from functools import wraps
+
+from decorator import decorator
 
 
-def coro(f):
+@decorator
+def coro(f, *args, **kwargs):
     """
     Decorator to get started with async/await with click
 
     https://github.com/pallets/click/issues/85#issuecomment-503464628
     """
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        return asyncio.run(f(*args, **kwargs))
-
-    return wrapper
+    return asyncio.run(f(*args, **kwargs))

--- a/plextraktsync/decorators/flatten.py
+++ b/plextraktsync/decorators/flatten.py
@@ -1,25 +1,16 @@
-from functools import wraps
+from decorator import decorator
 
 
-def flatten_list(method):
-    @wraps(method)
-    def inner(*args, **kwargs):
-        return list(method(*args, **kwargs))
-
-    return inner
+@decorator
+def flatten_list(method, *args, **kwargs):
+    return list(method(*args, **kwargs))
 
 
-def flatten_dict(method):
-    @wraps(method)
-    def inner(*args, **kwargs):
-        return dict(method(*args, **kwargs))
-
-    return inner
+@decorator
+def flatten_dict(method, *args, **kwargs):
+    return dict(method(*args, **kwargs))
 
 
-def flatten_set(method):
-    @wraps(method)
-    def inner(*args, **kwargs):
-        return set(method(*args, **kwargs))
-
-    return inner
+@decorator
+def flatten_set(method, *args, **kwargs):
+    return set(method(*args, **kwargs))

--- a/plextraktsync/decorators/nocache.py
+++ b/plextraktsync/decorators/nocache.py
@@ -1,14 +1,11 @@
-from functools import wraps
+from decorator import decorator
 
 from plextraktsync.factory import factory
 
 session = factory.session
 
 
-def nocache(method):
-    @wraps(method)
-    def inner(*args, **kwargs):
-        with session.cache_disabled():
-            return method(*args, **kwargs)
-
-    return inner
+@decorator
+def nocache(method, *args, **kwargs):
+    with session.cache_disabled():
+        return method(*args, **kwargs)

--- a/plextraktsync/decorators/rate_limit.py
+++ b/plextraktsync/decorators/rate_limit.py
@@ -1,8 +1,9 @@
-from functools import wraps
 from time import sleep
 
 from click import ClickException
 from trakt.errors import RateLimitException
+from decorator import decorator
+
 
 from plextraktsync.factory import logging
 
@@ -10,37 +11,26 @@ logger = logging.getLogger(__name__)
 
 
 # https://trakt.docs.apiary.io/#introduction/rate-limiting
-def rate_limit(retries=5):
-    """
-    :param retries: number of retries
-    :return:
-    """
+@decorator
+def rate_limit(fn, retries=5, *args, **kwargs):
+    retry = 0
+    while True:
+        try:
+            return fn(*args, **kwargs)
+        except RateLimitException as e:
+            if retry == retries:
+                logger.error(f"Trakt Error: {e}")
+                logger.error(
+                    f"Last call: {fn.__module__}.{fn.__name__}({args[1:]}, {kwargs})"
+                )
+                raise ClickException(
+                    "Trakt API didn't respond properly, script will abort now. Please try again later."
+                )
 
-    def decorator(fn):
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            retry = 0
-            while True:
-                try:
-                    return fn(*args, **kwargs)
-                except RateLimitException as e:
-                    if retry == retries:
-                        logger.error(f"Trakt Error: {e}")
-                        logger.error(
-                            f"Last call: {fn.__module__}.{fn.__name__}({args[1:]}, {kwargs})"
-                        )
-                        raise ClickException(
-                            "Trakt API didn't respond properly, script will abort now. Please try again later."
-                        )
-
-                    seconds = e.retry_after
-                    retry += 1
-                    logger.warning(
-                        f"{e} for {fn.__module__}.{fn.__name__}(), retrying after {seconds} seconds (try: {retry}/{retries})"
-                    )
-                    logger.debug(e.details)
-                    sleep(seconds)
-
-        return wrapper
-
-    return decorator
+            seconds = e.retry_after
+            retry += 1
+            logger.warning(
+                f"{e} for {fn.__module__}.{fn.__name__}(), retrying after {seconds} seconds (try: {retry}/{retries})"
+            )
+            logger.debug(e.details)
+            sleep(seconds)

--- a/plextraktsync/decorators/retry.py
+++ b/plextraktsync/decorators/retry.py
@@ -1,63 +1,54 @@
-from functools import wraps
 from time import sleep
 
 from click import ClickException
+from decorator import decorator
 from plexapi.exceptions import BadRequest
 from requests import ReadTimeout, RequestException
-from trakt.errors import (BadResponseException, TraktBadGateway,
-                          TraktInternalException, TraktUnavailable)
+from trakt.errors import (
+    BadResponseException,
+    TraktBadGateway,
+    TraktInternalException,
+    TraktUnavailable,
+)
 
 from plextraktsync.factory import logging
 
 logger = logging.getLogger(__name__)
 
 
-def retry(retries=5):
-    """
-    retry a call retries times
+@decorator
+def retry(fn, retries=5, *args, **kwargs):
+    count = 0
+    while True:
+        try:
+            return fn(*args, **kwargs)
+        except (
+            BadRequest,
+            BadResponseException,
+            ReadTimeout,
+            RequestException,
+            TraktBadGateway,
+            TraktUnavailable,
+            TraktInternalException,
+        ) as e:
+            if count == retries:
+                logger.error(f"Error: {e}")
 
-    :param retries: number of retries
-    :return:
-    """
+                if isinstance(e, BadResponseException):
+                    logger.error(f"Details: {e.details}")
+                if isinstance(e, TraktInternalException):
+                    logger.error(f"Error message: {e.error_message}")
 
-    def decorator(fn):
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            count = 0
-            while True:
-                try:
-                    return fn(*args, **kwargs)
-                except (
-                        BadRequest,
-                        BadResponseException,
-                        ReadTimeout,
-                        RequestException,
-                        TraktBadGateway,
-                        TraktUnavailable,
-                        TraktInternalException,
-                ) as e:
-                    if count == retries:
-                        logger.error(f"Error: {e}")
+                logger.error(
+                    f"Last call: {fn.__module__}.{fn.__name__}({args[1:]}, {kwargs})"
+                )
+                raise ClickException(
+                    "API didn't respond properly, script will abort now. Please try again later."
+                )
 
-                        if isinstance(e, BadResponseException):
-                            logger.error(f"Details: {e.details}")
-                        if isinstance(e, TraktInternalException):
-                            logger.error(f"Error message: {e.error_message}")
-
-                        logger.error(
-                            f"Last call: {fn.__module__}.{fn.__name__}({args[1:]}, {kwargs})"
-                        )
-                        raise ClickException(
-                            "API didn't respond properly, script will abort now. Please try again later."
-                        )
-
-                    seconds = 1 + count
-                    count += 1
-                    logger.warning(
-                        f"{e} for {fn.__module__}.{fn.__name__}(), retrying after {seconds} seconds (try: {count}/{retries})"
-                    )
-                    sleep(seconds)
-
-        return wrapper
-
-    return decorator
+            seconds = 1 + count
+            count += 1
+            logger.warning(
+                f"{e} for {fn.__module__}.{fn.__name__}(), retrying after {seconds} seconds (try: {count}/{retries})"
+            )
+            sleep(seconds)

--- a/plextraktsync/decorators/time_limit.py
+++ b/plextraktsync/decorators/time_limit.py
@@ -1,22 +1,17 @@
-from functools import wraps
-
 from plextraktsync.config import TRAKT_POST_DELAY
 from plextraktsync.util.Timer import Timer
+from decorator import decorator
+
 
 timer = Timer(TRAKT_POST_DELAY)
 
 
-def time_limit():
+@decorator
+def time_limit(fn, *args, **kwargs):
     """
     Throttles calls not to be called more often than TRAKT_POST_DELAY
     """
 
-    def decorator(fn):
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            timer.wait_if_needed()
-            return fn(*args, **kwargs)
+    timer.wait_if_needed()
 
-        return wrapper
-
-    return decorator
+    return fn(*args, **kwargs)


### PR DESCRIPTION
Makes decorator code more readable, because nested functions no longer needed.

NOTE: [decorator](https://pypi.org/project/decorator/) is already in dependencies.

Also, not a clue why pipenv again changed all decorators: 4e6ff6f636cea8f53849b6e1e43d46b88978dbe4