### PR TITLE
Pipenv: Track typing-extensions package for dependabot

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,6 +37,7 @@ requests-oauthlib = {version="==2.0.0", python_version=">='3.4'"}
 rich = "==13.7.1"
 six = {version="==1.16.0", python_version=">='3.4'"}
 tqdm = "==4.66.4"
+typing-extensions = {version="==4.12.2", python_version=">= '3.8'"}
 url-normalize = {version="==1.4.3", python_version=">='3.6'"}
 urllib3 = "==2.2.1"
 wcwidth = "==0.2.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fd431881ca1512f230a0a9a9464830b6cefe5410502e31e1c9612ad377704e47"
+            "sha256": "1b904c4f7313414354001c267a335c3cd1eaf5e7e3332c2445ebae68b88db440"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/requirements.pipenv.txt
+++ b/requirements.pipenv.txt
@@ -5,4 +5,4 @@
 #
 
 -i https://pypi.org/simple/
-pipenv==2023.11.15
+pipenv==2023.12.1


### PR DESCRIPTION
Seems @dependabot still sucks and not able to track properly without entries in `Pipfile`:
- https://github.com/dependabot/dependabot-core/issues/6200#issuecomment-1325144662

So that dependabot doesn't go crazy and create incomplete pull requests:
- https://github.com/Taxel/PlexTraktSync/pull/1975
- https://github.com/Taxel/PlexTraktSync/pull/1980
- https://github.com/Taxel/PlexTraktSync/pull/1982
