### PR TITLE
Update README.md: change docker-compose to docker compose because command syntax has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Note: `main` is development version and reporting bugs against development versi
 To run sync:
 
 ```
-docker-compose run --rm plextraktsync sync
+docker compose run --rm plextraktsync sync
 ```
 
 The container will stop after the sync is completed. Read Setup section to run
@@ -263,7 +263,7 @@ Installing from GitHub is considered developer mode, and it's documented in
 
 [ofelia]: https://github.com/mcuadros/ofelia/
 
-A docker-compose example with a 6h interval:
+A docker compose example with a 6h interval:
 
 ```yaml
 version: "2"
@@ -468,7 +468,7 @@ compose, you can run them at the same time.
 The above config means that a job is running every 6 hours, alternating between
 the two "servers". The PlexTraktSync container also has a [docker compose
 profile] called "schedule" which means that it won't run automatically when you
-run for example `docker-compose up`.
+run for example `docker compose up`.
 
 [docker compose profile]: https://docs.docker.com/compose/profiles/
 
@@ -617,10 +617,10 @@ To run `watch` command:
 or
 
 ```
-docker-compose run --rm plextraktsync watch
+docker compose run --rm plextraktsync watch
 ```
 
-or add `command: watch` to docker compose file, and `docker-compose up -d
+or add `command: watch` to docker compose file, and `docker compose up -d
 plextraktsync` to start the container detached:
 
 ```yaml


### PR DESCRIPTION
`docker-compose` --> `docker compose`

The official syntax of the command has changed. Many distributions and installers will automatically create an alias, but this should no be relied upon since it will not always be there. Documentation should be updated to reflect the standard syntax as defined by Docker. 

```
$ docker-compose
The program 'docker-compose' is currently not installed. It is provided by
several packages. You can install it by typing one of the following:

$ docker compose
Usage:  docker compose [OPTIONS] COMMAND
```