### PR TITLE
Fix matching of matches by name and value

### DIFF
--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -133,9 +133,8 @@ class PlexApi:
             for m in result:
                 pm = PlexLibraryItem(m, self)
                 # Do proper matching with provider type and provider id
-                matched = len(
-                    [[True for g1 in pm.guids if g1 == g2] for g2 in plexguids]
-                )
+                matrix = list([g1 for g1 in pm.guids if g1 == g2] for g2 in plexguids)
+                matched = sum(matrix, [])
                 if matched:
                     results.append(pm)
 


### PR DESCRIPTION
The previous code didn't work at all: it always took all matches are positive matches.

Credits for the `sum()` trick:
- https://realpython.com/python-flatten-list/