### PR TITLE
Fix inspect of discover url

### DIFF
--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -41,9 +41,7 @@ class PlexLibraryItem(RichMarkup):
 
     @cached_property
     def is_discover(self):
-        # Use __dict__ access to prevent reloads:
-        # https://github.com/pkkid/python-plexapi/pull/1093
-        return self.item.__dict__["librarySectionID"] is None
+        return self.section_id is None
 
     @property
     def web_url(self):
@@ -128,10 +126,10 @@ class PlexLibraryItem(RichMarkup):
         if self.is_discover:
             return None
 
-        if self.item.librarySectionID not in self.plex.library_sections:
+        if self.section_id not in self.plex.library_sections:
             return None
 
-        return self.plex.library_sections[self.item.librarySectionID]
+        return self.plex.library_sections[self.section_id]
 
     @cached_property
     def edition_title(self):

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -34,6 +34,12 @@ class PlexLibraryItem(RichMarkup):
         return not self.item.guid.startswith("plex://")
 
     @cached_property
+    def section_id(self):
+        # Use __dict__ access to prevent reloads:
+        # https://github.com/pkkid/python-plexapi/pull/1093
+        return self.item.__dict__["librarySectionID"]
+
+    @cached_property
     def is_discover(self):
         # Use __dict__ access to prevent reloads:
         # https://github.com/pkkid/python-plexapi/pull/1093

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -37,7 +37,13 @@ class PlexLibraryItem(RichMarkup):
     def section_id(self):
         # Use __dict__ access to prevent reloads:
         # https://github.com/pkkid/python-plexapi/pull/1093
-        return self.item.__dict__["librarySectionID"]
+        section_id = self.item.__dict__["librarySectionID"]
+        # For some odd reason (or bug) section id is NaN.
+        # Treat it as None instead
+        # This is same as math.isnan(section_id)
+        if section_id != section_id:
+            return None
+        return section_id
 
     @cached_property
     def is_discover(self):


### PR DESCRIPTION
Example:
- https://app.plex.tv/desktop/#!/provider/tv.plex.provider.discover/details?key=/library/metadata/60cefe5ed208b5002dd25f5f

It would fail because `is_discover` is giving false result.