### PR TITLE
Feature: Add compare-libraries command

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -128,6 +128,25 @@ def clear_collections():
 
 
 @command()
+@click.option(
+    "--library1",
+    type=str,
+    required=True,
+    help="Plex Server/Plex Library name from servers.yml",
+)
+@click.option(
+    "--library2",
+    type=str,
+    required=True,
+    help="Plex Server/Plex Library name from servers.yml",
+)
+def compare_libraries():
+    """
+    Compare two Plex Libraries
+    """
+
+
+@command()
 def info():
     """
     Print application and environment version info
@@ -346,6 +365,7 @@ def config():
 cli.add_command(bug_report)
 cli.add_command(cache)
 cli.add_command(clear_collections)
+cli.add_command(compare_libraries)
 cli.add_command(config)
 cli.add_command(download)
 cli.add_command(imdb_import)

--- a/plextraktsync/commands/compare_libraries.py
+++ b/plextraktsync/commands/compare_libraries.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from plextraktsync.decorators.coro import coro
+from plextraktsync.factory import factory
+
+
+@coro
+async def compare_libraries(library1: str, library2: str):
+    print = factory.print
+    print(f"Compare contents of '{library1}' and '{library2}'")

--- a/plextraktsync/commands/compare_libraries.py
+++ b/plextraktsync/commands/compare_libraries.py
@@ -1,10 +1,109 @@
 from __future__ import annotations
 
+import contextlib
+
+from plexapi.exceptions import NotFound
+from sqlalchemy.util import OrderedSet
+
+from plextraktsync.config.ConfigLoader import ConfigLoader
 from plextraktsync.decorators.coro import coro
 from plextraktsync.factory import factory
+from plextraktsync.plex.PlexApi import PlexApi
+from plextraktsync.plex.PlexLibrarySection import PlexLibrarySection
+
+
+def get_plex_from_name(name: str):
+    try:
+        server_name, library_name = name.split("/", 2)
+    except ValueError:
+        return None
+
+    plex = factory.get_plex_by_name(server_name)
+    if library_name.isnumeric():
+        library = plex.library_sections[int(library_name)]
+    else:
+        library = [v for v in plex.library_sections.values() if v.title == library_name][0]
+    return plex, library
+
+
+def get_walker(plex: PlexApi, library: PlexLibrarySection):
+    from plextraktsync.plan.WalkConfig import WalkConfig
+    from plextraktsync.plan.Walker import Walker
+
+    wc = WalkConfig()
+    wc.add_library(library.title)
+
+    return Walker(plex=plex, trakt=factory.trakt_api, mf=factory.media_factory, config=wc, progressbar=factory.progressbar)
+
+
+async def load_movies(walker1, walker2):
+    movies1 = OrderedSet()
+    async for pm in walker1.get_plex_movies():
+        movies1.add(pm)
+
+    movies2 = set()
+    async for pm in walker2.get_plex_movies():
+        movies2.add(pm)
+
+    return movies1, movies2
+
+
+def get_pairs(movies1, movies2):
+    for pm1 in movies1:
+        for pm2 in movies2:
+            if pm1 == pm2:
+                yield pm1, pm2
+
+
+def cache_key(lib1: PlexLibrarySection, lib2: PlexLibrarySection):
+    return "-".join(
+        [
+            str(p)
+            for p in [
+                lib1.section._server.machineIdentifier,
+                lib1.section.key,
+                lib2.section._server.machineIdentifier,
+                lib2.section.key,
+            ]
+        ]
+    )
 
 
 @coro
 async def compare_libraries(library1: str, library2: str):
     print = factory.print
     print(f"Compare contents of '{library1}' and '{library2}'")
+    plex1, lib1 = get_plex_from_name(library1)
+    plex2, lib2 = get_plex_from_name(library2)
+    print(f"Loading contents of {lib1} and {lib2}")
+    walker1 = get_walker(plex1, lib1)
+    walker2 = get_walker(plex2, lib2)
+
+    movies1, movies2 = await load_movies(walker1, walker2)
+    matches = set()
+    cache_file = f"compare-cache-{cache_key(lib1, lib2)}.json"
+    cache = dict()
+    with contextlib.suppress(FileNotFoundError):
+        cache = ConfigLoader.load(cache_file)
+    for pm1, pm2 in get_pairs(movies1, movies2):
+        if cache.get(str(pm1.key)):
+            continue
+        if not pm1.is_watched:
+            cache[str(pm1.key)] = "not watched"
+            continue
+
+        try:
+            paths1 = set([part.file for part in pm1.parts])
+            paths2 = set([part.file for part in pm2.parts])
+        except NotFound as e:
+            print(e)
+            continue
+
+        print(f"Checking match '{pm1.key}': {pm1.title_link} == {pm2.title_link}")
+        print(paths1)
+        print(paths2)
+        matches.add(pm2)
+
+    ConfigLoader.write(cache_file, cache)
+
+    print(f"Made {len(matches)} matches")

--- a/plextraktsync/commands/compare_libraries.py
+++ b/plextraktsync/commands/compare_libraries.py
@@ -91,29 +91,26 @@ async def compare_libraries(library1: str, library2: str):
 
     movies1, movies2 = await load_movies(walker1, walker2)
     matches = set()
+
     cache_file = f"compare-cache-{cache_key(lib1, lib2)}.json"
-    cache = dict()
-    with contextlib.suppress(FileNotFoundError):
-        cache = ConfigLoader.load(cache_file)
-    for pm1, pm2 in get_pairs(movies1, movies2):
-        if cache.get(str(pm1.key)):
-            continue
-        if not pm1.is_watched:
-            cache[str(pm1.key)] = "not watched"
-            continue
+    with use_cache(cache_file) as cache:
+        for pm1, pm2 in get_pairs(movies1, movies2):
+            if cache.get(str(pm1.key)):
+                continue
+            if not pm1.is_watched:
+                cache[str(pm1.key)] = "not watched"
+                continue
 
-        try:
-            paths1 = set([part.file for part in pm1.parts])
-            paths2 = set([part.file for part in pm2.parts])
-        except NotFound as e:
-            print(e)
-            continue
+            try:
+                paths1 = set([part.file for part in pm1.parts])
+                paths2 = set([part.file for part in pm2.parts])
+            except NotFound as e:
+                print(e)
+                continue
 
-        print(f"Checking match '{pm1.key}': {pm1.title_link} == {pm2.title_link}")
-        print(paths1)
-        print(paths2)
-        matches.add(pm2)
-
-    ConfigLoader.write(cache_file, cache)
+            print(f"Checking match '{pm1.key}': {pm1.title_link} == {pm2.title_link}")
+            print(paths1)
+            print(paths2)
+            matches.add(pm2)
 
     print(f"Made {len(matches)} matches")

--- a/plextraktsync/commands/compare_libraries.py
+++ b/plextraktsync/commands/compare_libraries.py
@@ -69,6 +69,16 @@ def cache_key(lib1: PlexLibrarySection, lib2: PlexLibrarySection):
     )
 
 
+@contextlib.contextmanager
+def use_cache(cache_file: str):
+    cache = dict()  # noqa
+    with contextlib.suppress(FileNotFoundError):
+        cache = ConfigLoader.load(cache_file)
+
+    yield cache
+    ConfigLoader.write(cache_file, cache)
+
+
 @coro
 async def compare_libraries(library1: str, library2: str):
     print = factory.print

--- a/plextraktsync/util/Factory.py
+++ b/plextraktsync/util/Factory.py
@@ -67,6 +67,14 @@ class Factory:
 
         return self.plex_api
 
+    def get_plex_by_name(self, server_name: str):
+        server_config = self.server_config_factory.get_server(server_name)
+        if server_config is not None and server_config is not self.server_config:
+            self.invalidate(["plex_api", "plex_server", "server_config"])
+            self.run_config.server = server_config.name
+
+        return self.plex_api
+
     @cached_property
     def plex_server(self):
         from plextraktsync.factory import factory


### PR DESCRIPTION
The idea is to find duplicates across different libraries, different servers allowed.

Currently supports only Movie libraries.

```
$ plextraktsync compare-libraries  --library1=me/Movies --library2=friend/Movies
```

NOTE: Someone (else) should write docs for README. Docs is not my thing.