### PR TITLE
Refactor: Move project metadata to pyproject.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,39 @@
+[project]
+name = "PlexTraktSync"
+dynamic = ["version"]
+description = "Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server"
+readme = "README.md"
+license = {file = "LICENSE"}
+# See: https://pypi.python.org/pypi?:action=list_classifiers
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+
+  # Indicate who your project is intended for
+  "Environment :: Console",
+  "Operating System :: OS Independent",
+
+  # Pick your license as you wish (see also "license" above)
+  "License :: OSI Approved :: MIT License",
+
+  # List of Python versions and their support status:
+  # https://en.wikipedia.org/wiki/History_of_Python#Support
+  # https://endoflife.date/python
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "plextraktsync.__version__"}
+
+[project.urls]
+Homepage = "https://github.com/Taxel/PlexTraktSync"
+Repository = "https://github.com/Taxel/PlexTraktSync.git"
+Issues = "https://github.com/Taxel/PlexTraktSync/issues"
+
 [build-system]
 requires = [
     "setuptools-declarative-requirements>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
+requires-python = ">=3.8"
 
 [tool.setuptools.dynamic]
 version = {attr = "plextraktsync.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,30 +1,3 @@
-[metadata]
-name = PlexTraktSync
-version = attr: plextraktsync.__version__
-description = Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server
-long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/Taxel/PlexTraktSync
-license = MIT
-license_file = LICENSE
-classifiers =
-    # See: https://pypi.python.org/pypi?:action=list_classifiers
-    Environment :: Console
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
-    # List of Python versions and their support status:
-    # https://en.wikipedia.org/wiki/History_of_Python#Support
-    # https://endoflife.date/python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-project_urls =
-    Bug Tracker = https://github.com/Taxel/PlexTraktSync/issues
-
 [options]
 packages =
     plextraktsync

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ packages =
     plextraktsync.trakt
     plextraktsync.util
     plextraktsync.watch
-python_requires = >=3.8
 include_package_data = True
 
 [options.packages.find]


### PR DESCRIPTION
This is for tools like [rye][1] to work.

[1]: https://rye.astral.sh/

Refs:
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#writing-pyproject-toml