### PR TITLE
Build: Move entry points and packages to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ packages = [
     "plextraktsync.watch",
 ]
 
+[project.scripts]
+plextraktsync = "plextraktsync.cli:cli"
+
 [tool.ruff]
 # https://docs.astral.sh/ruff/settings/#line-length
 line-length = 150

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,27 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = [
+    "plextraktsync",
+    "plextraktsync.commands",
+    "plextraktsync.config",
+    "plextraktsync.decorators",
+    "plextraktsync.logger",
+    "plextraktsync.media",
+    "plextraktsync.mixin",
+    "plextraktsync.plan",
+    "plextraktsync.plex",
+    "plextraktsync.plugin",
+    "plextraktsync.queue",
+    "plextraktsync.rich",
+    "plextraktsync.sync",
+    "plextraktsync.sync.plugin",
+    "plextraktsync.trakt",
+    "plextraktsync.util",
+    "plextraktsync.watch",
+]
+
 [tool.ruff]
 # https://docs.astral.sh/ruff/settings/#line-length
 line-length = 150

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,4 @@
 [options]
-packages =
-    plextraktsync
-    plextraktsync.commands
-    plextraktsync.config
-    plextraktsync.decorators
-    plextraktsync.logger
-    plextraktsync.media
-    plextraktsync.mixin
-    plextraktsync.plan
-    plextraktsync.plex
-    plextraktsync.plugin
-    plextraktsync.queue
-    plextraktsync.rich
-    plextraktsync.sync
-    plextraktsync.sync.plugin
-    plextraktsync.trakt
-    plextraktsync.util
-    plextraktsync.watch
 include_package_data = True
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,6 @@ include_package_data = True
 exclude =
     tests
 
-[options.entry_points]
-console_scripts =
-    plextraktsync = plextraktsync.cli:cli
-
 [options.data_files]
 . =
     requirements.txt


### PR DESCRIPTION
Looks like changes were incomplete from https://github.com/Taxel/PlexTraktSync/pull/2045

```
$ pipx install plextraktsync==0.31.11
Note: Dependent package 'python-dotenv' contains 1 apps
  - dotenv
Note: Dependent package 'charset-normalizer' contains 1 apps
  - normalizer
Note: Dependent package 'websocket-client' contains 1 apps
  - wsdump
Note: Dependent package 'markdown-it-py' contains 1 apps
  - markdown-it
Note: Dependent package 'pygments' contains 1 apps
  - pygmentize
Note: Dependent package 'tqdm' contains 1 apps
  - tqdm

No apps associated with package plextraktsync. Try again with '--include-deps' to include apps of dependent packages, which are listed above. If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.
```