### PR TITLE
CI: Setup renovate bot

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,21 @@
+name: Renovate
+on:
+  schedule:
+    # The "*" (#42, asterisk) character has special semantics in YAML, so this
+    # string has to be quoted.
+    - cron: '42 3 * * *'
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://code.icb4dc0.de/prskr/ci-images/renovate:latest
+        with:
+          args: renovate "${{ github.repository }}"
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+          RENOVATE_PLATFORM: gitea
+          RENOVATE_AUTODISCOVER: "false"
+          RENOVATE_ENDPOINT: https://code.icb4dc0.de/api/v1
+          LOG_LEVEL: info


### PR DESCRIPTION
GitHub Dependabot is quite dumb, problems I've reported to them haven't been fixed for years. Perhaps renovate does better, or is more open actually fixing things.

Based on the file found on the internet:
- https://github.com/prskr/goveal/blob/90299a1405e95673bed349eb2847b918b014c73c/.gitea/workflows/renovate.yaml#L2

Setup renovate on github CI, because using service requires repo permissions I do not have:
- https://docs.renovatebot.com/getting-started/installing-onboarding/