### PR TITLE
added info to documentation on creating ciritcal files without access to commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ Installing from GitHub is considered developer mode, and it's documented in
   > **Note**
   > To setup the credentials in the Docker Container, refer to the [Run the Docker Container](#run-the-docker-container) section
 
+  > **Note2**
+  > If you are not able to run a docker container from commandline, like on a Synology NAS,
+  > run an instance of plextraktsync on a different device to create the necesary `.env`, `.pytrakt.json` and `servers.yml` files.
+  > Move them to the mapped `/app/config` folder and rebuild the container.
+  
 - At first run you will be asked to setup Trakt and Plex access.
 
   Follow the instructions, your credentials and API keys will be stored in


### PR DESCRIPTION
added a little help to hint at creating the necessary files elsewhere when docker image cannot be run from command-line (like on Synology NAS).