### PR TITLE
Feature: Re-use token for plex-login with --use-token flag

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -188,6 +188,11 @@ def env_plex_username():
     help="Plex password",
     default=lambda: environ.get("PLEX_PASSWORD", None),
 )
+@click.option(
+    "--use-token",
+    is_flag=True,
+    help="Use saved plex token if available",
+)
 def plex_login():
     """
     Log in to Plex Account to obtain Access Token. Optionally can use managed user on servers that you own.

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -56,14 +56,19 @@ def server_urls(server: MyPlexResource):
     yield local_url()
 
 
-def myplex_login(username: str, password: str, token: str | None):
+def myplex_login(username: str, password: str, token=None, code=None):
     while True:
-        username = Prompt.ask(PROMPT_PLEX_USERNAME, default=username)
-        password = Prompt.ask(PROMPT_PLEX_PASSWORD, password=True, default=password, show_default=False)
-        code = Prompt.ask(PROMPT_PLEX_CODE)
+        if token:
+            print("Using existing token to login to Plex")
+        if not token:
+            username = Prompt.ask(PROMPT_PLEX_USERNAME, default=username)
+            password = Prompt.ask(PROMPT_PLEX_PASSWORD, password=True, default=password, show_default=False)
+            code = Prompt.ask(PROMPT_PLEX_CODE)
         try:
             return MyPlexAccount(username=username, password=password, code=code, token=token)
         except Unauthorized as e:
+            if token:
+                raise e
             print(error(f"Log in to Plex failed: '{e}', Try again."), highlight=False)
         except BadRequest as e:
             raise ClickException(f"Log in to Plex failed: {e}")

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -190,17 +190,21 @@ def plex_login_autoconfig():
     login(username, password)
 
 
-def plex_login(username, password):
-    login(username, password)
+def plex_login(username, password, use_token: bool):
+    token = None
+    if use_token:
+        config = factory.config
+        token = config["PLEX_ACCOUNT_TOKEN"]
+
+    login(username, password, token)
 
 
-def login(username: str, password: str):
+def login(username: str, password: str, token=None):
     if factory.has_plex_token:
         if not Confirm.ask(PROMPT_PLEX_RELOGIN, default=True):
             return
 
-    config = factory.config
-    account = myplex_login(username, password, config["PLEX_ACCOUNT_TOKEN"])
+    account = myplex_login(username, password, token)
     print(
         Panel.fit(
             "Login to MyPlex was successful",

--- a/plextraktsync/commands/plex_login.py
+++ b/plextraktsync/commands/plex_login.py
@@ -56,13 +56,13 @@ def server_urls(server: MyPlexResource):
     yield local_url()
 
 
-def myplex_login(username, password):
+def myplex_login(username: str, password: str, token: str | None):
     while True:
         username = Prompt.ask(PROMPT_PLEX_USERNAME, default=username)
         password = Prompt.ask(PROMPT_PLEX_PASSWORD, password=True, default=password, show_default=False)
         code = Prompt.ask(PROMPT_PLEX_CODE)
         try:
-            return MyPlexAccount(username=username, password=password, code=code)
+            return MyPlexAccount(username=username, password=password, code=code, token=token)
         except Unauthorized as e:
             print(error(f"Log in to Plex failed: '{e}', Try again."), highlight=False)
         except BadRequest as e:
@@ -194,7 +194,8 @@ def login(username: str, password: str):
         if not Confirm.ask(PROMPT_PLEX_RELOGIN, default=True):
             return
 
-    account = myplex_login(username, password)
+    config = factory.config
+    account = myplex_login(username, password, config["PLEX_ACCOUNT_TOKEN"])
     print(
         Panel.fit(
             "Login to MyPlex was successful",


### PR DESCRIPTION
Recreate https://github.com/Taxel/PlexTraktSync/pull/1635

Can login to MyPlex without need for user/password.