### PR TITLE
Refactor: Enable stale_if_error, stale_while_revalidate

### DIFF
--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -109,8 +109,9 @@ class HttpCacheConfig:
         "*/devices": DO_NOT_CACHE,
         # system_account
         "*/accounts": DO_NOT_CACHE,
+        # Plex server root
         # version, updated_at
-        # "*/": DO_NOT_CACHE,
+        "*/": "10m",
     }
 
     @property

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -37,9 +37,9 @@ class HttpCacheConfig:
         "api.trakt.tv/users/*/collection/movies?extended=metadata": "10s",
         "api.trakt.tv/users/*/collection/movies": DO_NOT_CACHE,
         "api.trakt.tv/users/*/collection/shows": "1m",
-        "api.trakt.tv/users/*/ratings/episodes": "1m",
-        "api.trakt.tv/users/*/ratings/shows": "1m",
-        "api.trakt.tv/users/*/ratings/movies": "1m",
+        "api.trakt.tv/users/*/ratings/episodes": "10s",
+        "api.trakt.tv/users/*/ratings/shows": "10s",
+        "api.trakt.tv/users/*/ratings/movies": "10s",
         # Trakt search urls
         "api.trakt.tv/search/imdb/tt*?type=movie": "1d",
         "api.trakt.tv/search/imdb/tt*?type=show": "1d",

--- a/plextraktsync/config/HttpCacheConfig.py
+++ b/plextraktsync/config/HttpCacheConfig.py
@@ -34,7 +34,7 @@ class HttpCacheConfig:
         "api.trakt.tv/shows/*/seasons?extended=episodes": 28800,
         "api.trakt.tv/shows/*/seasons": DO_NOT_CACHE,
         "api.trakt.tv/sync/collection/shows": "1m",
-        "api.trakt.tv/users/*/collection/movies?extended=metadata": "1m",
+        "api.trakt.tv/users/*/collection/movies?extended=metadata": "10s",
         "api.trakt.tv/users/*/collection/movies": DO_NOT_CACHE,
         "api.trakt.tv/users/*/collection/shows": "1m",
         "api.trakt.tv/users/*/ratings/episodes": "1m",
@@ -55,10 +55,10 @@ class HttpCacheConfig:
         # Watchlist better be fresh for next run
         "api.trakt.tv/users/*/watchlist/movies": "1s",
         "api.trakt.tv/users/*/watchlist/shows": "1s",
-        "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "1s",
-        "metadata.provider.plex.tv/library/sections/watchlist/all": "1s",
-        "api.trakt.tv/users/likes/lists": DO_NOT_CACHE,
-        "api.trakt.tv/users/me": DO_NOT_CACHE,
+        "metadata.provider.plex.tv/library/sections/watchlist/all?*includeUserState=0": "60m",
+        "metadata.provider.plex.tv/library/sections/watchlist/all": "10m",
+        "api.trakt.tv/users/likes/lists": "5m",
+        "api.trakt.tv/users/me": "60m",
         # Public Lists
         "api.trakt.tv/lists/*": "1d",
         # Online Plex patterns
@@ -73,25 +73,26 @@ class HttpCacheConfig:
         # Plex account
         # Cache for some time, this activates 304 responses
         "plex.tv/users/account": "1m",
-        "plex.tv/api/v2/user": "1m",
+        "plex.tv/api/v2/user": "15m",
         # Plex patterns
         # Ratings search
-        "*/library/sections/*/all?*userRating%3E%3E=-1*": "1m",
+        "*/library/sections/*/all?*userRating*=-1*": "5m",
         # len(PlexLibrarySection)
-        "*/library/sections/*/all?includeCollections=0&X-Plex-Container-Size=0&X-Plex-Container-Start=0": DO_NOT_CACHE,
+        "*/library/sections/*/all?*X-Plex-Container-Size=0": DO_NOT_CACHE,
         # __iter__(PlexLibrarySection)
         "*/library/sections/*/all?includeGuids=1": DO_NOT_CACHE,
         # find_by_title
         "*/library/sections/*/all?includeGuids=1&title=*": DO_NOT_CACHE,
+        # episodes
+        "*/library/sections/*/all?includeGuids=1&type=4*": DO_NOT_CACHE,
         # fetch_item, fetch_items
         "*/library/sections/*/all?*": DO_NOT_CACHE,
+        "*/library/sections/*/collections?*X-Plex-Container-Size=0": DO_NOT_CACHE,
         "*/library/sections/*/collections": DO_NOT_CACHE,
         # library_sections
         "*/library/sections": DO_NOT_CACHE,
         # reloads
         "*/library/metadata/*?*include*": DO_NOT_CACHE,
-        # episodes
-        "*/library/sections/*/all?includeGuids=1&type=4*": DO_NOT_CACHE,
         # find_by_id
         "*/library/metadata/*": DO_NOT_CACHE,
         # mark played, mark unplayed

--- a/plextraktsync/factory/Factory.py
+++ b/plextraktsync/factory/Factory.py
@@ -139,6 +139,8 @@ class Factory:
             cache_name=self.config.cache_path,
             cache_control=True,
             urls_expire_after=self.urls_expire_after,
+            # Plex doesn't Send Vary: X-Plex-Container-Start
+            match_headers=["X-Plex-Container-Start"],
         )
 
     @cached_property

--- a/plextraktsync/factory/Factory.py
+++ b/plextraktsync/factory/Factory.py
@@ -137,7 +137,8 @@ class Factory:
 
         return CachedSession(
             cache_name=self.config.cache_path,
-            cache_control=True,
+            # Plex sends "Cache-Control: no-cache" headers to requests we want to cache
+            cache_control=False,
             urls_expire_after=self.urls_expire_after,
             # Plex doesn't Send Vary: X-Plex-Container-Start
             match_headers=["X-Plex-Container-Start"],

--- a/plextraktsync/factory/Factory.py
+++ b/plextraktsync/factory/Factory.py
@@ -140,6 +140,10 @@ class Factory:
             # Plex sends "Cache-Control: no-cache" headers to requests we want to cache
             cache_control=False,
             urls_expire_after=self.urls_expire_after,
+            # https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#expiration-and-error-handling
+            stale_if_error=True,
+            # https://requests-cache.readthedocs.io/en/stable/user_guide/expiration.html#asynchronous-revalidation
+            stale_while_revalidate=True,
             # Plex doesn't Send Vary: X-Plex-Container-Start
             match_headers=["X-Plex-Container-Start"],
         )

--- a/plextraktsync/plex/PlexServerConnection.py
+++ b/plextraktsync/plex/PlexServerConnection.py
@@ -7,7 +7,6 @@ from plexapi.server import PlexServer
 from requests.exceptions import ConnectionError, SSLError
 
 from plextraktsync.config import PLEX_PLATFORM
-from plextraktsync.decorators.nocache import nocache
 from plextraktsync.factory import Factory, logging
 
 
@@ -29,7 +28,6 @@ class PlexServerConnection:
     def session(self):
         return self.factory.session
 
-    @nocache
     def connect(self, urls: list[str], token: str):
         plexapi.X_PLEX_PLATFORM = PLEX_PLATFORM
         plexapi.TIMEOUT = self.timeout


### PR DESCRIPTION
_Extracted from https://github.com/Taxel/PlexTraktSync/pull/1870_

Extracted, because `stale_if_error` seems to have some issues to be resolved:
- https://github.com/Taxel/PlexTraktSync/pull/1870#issuecomment-2002598197