### PR TITLE
Fix: Treat rating=0 as no rating

### DIFF
--- a/plextraktsync/util/Rating.py
+++ b/plextraktsync/util/Rating.py
@@ -47,6 +47,12 @@ class Rating(NamedTuple):
             return None
 
         rating = int(rating)
+
+        # Treat rating=0 as no rating
+        # https://github.com/Taxel/PlexTraktSync/issues/2122
+        if rating == 0:
+            return None
+
         if isinstance(rated_at, str):
             try:
                 rated_at = datetime.fromisoformat(rated_at)


### PR DESCRIPTION
otherwise trakt would treat this as rating=1 (weak sauce):
- https://github.com/Taxel/PlexTraktSync/issues/2122#issuecomment-2567114618

Fixes https://github.com/Taxel/PlexTraktSync/issues/2122