### PR TITLE
Config updated: Working per server/library scheduling with ofelia

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,6 @@ services:
     image: ghcr.io/taxel/plextraktsync
     command: sync
     container_name: plextraktsync
-    profiles: ["schedule"]
     volumes:
       - /configs/mediarr/plextraktsync:/app/config
     environment:
@@ -464,7 +463,7 @@ services:
     depends_on:
       - plex
   scheduler:
-    image: mcuadros/ofelia:latest
+    image: mcuadros/ofelia
     container_name: scheduler
     command: daemon --docker
     restart: unless-stopped
@@ -489,11 +488,7 @@ hours. If you have two different PlexTraktSync containers in your docker
 compose, you can run them at the same time.
 
 The above config means that a job is running every 6 hours, alternating between
-the two "servers". The PlexTraktSync container also has a [docker compose
-profile] called "schedule" which means that it won't run automatically when you
-run for example `docker compose up`.
-
-[docker compose profile]: https://docs.docker.com/compose/profiles/
+the two "servers".
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can setup docker compose file like this:
 version: "2"
 services:
   plextraktsync:
-    image: ghcr.io/taxel/plextraktsync:latest
+    image: ghcr.io/taxel/plextraktsync
     command: sync
     container_name: plextraktsync
     restart: on-failure:2
@@ -292,7 +292,7 @@ A docker compose example with a 6h interval:
 version: "2"
 services:
   scheduler:
-    image: mcuadros/ofelia:latest
+    image: mcuadros/ofelia:0.3
     container_name: scheduler
     depends_on:
       - plextraktsync
@@ -452,7 +452,7 @@ something similar to this in your `docker-compose.yml`:
 ```yml
 services:
   plextraktsync:
-    image: ghcr.io/taxel/plextraktsync:latest
+    image: ghcr.io/taxel/plextraktsync
     command: sync
     container_name: plextraktsync
     volumes:
@@ -463,7 +463,7 @@ services:
     depends_on:
       - plex
   scheduler:
-    image: mcuadros/ofelia:latest
+    image: mcuadros/ofelia:0.3
     container_name: scheduler
     command: daemon --docker
     restart: unless-stopped

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can setup docker compose file like this:
 version: "2"
 services:
   plextraktsync:
-    image: ghcr.io/taxel/plextraktsync
+    image: ghcr.io/taxel/plextraktsync:latest
     command: sync
     container_name: plextraktsync
     restart: on-failure:2
@@ -452,18 +452,18 @@ something similar to this in your `docker-compose.yml`:
 ```yml
 services:
   plextraktsync:
-    image: ghcr.io/taxel/plextraktsync
+    image: ghcr.io/taxel/plextraktsync:latest
     command: sync
     container_name: plextraktsync
     volumes:
-      - /configs/mediarr/plextraktsync:/app/config
+      - ./config:/app/config
     environment:
       - PUID=1000
       - PGID=1000
     depends_on:
       - plex
   scheduler:
-    image: mcuadros/ofelia
+    image: mcuadros/ofelia:latest
     container_name: scheduler
     command: daemon --docker
     restart: unless-stopped


### PR DESCRIPTION
- Removes "schedule" profile in multi server setup since it doesnt work.
- Updates image versions so that it is cohesive through the whole documentation (latest on all).
- Updates config volume path so that it is the same in multi server config as it is in the single server config.

After discussions and testing for #2139.