### PR TITLE
Build: Lock pypa/gh-action-pypi-publish to v1.12.4

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -61,7 +61,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Ensure PEP 639 fix is in:
- https://github.com/Taxel/PlexTraktSync/pull/2191#issuecomment-2689133008

See:
- https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4