### PR TITLE
Fix: Revert "Replace deprecated classifier with licence expression (PEP 639)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ name = "PlexTraktSync"
 dynamic = ["version"]
 description = "Plex-Trakt-Sync is a two-way-sync between trakt.tv and Plex Media Server"
 readme = "README.md"
-license = "MIT"
-license-files = [ "LICENSE" ]
+license = {file = "LICENSE"}
 # See: https://pypi.python.org/pypi?:action=list_classifiers
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -12,6 +11,9 @@ classifiers = [
   # Indicate who your project is intended for
   "Environment :: Console",
   "Operating System :: OS Independent",
+
+  # Pick your license as you wish (see also "license" above)
+  "License :: OSI Approved :: MIT License",
 
   # List of Python versions and their support status:
   # https://en.wikipedia.org/wiki/History_of_Python#Support


### PR DESCRIPTION
This reverts commit 3db996fae1e7ea16885e15b86c9025af6d385330.

Setuptools is not yet ready:
- https://github.com/Taxel/PlexTraktSync/pull/2191#issuecomment-2690099403