### PR TITLE
Fix: Handle Trakt error 420 Account Limit Exceeded

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -55,7 +55,7 @@ sync:
   rating_priority: plex
 
   plex_to_trakt:
-    collection: true
+    collection: false
     # Clear collected state of items not present in Plex
     clear_collected: false
     ratings: true

--- a/plextraktsync/decorators/account_limit.py
+++ b/plextraktsync/decorators/account_limit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from decorator import decorator
+from trakt.errors import AccountLimitExceeded
+
+from plextraktsync.factory import logging
+
+logger = logging.getLogger(__name__)
+
+bypassed_lists = set()
+
+
+# https://forums.trakt.tv/t/freemium-experience-more-features-for-all-with-usage-limits/41641
+@decorator
+def account_limit(fn, *args, **kwargs):
+    list_name = fn.__name__.replace("add_to_", "")
+    if list_name in bypassed_lists:
+        return None
+
+    try:
+        return fn(*args, **kwargs)
+    except AccountLimitExceeded as e:
+        logger.error(f"Trakt Error: {e}")
+        logger.warning(
+            f"Account Limit Exceeded for Trakt {list_name}: {e.account_limit} items. " \
+            f"Consider disabling {list_name} sync or upgrading your Trakt account."
+        )
+        logger.debug(e.details)
+
+        if list_name:
+            bypassed_lists.add(list_name)
+        return None

--- a/plextraktsync/queue/TraktBatchWorker.py
+++ b/plextraktsync/queue/TraktBatchWorker.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import trakt.sync
 
+from plextraktsync.decorators.account_limit import account_limit
 from plextraktsync.decorators.rate_limit import rate_limit
 from plextraktsync.decorators.retry import retry
 from plextraktsync.decorators.time_limit import time_limit
@@ -32,11 +33,14 @@ class TraktBatchWorker:
     def submit(self, name, items):
         method = getattr(self, name)
         result = method(self.normalize(items))
+        if not result:
+            return
         result = remove_empty_values(result.copy())
         if result:
             self.logger.debug(f"Submitted {name}: {result}")
 
     @rate_limit()
+    @account_limit()
     @time_limit()
     @retry()
     def add_to_collection(self, items):
@@ -49,6 +53,7 @@ class TraktBatchWorker:
         return trakt.sync.remove_from_collection(items)
 
     @rate_limit()
+    @account_limit()
     @time_limit()
     @retry()
     def add_to_watchlist(self, items):


### PR DESCRIPTION
Handles http error `420 Account Limit Exceeded` to ensure sync without crashing and stops sending further requests to the affected endpoints.
This error can occur when a free Trakt account attempts to add items to _collection_ or _watchlist_ that have already reached their limit.
The account limit was introduced to the Trakt API in February 2025.

![limit](https://github.com/user-attachments/assets/37e1bdbd-de8d-4df1-a248-5be30b1425e2)


Refs :
- https://forums.trakt.tv/t/freemium-experience-more-features-for-all-with-usage-limits/41641

Closes #2162