### PR TITLE
Tests: Add skip_in_ci decorator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from os import environ
 from os.path import dirname
 from os.path import join as join_path
 
+import pytest
+from decorator import decorator
 from trakt.tv import TVShow
 
 from plextraktsync.factory import Factory
@@ -35,3 +38,13 @@ def make(cls=None, **kwargs) -> TVShow:
     cls = cls if cls is not None else "object"
     # https://stackoverflow.com/a/2827726/2314626
     return type(cls, (object,), kwargs)
+
+
+@decorator
+def skip_in_ci(func, reason="Skipped in CI environment", *args, **kwargs):
+    """Custom decorator to skip tests in CI."""
+
+    condition = os.getenv("CI") == "true"
+    if condition:
+        pytest.skip(reason)
+    func(*args, **kwargs)

--- a/tests/test_collection_metadata.py
+++ b/tests/test_collection_metadata.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import pytest
 
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
-from tests.conftest import make
+from tests.conftest import make, skip_in_ci
 
 testdata = [
     (
@@ -61,8 +61,8 @@ testdata = [
 ]
 
 
+@skip_in_ci
 @pytest.mark.parametrize("test_input,expected", testdata)
-@pytest.mark.skip(reason="Broken in CI")
 def test_collection_metadata(test_input, expected):
     m = PlexLibraryItem(test_input)
     json = m.to_json()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from os.path import join
 
-import pytest
-
 from plextraktsync.config.Config import Config
 from plextraktsync.factory import factory
+from tests.conftest import skip_in_ci
 
 
 def test_config_merge():
@@ -29,7 +28,7 @@ def test_config_merge_real():
     assert config["sync"]["plex_to_trakt"]["collection"] is False
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_sync_config():
     from tests.conftest import MOCK_DATA_DIR
 

--- a/tests/test_trakt_progress.py
+++ b/tests/test_trakt_progress.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3 -m pytest
 from __future__ import annotations
 
-import pytest
 from trakt.tv import TVShow
 
 from plextraktsync.pytrakt_extensions import ShowProgress
 from plextraktsync.trakt.TraktApi import TraktApi
-from tests.conftest import factory
+from tests.conftest import factory, skip_in_ci
 
 trakt: TraktApi = factory.trakt_api
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_trakt_watched_progress():
     show = TVShow("Game of Thrones")
     data = show.watched_progress()

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -43,6 +43,7 @@ def test_show_episodes():
     assert episodes[0].title == "Winter Is Coming"
 
 
+@skip_in_ci
 def test_show_episodes_attack_on_titan():
     show = TVShow("Attack on Titan")
 
@@ -69,6 +70,7 @@ def test_show_episodes_attack_on_titan():
     assert te.imdb == "tt2825724"
 
 
+@skip_in_ci
 def test_show_episodes_attack_on_titan_new_agent():
     show = TVShow("Attack on Titan")
 

--- a/tests/test_tv_lookup.py
+++ b/tests/test_tv_lookup.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3 -m pytest
 from __future__ import annotations
 
-import pytest
 from trakt.tv import TVShow
 
 from plextraktsync.plex.guid.PlexGuid import PlexGuid
 from plextraktsync.plex.PlexLibraryItem import PlexLibraryItem
 from plextraktsync.trakt.TraktLookup import TraktLookup
-from tests.conftest import factory, make
+from tests.conftest import factory, make, skip_in_ci
 
 trakt = factory.trakt_api
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_tv_lookup():
     m = PlexLibraryItem(make(cls="plexapi.video.Show", guid="imdb://tt10584350", type="show"))
     guid = m.guids[0]
@@ -23,7 +22,7 @@ def test_tv_lookup():
     assert te.imdb == "tt12057922", f"Unexpected! {te}"
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_show_episodes_plex():
     m = PlexLibraryItem(make(cls="plexapi.video.Show", guid="imdb://tt10584350", type="show"))
     guid = m.guids[0]
@@ -103,7 +102,7 @@ def test_show_episodes_attack_on_titan_new_agent():
     assert te.imdb == "tt2825724"
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_tv_lookup_by_episode_id():
     pe = PlexLibraryItem(
         make(
@@ -121,7 +120,7 @@ def test_tv_lookup_by_episode_id():
     assert te.tmdb == 511997
 
 
-@pytest.mark.skip(reason="Broken in CI")
+@skip_in_ci
 def test_find_episode():
     show = TVShow("Frank of Ireland")
 


### PR DESCRIPTION
Add and use `@skip_in_ci` decorator.

Disable two more tests that use trakt api:
- https://github.com/Taxel/PlexTraktSync/pull/2226
- https://github.com/Taxel/PlexTraktSync/pull/2227