### PR TITLE
Fix media remaining in "Continue Watching" due to 99.99% progress

### DIFF
--- a/plextraktsync/sync/WatchProgressPlugin.py
+++ b/plextraktsync/sync/WatchProgressPlugin.py
@@ -49,9 +49,19 @@ class WatchProgressPlugin:
 
         view_offset = timedelta(milliseconds=m.plex.item.viewOffset)
         progress_offset = timedelta(milliseconds=progress)
-        self.logger.info(
-            f"{m.title_link}: Set watch progress to {p.progress:.02F}%: {view_offset} -> {progress_offset}",
-            extra={"markup": True},
-        )
-        if not dry_run:
-            m.plex.item.updateProgress(progress)
+        
+        # Check if progress is at or very close to 100% (≥ 99%)
+        if p.progress >= 99.0:
+            self.logger.info(
+                f"{m.title_link}: Marking as fully watched (progress: {p.progress:.02F}%)",
+                extra={"markup": True},
+            )
+            if not dry_run:
+                m.plex.item.markWatched()
+        else:
+            self.logger.info(
+                f"{m.title_link}: Set watch progress to {p.progress:.02F}%: {view_offset} -> {progress_offset}",
+                extra={"markup": True},
+            )
+            if not dry_run:
+                m.plex.item.updateProgress(progress)


### PR DESCRIPTION
This PR fixes issue #2196 where media marked as watched in Trakt was being set to 99.99% progress in Plex instead of being marked as fully watched. This caused media items to remain in the "Continue Watching" section with 0 seconds remaining.

## Changes
- Modified `WatchProgressPlugin.sync_progress()` to check if the progress from Trakt is ≥ 99%
- For media with ≥ 99% progress, use `markWatched()` instead of `updateProgress()`
- Only use `updateProgress()` for media that is genuinely partially watched (< 99%)
- Updated the log messages to indicate when an item is being marked as fully watched

## Testing
I've tested this by:
- Syncing content that was marked as watched in Trakt
- Confirming that items previously stuck at 99.99% are now properly marked as watched
- Verifying that items are removed from the "Continue Watching" section
- Checking that partially watched content still syncs properly with the correct progress

Fixes #2196