### PR TITLE
Switch ubuntu-20.04 with ubuntu-latest for fastify/github-action-merge-dependabot

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,7 +8,7 @@ jobs:
   # https://github.com/fastify/github-action-merge-dependabot
   automerge:
     name: Dependabot auto-merge
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
 
     permissions:


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 retirement.
> Ubuntu 20.04 LTS runner will be removed on 2025-04-15.

For more details, see
- https://github.com/actions/runner-images/issues/11101

See:
- https://github.com/Taxel/PlexTraktSync/actions/runs/14574394377/job/40877534817?pr=2234

Unbreaks:
- https://github.com/Taxel/PlexTraktSync/pull/2234