### PR TITLE
Feature: Add support for private liked lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /tests/config.json
 /trakt_cache.sqlite
 __pycache__/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@
 /tests/config.json
 /trakt_cache.sqlite
 __pycache__/
-venv/

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -74,14 +74,11 @@ class TraktApi:
     @flatten_list
     def liked_lists(self) -> list[TraktLikedList]:
         for item in self.me.get_liked_lists("lists", limit=1000):
-            # Skip private lists
-            # https://github.com/Taxel/PlexTraktSync/issues/1864#issuecomment-2018171311
-            if item["list"]["privacy"] == "private":
-                self.logger.warning(f"Skipping private list: {item['list']['name']} - {item['list']['share_link']}")
-                continue
             tll: TraktLikedList = {
                 "listname": item["list"]["name"],
                 "listid": item["list"]["ids"]["trakt"],
+                "private": item["list"]["privacy"] == "private",
+                "list_type": item["list"]["type"],
             }
             yield tll
 

--- a/plextraktsync/trakt/TraktUserListCollection.py
+++ b/plextraktsync/trakt/TraktUserListCollection.py
@@ -33,16 +33,16 @@ class TraktUserListCollection(UserList):
 
     def load_lists(self, liked_lists: list[TraktLikedList]):
         for liked_list in liked_lists:
-            self.add_list(liked_list["listid"], liked_list["listname"])
+            self.add_list(liked_list["listid"], liked_list["listname"], liked_list["private"], liked_list["list_type"])
 
     def add_watchlist(self, items: list[TraktPlayable]):
         tl = TraktUserList.from_watchlist(items)
         self.append(tl)
         return tl
 
-    def add_list(self, list_id: int, list_name: str):
+    def add_list(self, list_id: int, list_name: str, is_private: bool = False, list_type: str = "personal"):
         list_config = self.trakt_lists_overrides.get(list_name, {})
         keep_watched = list_config.get("keep_watched", self.keep_watched)
-        tl = TraktUserList.from_trakt_list(list_id, list_name, keep_watched)
+        tl = TraktUserList.from_trakt_list(list_id, list_name, keep_watched, is_private, list_type)
         self.append(tl)
         return tl

--- a/plextraktsync/trakt/types.py
+++ b/plextraktsync/trakt/types.py
@@ -12,3 +12,5 @@ TraktPlayable = Union[Movie, TVEpisode]
 class TraktLikedList(TypedDict):
     listid: int
     listname: str
+    private: bool
+    list_type: str  # 'personal' or 'official'


### PR DESCRIPTION
Adds #1879 

I'm not sure if the implementation inside [`load_items()` of `TraktUserList.py`](https://github.com/Taxel/PlexTraktSync/blob/e08ae81d463429059ca6f66a1b25d483b84c89e2/plextraktsync/trakt/TraktUserList.py#L100) is correct. Because the return type of `PublicList.load()` is different from `User().get_list()`, I had to write a new function `build_dict_from_raw_items()` to build a dictionary similar to `build_dict()` that takes in a `PublicList`. But it works!

Feel free to make any changes as you see fit.

I tested it by creating a private personal list and liking it. I then ran the program with `python -m plextraktsync --no-cache sync`. 
I also followed the [contributing guide](https://github.com/Taxel/PlexTraktSync/blob/main/CONTRIBUTING.md) and ran all tests.

### Bug
For some reason, the terminal still says `Downloaded Trakt list` instead of `Downloaded private personal Trakt list` ([line 105 of `TraktUserList.py`](https://github.com/Taxel/PlexTraktSync/blob/e08ae81d463429059ca6f66a1b25d483b84c89e2/plextraktsync/trakt/TraktUserList.py#L105)). 