### PR TITLE
Handle unknown Plex guids

### DIFF
--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -101,7 +101,7 @@ class PlexLibraryItem(RichMarkup):
             "local": 100,
             "mbid": 1000,
         }
-        ordered = sorted(guids, key=lambda guid: sort_order[guid.provider])
+        ordered = sorted(guids, key=lambda guid: sort_order.get(guid.provider, 10))
         return ordered
 
     @cached_property


### PR DESCRIPTION
Prevent crash when dealing with unknown Plex guid.

fixes #2251

Refs
- https://en.wikipedia.org/wiki/EIDR