### PR TITLE
Handle BadRequest exception in PlexApi has_sessions method

### DIFF
--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -206,7 +206,7 @@ class PlexApi:
         try:
             self.server.sessions()
             return True
-        except Unauthorized:
+        except (Unauthorized, BadRequest):
             return False
 
     @property


### PR DESCRIPTION
With Plex Media Server _1.46.1_, the user sessions were detected as not available with a `401 Unauthorized` when PTS was logged with a non-admin Plex user.

With Plex Media Server _1.47.1_, the error returned is now a `403 Forbidden` raised  as `BadRequest` by [PlexApi](https://github.com/pushingkarmaorg/python-plexapi/blob/d5fcfd0bf41f123192be54cfb62f4db4a8eb1745/plexapi/server.py#L768-L773).

Fixes #2243 