### PR TITLE
Added providers parameter for plex discover api

### DIFF
--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -268,7 +268,7 @@ class PlexApi:
         if not self.account:
             return None
         try:
-            result = self.account.searchDiscover(title, libtype=media_type)
+            result = self.account.searchDiscover(title, libtype=media_type, providers='discover')
         except (BadRequest, Unauthorized) as e:
             self.logger.error(f"{title}: Searching Plex Discover error: {e}")
             return None


### PR DESCRIPTION
Add the providers parameter to the searchDiscover method call. Fixes the issue with syncing watchlist from Trakt to Plex.
Closes #2066