### PR TITLE
Fix: Support new "type" property in ShowProgress

### DIFF
--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -71,6 +71,7 @@ class ShowProgress:
         last_watched_at=None,
         last_updated_at=None,
         reset_at=None,
+        type=None,
         show=None,
         seasons=None,
         hidden_seasons=None,


### PR DESCRIPTION
New `type` property for :
- */sync/collection/shows*
- */sync/collection/movies*

ℹ️  Trakt devs updated their API without any notice again. Even [the doc](https://trakt.docs.apiary.io/#reference/sync/get-collection/get-collection) is not updated...


Data received from API :
```json
[
  {
    "last_collected_at": "2025-11-05T09:12:05.000Z",
    "last_updated_at": "2025-11-05T14:34:01.000Z",
    "type": "show",
    "show": {
      "title": "Silo",
      "year": 2023,
      "ids": {
        "trakt": 180770,
        "slug": "silo",
        "tvdb": 403245,
        "imdb": "tt14688458",
        "tmdb": 125988,
        "tvrage": null
      }
    },
    "seasons": [
      {
        "number": 1,
        "episodes": [
          {
            "number": 1,
            "collected_at": "2025-11-05T09:12:05.000Z"
          },
          {
            "number": 2,
            "collected_at": "2025-11-05T09:12:05.000Z"
          }
        ]
      }
    ]
  }
]
```