### PR TITLE
Add a margin to retry-after sleep to prevent premature rate-limit retry

### DIFF
--- a/plextraktsync/config/__init__.py
+++ b/plextraktsync/config/__init__.py
@@ -10,3 +10,8 @@ PLEX_PLATFORM = "PlexTraktSync"
 Constant in seconds for how much to wait between Trakt POST API calls.
 """
 TRAKT_POST_DELAY = 1.1
+
+"""
+Constants in seconds for the margin added to retry-after delay to account for network jitter in rate limiting retries.
+"""
+TRAKT_RETRY_AFTER_MARGIN = 0.9

--- a/plextraktsync/decorators/rate_limit.py
+++ b/plextraktsync/decorators/rate_limit.py
@@ -6,6 +6,7 @@ from click import ClickException
 from decorator import decorator
 from trakt.errors import RateLimitException
 
+from plextraktsync.config import TRAKT_RETRY_AFTER_MARGIN
 from plextraktsync.factory import logging
 
 logger = logging.getLogger(__name__)
@@ -28,4 +29,4 @@ def rate_limit(fn, retries=5, *args, **kwargs):
             retry += 1
             logger.warning(f"{e} for {fn.__module__}.{fn.__name__}(), retrying after {seconds} seconds (try: {retry}/{retries})")
             logger.debug(e.details)
-            sleep(seconds)
+            sleep(seconds + TRAKT_RETRY_AFTER_MARGIN)


### PR DESCRIPTION
Add a sleep margin in rate-limit decorator to prevent premature retries and avoid such error :

```
WARNING  Rate Limit Exceeded for plextraktsync.trakt.TraktApi.search_by_id(), retrying after 300 seconds (try: 1/5)
WARNING  Rate Limit Exceeded for plextraktsync.trakt.TraktApi.search_by_id(), retrying after 0 seconds (try: 2/5)
WARNING  Rate Limit Exceeded for plextraktsync.trakt.TraktApi.search_by_id(), retrying after 0 seconds (try: 3/5)
WARNING  Rate Limit Exceeded for plextraktsync.trakt.TraktApi.search_by_id(), retrying after 0 seconds (try: 4/5)
WARNING  Rate Limit Exceeded for plextraktsync.trakt.TraktApi.search_by_id(), retrying after 0 seconds (try: 5/5)
```
Keep logging the original `retry-after` value.
Tested successfully with Cloudflare rate limiting used by Trakt API.