### PR TITLE
Raise error when Trakt media type does not match episode

### DIFF
--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -179,6 +179,8 @@ class Media(RichMarkup):
             return self.trakt_id in self.trakt_api.watched_movies
         elif not self.is_episode:
             raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.media_type}")
+        elif self.type != "episode":
+            raise RuntimeError(f"watched_on_trakt: Trakt media type is not episode: {self.trakt.type}")
 
         watched = self.trakt_api.watched_shows
         return watched.get_completed(self.show_trakt_id, self.season_number, self.episode_number)

--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -139,7 +139,7 @@ class Media(RichMarkup):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.movie_collection_set
         elif not self.is_episode:
-            raise RuntimeError(f"is_collected: Unsupported media type: {self.media_type}")
+            raise RuntimeError(f"is_collected: Unsupported media type: {self.media_type} for '{self.title}'")
 
         collected = self.trakt_api.collected_shows
         return collected.is_collected(self.show_trakt_id, self.season_number, self.episode_number)
@@ -165,7 +165,7 @@ class Media(RichMarkup):
     @cached_property
     def seasons(self):
         if self.media_type != "shows":
-            raise RuntimeError(f"seasons: Unsupported media type: {self.media_type}")
+            raise RuntimeError(f"seasons: Unsupported media type: {self.media_type} for '{self.title}'")
 
         return TraktLookup(self.trakt)
 
@@ -178,9 +178,9 @@ class Media(RichMarkup):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.watched_movies
         elif not self.is_episode:
-            raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.media_type}")
+            raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.media_type} for '{self.title}'")
         elif self.type != "episode":
-            raise RuntimeError(f"watched_on_trakt: Trakt media type is not episode: {self.trakt.type}")
+            raise RuntimeError(f"watched_on_trakt: Trakt media type is not episode: {self.type} for '{self.title}'")
 
         watched = self.trakt_api.watched_shows
         return watched.get_completed(self.show_trakt_id, self.season_number, self.episode_number)
@@ -191,7 +191,7 @@ class Media(RichMarkup):
         Return True if episode was watched before show reset (if there is a reset).
         """
         if not self.is_episode:
-            raise RuntimeError("watched_before_reset is valid for episodes only")
+            raise RuntimeError(f"watched_before_reset is valid for episodes only, got {self.media_type} for '{self.title}'")
 
         return self.show_reset_at and self.plex.seen_date.replace(tzinfo=None) < self.show_reset_at
 
@@ -207,7 +207,7 @@ class Media(RichMarkup):
         elif self.is_episode:
             self.trakt_api.mark_watched(self.trakt, self.plex.seen_date, self.show_trakt_id)
         else:
-            raise RuntimeError(f"mark_watched_trakt: Unsupported media type: {self.media_type}")
+            raise RuntimeError(f"mark_watched_trakt: Unsupported media type: {self.media_type} for '{self.title}'")
 
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)

--- a/plextraktsync/plan/WalkPlanner.py
+++ b/plextraktsync/plan/WalkPlanner.py
@@ -59,7 +59,8 @@ class WalkPlanner:
             elif mediatype == "movie":
                 movies.extend(items)
             else:
-                raise RuntimeError(f"Unsupported type: {mediatype}")
+                titles = [m.title for m in items]
+                raise RuntimeError(f"find_by_id: Unsupported type: {mediatype} for items: {titles}")
 
         return [movies, shows, episodes]
 

--- a/plextraktsync/plex/PlexLibraryItem.py
+++ b/plextraktsync/plex/PlexLibraryItem.py
@@ -357,7 +357,7 @@ class PlexLibraryItem(RichMarkup):
             return self.item.parentRatingKey
         if self.type == "episode":
             return self.item.grandparentRatingKey
-        raise RuntimeError(f"Unsupported type={self.type} for show_id")
+        raise RuntimeError(f"show_id: Unsupported media type: {self.type} for '{self.title}'")
 
     @property
     def show(self):
@@ -369,7 +369,7 @@ class PlexLibraryItem(RichMarkup):
     @show.setter
     def show(self, show):
         if self.type != "episode":
-            raise RuntimeError("show_id is valid for episodes only")
+            raise RuntimeError(f"Set show: Media type is not episode: {self.type} for '{self.title}'")
 
         self._show = show
 

--- a/plextraktsync/plex/PlexRatings.py
+++ b/plextraktsync/plex/PlexRatings.py
@@ -26,7 +26,7 @@ class PlexRatings:
         if section_id not in self.plex.library_sections:
             return None
         if m.media_type not in ["movies", "shows", "episodes"]:
-            raise RuntimeError(f"Unsupported media type: {m.media_type}")
+            raise RuntimeError(f"Unsupported media type: {m.media_type} for '{m.title}'")
 
         section = self.plex.library_sections[section_id]
         ratings: dict[int, Rating] = self.ratings(section, m.media_type)

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -116,7 +116,7 @@ class TraktApi:
 
     def remove_from_collection(self, m: TraktMedia):
         if m.media_type not in ["movies", "shows", "episodes"]:
-            raise ValueError(f"Unsupported media type: {m.media_type}")
+            raise ValueError(f"remove_from_collection: Unsupported media type: {m.media_type} for '{m.title}'")
 
         item = dict(
             title=m.title,
@@ -166,7 +166,7 @@ class TraktApi:
         So fetch for all types.
         """
         if m.media_type not in ["movies", "shows", "episodes"]:
-            raise ValueError(f"Unsupported type: {m.media_type}")
+            raise ValueError(f"rating: Unsupported media type: {m.media_type} for '{m.title}'")
 
         return self.ratings[m.media_type].get(m.trakt, None)
 
@@ -190,7 +190,7 @@ class TraktApi:
         elif m.media_type == "episodes" and show_trakt_id:
             self.watched_shows.add(show_trakt_id, m.season, m.number)
         else:
-            raise RuntimeError(f"mark_watched: Unsupported media type: {m.media_type}")
+            raise RuntimeError(f"mark_watched: Unsupported media type: {m.media_type} for '{m.title}'")
 
         # Add partial object to conserve memory
         partial = PartialTraktMedia.create(m, watched_at=time)
@@ -207,13 +207,13 @@ class TraktApi:
         elif m.media_type == "episodes":
             item = dict(**m.ids, **pm.to_json())
         else:
-            raise ValueError(f"Unsupported media type: {m.media_type}")
+            raise ValueError(f"add_to_collection: Unsupported media type: {m.media_type} for '{m.title}' (plex: '{pm.title}')")
 
         self.queue.add_to_collection((m.media_type, item))
 
     def add_to_watchlist(self, m):
         if m.media_type not in ["movies", "shows"]:
-            raise ValueError(f"Unsupported media type for watchlist: {m.media_type}")
+            raise ValueError(f"add_to_watchlist: Unsupported media type: {m.media_type} for '{m.title}'")
 
         item = dict(
             title=m.title,
@@ -225,7 +225,7 @@ class TraktApi:
 
     def remove_from_watchlist(self, m):
         if m.media_type not in ["movies", "shows"]:
-            raise ValueError(f"Unsupported media type for watchlist: {m.media_type}")
+            raise ValueError(f"remove_from_watchlist: Unsupported media type: {m.media_type} for '{m.title}'")
 
         item = dict(
             title=m.title,
@@ -274,12 +274,12 @@ class TraktApi:
 
             factory_method = Movie
         else:
-            raise RuntimeError(f"Unsupported media_type={media_type}")
+            raise RuntimeError(f"find_by_slug: Unsupported media_type: {media_type} for slug: '{slug}'")
 
         try:
             return factory_method(title=slug, slug=slug)
         except NotFoundException:
-            raise RuntimeError(f"Unable to find by slug: {slug}")
+            raise RuntimeError(f"find_by_slug: Unable to find with slug: {slug}")
 
     @rate_limit()
     def search_by_id(self, media_id: str, id_type: str, media_type: str) -> TVShow | Movie | None:


### PR DESCRIPTION
Raise error and bypass instead of crashing sync when Plex episode is matched with Trakt item that is not an episode.
see : https://github.com/Taxel/PlexTraktSync/issues/2431 https://github.com/Taxel/PlexTraktSync/issues/2436

Just like : https://github.com/Taxel/PlexTraktSync/discussions/2433

Note: Some mismatch types are recently coming from Plex : episode seen as movie, movie seen as show 🤔 

