### PR TITLE
Enhance search_by_id method to validate media type & id

### DIFF
--- a/plextraktsync/media/Media.py
+++ b/plextraktsync/media/Media.py
@@ -139,7 +139,7 @@ class Media(RichMarkup):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.movie_collection_set
         elif not self.is_episode:
-            raise RuntimeError(f"is_collected: Unsupported media type: {self.media_type} for '{self.title}'")
+            raise RuntimeError(f"is_collected: Unsupported media type: {self.type} for '{self.title}'")
 
         collected = self.trakt_api.collected_shows
         return collected.is_collected(self.show_trakt_id, self.season_number, self.episode_number)
@@ -165,7 +165,7 @@ class Media(RichMarkup):
     @cached_property
     def seasons(self):
         if self.media_type != "shows":
-            raise RuntimeError(f"seasons: Unsupported media type: {self.media_type} for '{self.title}'")
+            raise RuntimeError(f"seasons: Unsupported media type: {self.type} for '{self.title}'")
 
         return TraktLookup(self.trakt)
 
@@ -178,7 +178,7 @@ class Media(RichMarkup):
         if self.is_movie:
             return self.trakt_id in self.trakt_api.watched_movies
         elif not self.is_episode:
-            raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.media_type} for '{self.title}'")
+            raise RuntimeError(f"watched_on_trakt: Unsupported media type: {self.type} for '{self.title}'")
         elif self.type != "episode":
             raise RuntimeError(f"watched_on_trakt: Trakt media type is not episode: {self.type} for '{self.title}'")
 
@@ -191,7 +191,7 @@ class Media(RichMarkup):
         Return True if episode was watched before show reset (if there is a reset).
         """
         if not self.is_episode:
-            raise RuntimeError(f"watched_before_reset is valid for episodes only, got {self.media_type} for '{self.title}'")
+            raise RuntimeError(f"watched_before_reset is valid for episodes only, got {self.type} for '{self.title}'")
 
         return self.show_reset_at and self.plex.seen_date.replace(tzinfo=None) < self.show_reset_at
 
@@ -207,7 +207,7 @@ class Media(RichMarkup):
         elif self.is_episode:
             self.trakt_api.mark_watched(self.trakt, self.plex.seen_date, self.show_trakt_id)
         else:
-            raise RuntimeError(f"mark_watched_trakt: Unsupported media type: {self.media_type} for '{self.title}'")
+            raise RuntimeError(f"mark_watched_trakt: Unsupported media type: {self.type} for '{self.title}'")
 
     def mark_watched_plex(self):
         self.plex_api.mark_watched(self.plex.item)

--- a/plextraktsync/media/MediaFactory.py
+++ b/plextraktsync/media/MediaFactory.py
@@ -75,7 +75,7 @@ class MediaFactory:
 
         if tm is None:
             self.logger.warning(
-                f"{guid.title_link}: Skipping {guid} not found on Trakt",
+                f"{guid.title_link}: Skipping {guid} {guid.type} not found on Trakt",
                 extra={"markup": True},
             )
             return None

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -308,8 +308,23 @@ class TraktApi:
             self.logger.debug(f"search_by_id({media_id}, {id_type}, {media_type}) got {len(search)} results, taking first one")
             self.logger.debug([pm.to_json() for pm in search])
 
-        # TODO: sort by "score"?
-        return search[0]
+        m = search[0]
+
+        # Check that the found item has the correct type
+        found_type = m.media_type.rstrip("s")
+        if found_type != media_type:
+            self.logger.debug(f"search_by_id({media_id}, {id_type}, {media_type}): result type '{found_type}' does not match expected '{media_type}'")
+            return None
+
+        # Check that the found item has the correct id
+        found_id = str(m.ids["ids"].get(id_type))
+        if found_id != str(media_id):
+            self.logger.debug(
+                f"search_by_id({media_id}, {id_type}, {media_type}): result {id_type} id '{found_id}' does not match expected '{media_id}'"
+            )
+            return None
+
+        return m
 
     @staticmethod
     def valid_trakt_id(media_id: str):

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -116,7 +116,7 @@ class TraktApi:
 
     def remove_from_collection(self, m: TraktMedia):
         if m.media_type not in ["movies", "shows", "episodes"]:
-            raise ValueError(f"remove_from_collection: Unsupported media type: {m.media_type} for '{m.title}'")
+            raise ValueError(f"remove_from_collection: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}'")
 
         item = dict(
             title=m.title,
@@ -166,7 +166,7 @@ class TraktApi:
         So fetch for all types.
         """
         if m.media_type not in ["movies", "shows", "episodes"]:
-            raise ValueError(f"rating: Unsupported media type: {m.media_type} for '{m.title}'")
+            raise ValueError(f"rating: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}'")
 
         return self.ratings[m.media_type].get(m.trakt, None)
 
@@ -190,7 +190,7 @@ class TraktApi:
         elif m.media_type == "episodes" and show_trakt_id:
             self.watched_shows.add(show_trakt_id, m.season, m.number)
         else:
-            raise RuntimeError(f"mark_watched: Unsupported media type: {m.media_type} for '{m.title}'")
+            raise RuntimeError(f"mark_watched: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}'")
 
         # Add partial object to conserve memory
         partial = PartialTraktMedia.create(m, watched_at=time)
@@ -207,13 +207,13 @@ class TraktApi:
         elif m.media_type == "episodes":
             item = dict(**m.ids, **pm.to_json())
         else:
-            raise ValueError(f"add_to_collection: Unsupported media type: {m.media_type} for '{m.title}' (plex: '{pm.title}')")
+            raise ValueError(f"add_to_collection: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}' (plex: '{pm.title}')")
 
         self.queue.add_to_collection((m.media_type, item))
 
     def add_to_watchlist(self, m):
         if m.media_type not in ["movies", "shows"]:
-            raise ValueError(f"add_to_watchlist: Unsupported media type: {m.media_type} for '{m.title}'")
+            raise ValueError(f"add_to_watchlist: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}'")
 
         item = dict(
             title=m.title,
@@ -225,7 +225,7 @@ class TraktApi:
 
     def remove_from_watchlist(self, m):
         if m.media_type not in ["movies", "shows"]:
-            raise ValueError(f"remove_from_watchlist: Unsupported media type: {m.media_type} for '{m.title}'")
+            raise ValueError(f"remove_from_watchlist: Unsupported media type: {m.media_type.rstrip('s')} for '{m.title}'")
 
         item = dict(
             title=m.title,

--- a/tests/test_trakt_search_by_id.py
+++ b/tests/test_trakt_search_by_id.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3 -m pytest
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plextraktsync.trakt.TraktApi import TraktApi
+
+
+def make_trakt_item(media_type: str, id_type: str, media_id: str):
+    """Return a minimal mock Trakt search-result item."""
+    item = MagicMock()
+    item.media_type = media_type
+    item.ids = {"ids": {id_type: media_id}}
+    return item
+
+
+@pytest.fixture
+def trakt_api():
+    # Patch the module-level `factory` imported by TraktApi to avoid
+    # real HTTP session creation during __init__.
+    with patch("plextraktsync.trakt.TraktApi.factory") as mock_factory:
+        mock_factory.session = MagicMock()
+        yield TraktApi()
+
+
+def test_search_by_id_type_mismatch_returns_none(trakt_api):
+    """When the API returns an item whose type differs from the requested type, return None."""
+    # Requested "movie" but API returned a "shows" result.
+    item = make_trakt_item(media_type="shows", id_type="tmdb", media_id="12345")
+    with patch("trakt.sync.search_by_id", return_value=[item]):
+        result = trakt_api.search_by_id("12345", id_type="tmdb", media_type="movie")
+    assert result is None
+
+
+def test_search_by_id_id_mismatch_returns_none(trakt_api):
+    """When the API returns an item whose id differs from the requested id, return None."""
+    # Requested id "12345" but API returned an item with id "99999".
+    item = make_trakt_item(media_type="movies", id_type="tmdb", media_id="99999")
+    with patch("trakt.sync.search_by_id", return_value=[item]):
+        result = trakt_api.search_by_id("12345", id_type="tmdb", media_type="movie")
+    assert result is None
+
+
+def test_search_by_id_matching_returns_item(trakt_api):
+    """When the API returns an item whose type and id both match, return that item."""
+    item = make_trakt_item(media_type="movies", id_type="tmdb", media_id="12345")
+    with patch("trakt.sync.search_by_id", return_value=[item]):
+        result = trakt_api.search_by_id("12345", id_type="tmdb", media_type="movie")
+    assert result is item


### PR DESCRIPTION
Now, since April 2026, Trakt API can return media that doesn't match request type during a `search_by_id` request so we have to check result before using it.

Example, we request a movie : https://api.trakt.tv/search/imdb/tt11005770?type=movie
No movie matching this id, it returns a matching show :
```json
[
  {
    "show": {
      "ids": {
        "imdb": "tt11005770",
        "plex": {
          "guid": null,
          "slug": null
        },
        "slug": "inside-suspicion",
        "tmdb": 93485,
        "tvdb": 369286,
        "trakt": 154246
      },
    ....
    },
    "type": "show",
    "score": 100
  }
]
```

PS: Related to recent update on Trakt API which raises many issues about non-matching type : #2434 #2431 #2436

fixes #2433
fixes #2450 