### PR TITLE
fix: paginate Trakt watchlist to fetch more than 100 items

### DIFF
--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -1,7 +1,35 @@
 from __future__ import annotations
 
+import trakt.core
 from trakt.core import get
 from trakt.utils import airs_date
+
+
+def get_watchlist(media_type: str) -> list:
+    """Fetch all watchlist items with pagination, bypassing pytrakt's single-page limit."""
+    from trakt.movies import Movie
+    from trakt.tv import TVShow
+
+    factory = Movie if media_type == "movies" else TVShow
+    item_key = "movie" if media_type == "movies" else "show"
+
+    page = 1
+    limit = 1000
+    results = []
+
+    while True:
+        data = trakt.core.api().request("get", f"users/me/watchlist/{media_type}", {"page": page, "limit": limit})
+        if not data:
+            break
+        for item in data:
+            item_data = item.pop(item_key)
+            item_data.update(item)
+            results.append(factory(**item_data))
+        if len(data) < limit:
+            break
+        page += 1
+
+    return results
 
 
 @get

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -146,13 +146,13 @@ class TraktApi:
     @rate_limit()
     @retry()
     def watchlist_movies(self):
-        return self.me.watchlist_movies
+        return pytrakt_extensions.get_watchlist("movies")
 
     @property
     @rate_limit()
     @retry()
     def watchlist_shows(self):
-        return self.me.watchlist_shows
+        return pytrakt_extensions.get_watchlist("shows")
 
     @cached_property
     def ratings(self):


### PR DESCRIPTION
## Summary

Fixes #2452 — only the first 100 items in the Trakt watchlist were being used.

**Root cause:** `pytrakt`'s `User.watchlist_movies` and `User.watchlist_shows` properties make a single API call with no pagination parameters. The Trakt API returns at most 100 items per page by default, so users with watchlists larger than 100 items would only see the first 100 — causing items to be incorrectly removed on sync.

**Fix:**
- Added `get_watchlist(media_type)` to `pytrakt_extensions.py` that uses `trakt.core.api()` directly to page through results in batches of 1000 until the full watchlist is fetched
- Updated `TraktApi.watchlist_movies` and `TraktApi.watchlist_shows` to use the new paginated function instead of the broken `self.me.watchlist_movies/shows`

## Test plan

- [ ] Verify sync works correctly with a Trakt watchlist of fewer than 100 items (existing behavior unchanged)
- [ ] Verify sync correctly fetches all items with a Trakt watchlist of more than 100 items
- [ ] Verify items are no longer incorrectly removed when watchlist exceeds 100 items