### PR TITLE
Fix: Preserve server config on re-login

### DIFF
--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -20,6 +20,12 @@ class PlexServerConfig:
         data = asdict(self)
         del data["name"]
 
+        # Remove optional fields that are None so they don't overwrite
+        # existing values when merging (e.g. preserving user config on re-login)
+        for key in ("id", "config"):
+            if data[key] is None:
+                del data[key]
+
         return data
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from os.path import join
 import pytest
 
 from plextraktsync.config.Config import Config
+from plextraktsync.config.ServerConfigFactory import ServerConfigFactory
 from plextraktsync.factory import factory
 
 
@@ -37,6 +38,35 @@ def test_sync_config():
     sync_config = Config(config_file).sync
 
     assert sync_config.plex_to_trakt["collection"] is False
+
+
+def test_relogin_preserves_server_config():
+    """Re-login must not overwrite the user's custom server config (libraries, etc.)."""
+    sc = ServerConfigFactory()
+    sc.loaded = True
+
+    # Simulate initial login with a custom config (libraries whitelist)
+    sc.add_server(
+        name="myserver",
+        token="old-token",
+        urls=["https://plex.example.com:32400"],
+        id="abc123",
+        config={"libraries": ["Movies", "Series"]},
+    )
+    assert sc.servers["myserver"]["config"] == {"libraries": ["Movies", "Series"]}
+
+    # Simulate re-login: only token, urls, id are passed — config is not supplied
+    sc.add_server(
+        name="myserver",
+        token="new-token",
+        urls=["https://plex.example.com:32400"],
+        id="abc123",
+    )
+
+    # Token should be updated
+    assert sc.servers["myserver"]["token"] == "new-token"
+    # Config must be preserved, not overwritten with None
+    assert sc.servers["myserver"]["config"] == {"libraries": ["Movies", "Series"]}
 
 
 def test_http_config():


### PR DESCRIPTION
## Summary

Fixes #2222 — re-login overwrites the user's custom server configuration (e.g. `libraries` whitelist).

**Root cause:** `PlexServerConfig.asdict()` always included the `config` key in its output, even when `config=None`. When `ServerConfigFactory.add_server()` calls `ConfigMergeMixin.merge()`, the `None` value for `config` would overwrite the existing dict in `servers.yml`, erasing any library/sync settings the user had configured.

**Fix:** Strip optional fields (`id`, `config`) from the `asdict()` output when they are `None`, so a re-login that doesn't supply a new config value simply leaves the existing one untouched.

## Changes

- `plextraktsync/config/PlexServerConfig.py`: Remove `None`-valued optional fields from `asdict()` output before merge.
- `tests/test_config.py`: Add regression test `test_relogin_preserves_server_config` that verifies the library whitelist survives a re-login token refresh.

## Test plan

- [x] `python3 -m pytest tests/test_config.py::test_relogin_preserves_server_config -v` → passes
- [ ] Re-login to a server that has a custom `libraries:` config; verify the library list is preserved in `servers.yml` after re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)