### PR TITLE
feat(healthcheck): add healthcheck command and Docker healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ services:
       - TZ=Europe/Tallinn
 ```
 
+To enable optional container health monitoring, add a `healthcheck` entry. This scans the log for ERROR or CRITICAL entries within the last hour and marks the container unhealthy if any are found.
+
+```yaml
+    healthcheck:
+      test: ["CMD", "plextraktsync", "healthcheck"]
+      interval: 60s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+```
+
 You can use specific version `0.25.16`:
 
 - `image: ghcr.io/taxel/plextraktsync:0.25.16`

--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -331,6 +331,17 @@ def self_update():
 
 
 @command()
+@click.option("--max-age", type=int, default=3600, show_default=True, help="Only consider log entries newer than N seconds")
+def healthcheck():
+    """
+    Check health of PlexTraktSync services.
+
+    Scans the log for ERROR or CRITICAL entries within --max-age seconds.
+    Exits 0 if healthy, 1 if any errors are found.
+    """
+
+
+@command()
 def bug_report():
     """
     Create a pre-populated GitHub issue with information about your configuration
@@ -369,6 +380,7 @@ def config():
 
 
 cli.add_command(bug_report)
+cli.add_command(healthcheck)
 cli.add_command(cache)
 cli.add_command(clear_collections)
 cli.add_command(compare_libraries)

--- a/plextraktsync/commands/healthcheck.py
+++ b/plextraktsync/commands/healthcheck.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+import sys
+import time
+from datetime import datetime
+
+from plextraktsync.factory import factory
+
+# Matches log level in the file format: "%(asctime)-15s %(levelname)s[%(name)s]:%(message)s"
+ERROR_RE = re.compile(r"\b(?:ERROR|CRITICAL)\[")
+LOG_TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+
+_TAIL_BYTES_PER_SECOND = 256
+
+
+def healthcheck(max_age: int):
+    log_file = factory.config.log_file
+    cutoff = time.time() - max_age
+    last_error = None
+
+    tail_bytes = max_age * _TAIL_BYTES_PER_SECOND
+
+    try:
+        with open(log_file, "rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            if size > tail_bytes:
+                f.seek(size - tail_bytes)
+                f.readline()  # discard partial line at seek point
+            content = f.read().decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        print(f"Log file not found: {log_file}", file=sys.stderr)
+        raise SystemExit(1)
+
+    for line in content.splitlines():
+        if not ERROR_RE.search(line):
+            continue
+        m = LOG_TIMESTAMP_RE.match(line)
+        if m:
+            try:
+                ts = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+                if ts.timestamp() < cutoff:
+                    continue
+            except ValueError:
+                pass  # unparseable timestamp: treat as recent
+        last_error = line.strip()
+
+    if last_error:
+        print(f"Healthcheck failed: {last_error}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print("Healthcheck passed")


### PR DESCRIPTION
`watch` silently fails on error (e.g. OAUTH, see #2323), but would benefit from an error state leveraging docker healthchecks.

This PR adds `plextraktsync healthcheck` to detect unhealthy containers in watch mode. Scans the configured log file for ERROR or CRITICAL level entries within a time window (default 3600s) and exits 1 if any are found, letting Docker mark the container unhealthy after --retries=3.

The log probe tails only the last max_age * 256 bytes so it stays fast on large log files between rotations.

Adds HEALTHCHECK to the `Dockerfile` runtime stage:
  --interval=60s --timeout=10s --start-period=30s --retries=3
  CMD plextraktsync healthcheck

Closes #2323

```
plextraktsync                 running   Up 36 seconds (health: starting)
[...]
plextraktsync                 running   Up 3 minutes (healthy)
```