### PR TITLE
Fix Trakt API liked lists limit to 100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__/
 /dist/
 /docker-compose.override.yml
 /last_update.log
-/plextraktsync.log
+/plextraktsync.log*
 /servers.yml
 /tests/.env
 /tests/config.json

--- a/plextraktsync/trakt/TraktApi.py
+++ b/plextraktsync/trakt/TraktApi.py
@@ -73,7 +73,7 @@ class TraktApi:
     @retry()
     @flatten_list
     def liked_lists(self) -> list[TraktLikedList]:
-        for item in self.me.get_liked_lists("lists", limit=1000):
+        for item in self.me.get_liked_lists("lists", limit=100):
             tll: TraktLikedList = {
                 "listname": item["list"]["name"],
                 "username": item["list"]["user"]["username"],
@@ -101,7 +101,7 @@ class TraktApi:
     def movie_collection(self):
         return self.me.movie_collection
 
-    @property
+    @cached_property
     @rate_limit()
     @retry()
     def show_collection(self):


### PR DESCRIPTION
1000 is above new trakt pagination limit.
There is no need to set liked lists limit above 100 because max is 5 for free users and 100 for VIP users.

Preparing for new **pytrakt** pagination limit.
- github.com/glensc/python-pytrakt/pull/103

Feature | Free | VIP
-- | -- | --
Watched History | 100K | 100K
Ratings | 10K | 20K
Watchlist Items | 250 | 5K
List Items (per list) | 250 | 5K
Total List Items (across personal lists) | 1K | 100K
**Personal Lists** | **5** | **100**

https://forums.trakt.tv/t/updating-trakt-limits-for-2026/101592

> Max page size
>
> The current target maximum page size is 250 when you request a limit.
>
> For most paginated requests, that will be the upper limit per page.

https://github.com/trakt/trakt-api/discussions/775