### PR TITLE
Refactor: Use program_name in self-update PR detection

### DIFF
--- a/plextraktsync/commands/self_update.py
+++ b/plextraktsync/commands/self_update.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from plextraktsync.factory import factory
 from plextraktsync.util.execp import execp
+from plextraktsync.util.packaging import program_name
 
 
 def has_previous_pr(pr: int):
@@ -17,10 +18,8 @@ def pr_number() -> int | None:
     Check if current executable is named plextraktsync@<pr>
     """
 
-    import sys
-
     try:
-        pr = sys.argv[0].split("@")[1]
+        pr = program_name().split("@")[1]
     except IndexError:
         return None
 


### PR DESCRIPTION
- Reuse the shared executable-name helper in `self_update`
- Avoid duplicating direct `sys.argv[0]` parsing

Extracted from https://github.com/Taxel/PlexTraktSync/pull/2487