### PR TITLE
Fix: Handle unexpected metadata field in Trakt API responses

### DIFF
--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -27,6 +27,7 @@ class EpisodeProgress:
         completed=False,
         last_watched_at=None,
         collected_at=None,
+        metadata=None,
     ):
         self.number = number
         self.aired = aired
@@ -41,7 +42,7 @@ class EpisodeProgress:
 
 
 class SeasonProgress:
-    def __init__(self, number=0, title=None, aired=0, completed=False, episodes=None):
+    def __init__(self, number=0, title=None, aired=0, completed=False, episodes=None, metadata=None):
         self.number = number
         self.aired = aired
         self.episodes = {}
@@ -78,6 +79,7 @@ class ShowProgress:
         next_episode=0,
         last_episode=0,
         last_collected_at=None,
+        metadata=None,
     ):
         self.aired = aired
         self.last_watched_at = last_watched_at


### PR DESCRIPTION
### The Problem
Recently, the Trakt API began returning a new `metadata` field in the JSON response payload for the `/sync/collection/shows` endpoint. This caused progress classes to fail when unpacking the data, as they were not expecting this extra keyword argument:

`TypeError: EpisodeProgress.__init__() got an unexpected keyword argument 'metadata'`

This resulted in two distinct issues depending on the command being run:
* **During `sync`:** The process would crash completely and fail to finish.
* **During `watch`:** The application would throw this error message in the console, although it would thankfully still continue working and successfully send the watched status to Trakt.

### The Solution
This PR adds `metadata=None` to the constructor methods of `EpisodeProgress`, `SeasonProgress`, and `ShowProgress` within `plextraktsync/pytrakt_extensions.py`. 

By explicitly defining this field, the application can safely absorb and ignore the new data. This prevents the hard crash during a sync and clears up the noisy error output during a watch session, all while maintaining strict data validation for any future API changes.

### Steps to Verify
* Running `plextraktsync sync` will now complete successfully. 
* Playing content while using the `watch` command will function normally without throwing the `TypeError` in the logs.

Fixes #2503 