### PR TITLE
feat: add newer-wins rating priority

### DIFF
--- a/plextraktsync/config.default.yml
+++ b/plextraktsync/config.default.yml
@@ -54,10 +54,11 @@ logging:
 # settings for 'sync' command
 sync:
   # Setting for whether ratings from one platform should have priority.
-  # Valid values are trakt, plex or none. (default: plex)
+  # Valid values are trakt, plex, newer_wins or none. (default: plex)
   # none - No rating priority. Existing ratings are not overwritten.
   # trakt - Trakt ratings have priority. Existing Plex ratings are overwritten.
   # plex - Plex ratings have priority. Existing Trakt ratings are overwritten.
+  # newer_wins - The most recently rated side has priority. Missing ratings are filled.
   rating_priority: plex
 
   plex_to_trakt:

--- a/plextraktsync/sync/SyncRatingsPlugin.py
+++ b/plextraktsync/sync/SyncRatingsPlugin.py
@@ -75,6 +75,30 @@ class SyncRatingsPlugin:
             elif self.trakt_to_plex and has_trakt:
                 rate = "plex"
 
+        elif self.rating_priority == "newer_wins":
+            # Prefer the side with the newest rating timestamp. If one side is
+            # missing a rating, fill it from the side that has one. If neither
+            # side has a timestamp, keep the previous default behavior of
+            # preferring Plex when both directions are enabled.
+            if m.plex_rating is not None and m.trakt_rating is not None:
+                plex_rated_at = m.plex_rating.rated_at
+                trakt_rated_at = m.trakt_rating.rated_at
+                plex_is_newer = plex_rated_at is None and trakt_rated_at is None
+
+                if plex_rated_at is not None and trakt_rated_at is None:
+                    plex_is_newer = True
+                elif plex_rated_at is not None and trakt_rated_at is not None:
+                    plex_is_newer = plex_rated_at >= trakt_rated_at
+
+                if plex_is_newer and self.plex_to_trakt:
+                    rate = "trakt"
+                elif not plex_is_newer and self.trakt_to_plex:
+                    rate = "plex"
+            elif self.plex_to_trakt and has_plex:
+                rate = "trakt"
+            elif self.trakt_to_plex and has_trakt:
+                rate = "plex"
+
         if rate == "trakt":
             self.logger.info(
                 f"Rating {m.title_link} with {m.plex_rating} on Trakt (was {m.trakt_rating})",

--- a/tests/test_sync_ratings_plugin.py
+++ b/tests/test_sync_ratings_plugin.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3 -m pytest
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from plextraktsync.sync.SyncRatingsPlugin import SyncRatingsPlugin
+from plextraktsync.util.Rating import Rating
+
+
+class Config(dict):
+    def __init__(self, rating_priority="newer_wins", plex_to_trakt=True, trakt_to_plex=True):
+        super().__init__({"rating_priority": rating_priority})
+        self.plex_to_trakt = {"ratings": plex_to_trakt}
+        self.trakt_to_plex = {"ratings": trakt_to_plex}
+
+
+class Media(SimpleNamespace):
+    title_link = "Test Movie"
+
+    def __init__(self, plex_rating=None, trakt_rating=None):
+        super().__init__(
+            plex_rating=plex_rating,
+            trakt_rating=trakt_rating,
+            plex_rate_calls=0,
+            trakt_rate_calls=0,
+        )
+
+    def plex_rate(self):
+        self.plex_rate_calls += 1
+
+    def trakt_rate(self):
+        self.trakt_rate_calls += 1
+
+
+UTC = timezone.utc
+OLDER = datetime(2024, 1, 1, tzinfo=UTC)
+NEWER = datetime(2024, 2, 1, tzinfo=UTC)
+
+
+async def sync(media, *, dry_run=False, plex_to_trakt=True, trakt_to_plex=True):
+    plugin = SyncRatingsPlugin(Config(plex_to_trakt=plex_to_trakt, trakt_to_plex=trakt_to_plex))
+    await plugin.sync_ratings(media, dry_run=dry_run)
+    return media
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_rates_trakt_when_plex_rating_is_newer():
+    media = Media(
+        plex_rating=Rating(9, NEWER),
+        trakt_rating=Rating(8, OLDER),
+    )
+
+    await sync(media)
+
+    assert media.trakt_rate_calls == 1
+    assert media.plex_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_rates_plex_when_trakt_rating_is_newer():
+    media = Media(
+        plex_rating=Rating(9, OLDER),
+        trakt_rating=Rating(8, NEWER),
+    )
+
+    await sync(media)
+
+    assert media.plex_rate_calls == 1
+    assert media.trakt_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_fills_missing_trakt_rating_from_plex():
+    media = Media(plex_rating=Rating(9, NEWER), trakt_rating=None)
+
+    await sync(media)
+
+    assert media.trakt_rate_calls == 1
+    assert media.plex_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_fills_missing_plex_rating_from_trakt():
+    media = Media(plex_rating=None, trakt_rating=Rating(8, NEWER))
+
+    await sync(media)
+
+    assert media.plex_rate_calls == 1
+    assert media.trakt_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_does_not_rate_when_values_match():
+    media = Media(
+        plex_rating=Rating(8, OLDER),
+        trakt_rating=Rating(8, NEWER),
+    )
+
+    await sync(media)
+
+    assert media.plex_rate_calls == 0
+    assert media.trakt_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_respects_disabled_plex_to_trakt_direction():
+    media = Media(
+        plex_rating=Rating(9, NEWER),
+        trakt_rating=Rating(8, OLDER),
+    )
+
+    await sync(media, plex_to_trakt=False)
+
+    assert media.trakt_rate_calls == 0
+    assert media.plex_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_respects_disabled_trakt_to_plex_direction():
+    media = Media(
+        plex_rating=Rating(9, OLDER),
+        trakt_rating=Rating(8, NEWER),
+    )
+
+    await sync(media, trakt_to_plex=False)
+
+    assert media.plex_rate_calls == 0
+    assert media.trakt_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_uses_plex_when_timestamps_are_missing():
+    media = Media(
+        plex_rating=Rating(9, None),
+        trakt_rating=Rating(8, None),
+    )
+
+    await sync(media)
+
+    assert media.trakt_rate_calls == 1
+    assert media.plex_rate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_newer_wins_dry_run_does_not_write():
+    media = Media(
+        plex_rating=Rating(9, NEWER),
+        trakt_rating=Rating(8, OLDER),
+    )
+
+    await sync(media, dry_run=True)
+
+    assert media.trakt_rate_calls == 0
+    assert media.plex_rate_calls == 0


### PR DESCRIPTION
## Summary
- Adds `rating_priority: newer_wins` for rating sync.
- Uses rating timestamps to decide which side wins when Plex and Trakt ratings differ.
- Keeps the existing `plex`, `trakt`, and `none` behavior unchanged.
- Documents the new option in `config.default.yml`.

## Behavior
With `rating_priority: newer_wins`:
- if both sides have different ratings, the side with the newest `rated_at` / `lastRatedAt` wins;
- if only Plex has a rating, it can fill Trakt when `plex_to_trakt.ratings` is enabled;
- if only Trakt has a rating, it can fill Plex when `trakt_to_plex.ratings` is enabled;
- if ratings are equal, no action is taken;
- dry-run still logs without writing.

If both timestamps are missing, Plex is treated as the newer side to preserve the previous default preference when both directions are enabled.

## Test Plan
- `python -m ruff check plextraktsync/sync/SyncRatingsPlugin.py tests/test_sync_ratings_plugin.py`
- YAML parse of `plextraktsync/config.default.yml`
- `python -m pytest -q tests/test_rating.py tests/test_sync_ratings_plugin.py` → `10 passed`
- `python -m pytest -q` → `32 passed, 11 skipped`

Note: the full test run prints an expected fake-API-key error log from existing tests, but exits successfully.
