### PR TITLE
fix: handle None seasons/episodes/shows in pytrakt_extensions

### DIFF
--- a/plextraktsync/pytrakt_extensions.py
+++ b/plextraktsync/pytrakt_extensions.py
@@ -46,6 +46,7 @@ class SeasonProgress:
         self.number = number
         self.aired = aired
         self.episodes = {}
+        episodes = episodes or []
         for episode in episodes:
             prog = EpisodeProgress(**episode)
             self.episodes[prog.number] = prog
@@ -93,6 +94,7 @@ class ShowProgress:
         self.slug = show["ids"]["slug"] if show else None
         self.seasons = {}
         allCompleted = True
+        seasons = seasons or []
         for season in seasons:
             prog = SeasonProgress(**season)
             self.seasons[prog.number] = prog
@@ -112,6 +114,7 @@ class ShowProgress:
 class AllShowsProgress:
     def __init__(self, shows=None):
         self.shows = {}
+        shows = shows or []
         for show in shows:
             prog = ShowProgress(**show)
             self.shows[prog.trakt] = prog

--- a/tests/test_trakt_progress.py
+++ b/tests/test_trakt_progress.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 from trakt.tv import TVShow
 
-from plextraktsync.pytrakt_extensions import ShowProgress
+from plextraktsync.pytrakt_extensions import AllShowsProgress, ShowProgress
 from plextraktsync.trakt.TraktApi import TraktApi
 from tests.conftest import factory
 
@@ -22,5 +22,29 @@ def test_trakt_watched_progress():
     assert isinstance(s01e01, bool)
 
 
+def test_show_progress_with_missing_seasons():
+    """Trakt can return a show entry without a "seasons" key (e.g. shows with
+    zero watched progress). This should not raise TypeError: 'NoneType' object
+    is not iterable. Regression test for #2515."""
+    show = {"show": {"ids": {"trakt": 1, "slug": "some-show"}}}
+    prog = ShowProgress(**show)
+
+    assert isinstance(prog, ShowProgress)
+    assert prog.seasons == {}
+    assert prog.completed is False
+
+
+def test_all_shows_progress_with_missing_shows():
+    """Trakt's /sync/watched/shows can return null instead of an empty list.
+    This should not raise TypeError: 'NoneType' object is not iterable.
+    Regression test for #2515."""
+    progress = AllShowsProgress(shows=None)
+
+    assert isinstance(progress, AllShowsProgress)
+    assert progress.shows == {}
+
+
 if __name__ == "__main__":
     test_trakt_watched_progress()
+    test_show_progress_with_missing_seasons()
+    test_all_shows_progress_with_missing_shows()


### PR DESCRIPTION
Trakt's /sync/watched/shows (and /sync/collection/shows) endpoints can return an entry where the "seasons" key is null instead of an empty list (and, more rarely, episodes or the top-level shows list can be null too). This caused:

    TypeError: 'NoneType' object is not iterable

in ShowProgress.__init__, SeasonProgress.__init__, and AllShowsProgress.__init__, crashing the whole sync as soon as such a show was encountered.

Guard each with "x = x or []" before iterating, matching the pattern already used for optional dict fields like "show" in ShowProgress.

Fixes #2515