### PR TITLE
Fix: Catch NotFound from plex account access

### DIFF
--- a/plextraktsync/plex/PlexApi.py
+++ b/plextraktsync/plex/PlexApi.py
@@ -239,7 +239,7 @@ class PlexApi:
 
         try:
             return try_login()
-        except BadRequest as e:
+        except (BadRequest, NotFound) as e:
             self.logger.error(f"Error during Plex {plex_username} account access: {e}. Try log in with plex-login again")
 
             return None


### PR DESCRIPTION
Fixes #2449

Doesn't really solve the issue, but changes error reporting not to crash. The actual error seems use configuration error.