### PR TITLE
Feature: Add --server option to config

### DIFF
--- a/plextraktsync/cli.py
+++ b/plextraktsync/cli.py
@@ -371,6 +371,7 @@ def watched_shows():
 
 @command()
 @click.option("--urls-expire-after", is_flag=True, help="Print urls_expire_after configuration")
+@click.option("--server", is_flag=True, help="Print active server configuration")
 @click.option("--edit", is_flag=True, help="Open config file in editor")
 @click.option("--locate", is_flag=True, help="Locate config file in file browser")
 def config():

--- a/plextraktsync/commands/config.py
+++ b/plextraktsync/commands/config.py
@@ -26,6 +26,12 @@ def config(urls_expire_after: bool, server: bool, edit: bool, locate: bool):
         click.launch(config.config_yml, locate=locate)
         return
 
+    if server:
+        print("# Server Config")
+        config = factory.server_config
+        dump(config.serialize(), print=print)
+        return
+
     if urls_expire_after:
         print("# HTTP Cache")
         dump(config.http_cache.serialize(), print=print)

--- a/plextraktsync/commands/config.py
+++ b/plextraktsync/commands/config.py
@@ -16,7 +16,7 @@ def dump(data, print=None):
     print(dump)
 
 
-def config(urls_expire_after: bool, edit: bool, locate: bool):
+def config(urls_expire_after: bool, server: bool, edit: bool, locate: bool):
     config = factory.config
     print = factory.print
 

--- a/plextraktsync/config/PlexServerConfig.py
+++ b/plextraktsync/config/PlexServerConfig.py
@@ -45,3 +45,8 @@ class PlexServerConfig:
             return default
 
         return self.config.get(section, default)
+
+    def serialize(self):
+        return {
+            self.name: self.asdict(),
+        }


### PR DESCRIPTION
Print current server config:
```sh
$ plextraktsync config --server
```

Print "Voldemar" server config:
```sh
$ plextraktsync --server=Voldemar config --server
```

Note: output includes tokens; remember to redact them when sharing the results