### PR TITLE
Skip an episode whose show was not preloaded

### DIFF
--- a/plextraktsync/plan/Walker.py
+++ b/plextraktsync/plan/Walker.py
@@ -133,7 +133,16 @@ class Walker(SetWindowTitle):
 
         async for ep in self.episodes_from_sections(self.plan.show_sections):
             show_id = ep.show_id
-            ep.show = plex_shows[show_id]
+            # The shows above and the episodes here are two independent pagers
+            # over a live server: `section.pager()` for shows,
+            # `section.pager("episode")` here. An episode whose show was not
+            # yielded by the first pass (library changed mid-sync, or the show
+            # itself failed to load) must not abort the whole sync.
+            plex_show = plex_shows.get(show_id)
+            if plex_show is None:
+                self.logger.warning(f"Skipping episode {ep}: show {show_id} was not found in the preloaded shows")
+                continue
+            ep.show = plex_show
             show = show_cache.get(show_id)
             m = self.mf.resolve_any(ep, show)
             if not m:

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -71,3 +71,90 @@ def test_walker():
     assert len(plan.show_sections) == 0
     assert len(plan.movies) == 1
     assert len(plan.shows) == 1
+
+
+class ShowStub:
+    """Minimal stand-in for a preloaded PlexLibraryItem show."""
+
+    def __init__(self, key):
+        self.key = key
+
+    def __str__(self):
+        return f"show:{self.key}"
+
+
+class EpisodeStub:
+    """Minimal stand-in for an episode yielded by the episode pager."""
+
+    def __init__(self, show_id, title):
+        self.show_id = show_id
+        self.title = title
+        self.show = None
+
+    def __str__(self):
+        return self.title
+
+
+class MediaFactoryStub:
+    def resolve_any(self, item, show=None):
+        return item
+
+
+class WalkPlanStub:
+    def __init__(self):
+        self.episodes = None
+        self.show_sections = ["section"]
+
+
+def _walker_with(shows, episodes):
+    from plextraktsync.plan.Walker import Walker
+
+    walker = Walker(plex=None, trakt=None, mf=MediaFactoryStub(), config=None)
+    walker.__dict__["plan"] = WalkPlanStub()
+
+    async def get_plex_shows():
+        for s in shows:
+            yield s
+
+    async def episodes_from_sections(_sections):
+        for e in episodes:
+            yield e
+
+    walker.get_plex_shows = get_plex_shows
+    walker.episodes_from_sections = episodes_from_sections
+    return walker
+
+
+async def _collect(walker):
+    return [m async for m in walker.find_episodes()]
+
+
+def test_find_episodes_skips_an_episode_whose_show_was_not_preloaded(caplog):
+    """An orphan episode must not abort the whole sync.
+
+    The shows and the episodes come from two independent pagers over a live
+    server, so an episode can arrive whose show the first pass never yielded.
+    Before this was guarded, that raised KeyError out of find_episodes and
+    killed the run (gh-2113).
+    """
+    import asyncio
+    import logging
+
+    known = ShowStub(1)
+    walker = _walker_with(
+        shows=[known],
+        episodes=[
+            EpisodeStub(1, "kept-before"),
+            EpisodeStub(568765, "orphan"),
+            EpisodeStub(1, "kept-after"),
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(_collect(walker))
+
+    # The orphan is dropped and both good episodes survive, including the one
+    # after it: a fix that returned early instead of continuing would lose it.
+    assert [str(m) for m in result] == ["kept-before", "kept-after"]
+    assert all(m.show is known for m in result)
+    assert "568765" in caplog.text


### PR DESCRIPTION
Fixes #2113

`find_episodes` preloads shows into a dict, then looks each episode's show up with a bare subscript:

```python
ep.show = plex_shows[show_id]
show = show_cache.get(show_id)     # same key, treated as possibly absent
```

The two collections come from independent pagers over a live server: `section.pager()` for the shows in `media_from_sections`, `section.pager("episode")` for the episodes in `episodes_from_sections`. An episode can therefore arrive whose show the first pass never yielded, and the subscript aborted the whole sync with `KeyError: 568765` as in the report.

The line immediately below already uses `.get()` on the same key, so this does the same, logs the skip at warning, and continues. One orphan episode should cost that episode, not the run.

I did not try to make the two passes agree. That would mean either a third traversal or holding the show list differently, and I could not tell from the outside whether the mismatch is pagination skew on large libraries, a library edited mid-sync, or a show whose metadata failed to load. Happy to dig into the cause if you would rather fix it there.

### Test

`test_find_episodes_skips_an_episode_whose_show_was_not_preloaded` in `tests/test_walker.py` stubs the two generators, so it needs no Plex or Trakt account. It reproduces the reported error exactly on unfixed `main`:

```
E           KeyError: 568765
plextraktsync/plan/Walker.py:136: KeyError
```

The episode list is `[kept-before, orphan, kept-after]` on purpose: a fix that returned instead of continuing would still drop the episode after the orphan, and that ordering catches it.

```
$ pytest tests/test_walker.py -q
2 passed

$ pytest -q
30 passed, 11 skipped

$ ruff check plextraktsync/plan/Walker.py tests/test_walker.py
All checks passed!
$ ruff format --check plextraktsync/plan/Walker.py tests/test_walker.py
2 files already formatted
```

### AI usage

Per `AGENTS.md`, the commit carries a `Co-authored-by` trailer. I used Claude Code to investigate and write this. I read every line, traced the two pager call sites myself, and confirmed the before/after behaviour with the test above.
