### PR TITLE
CI: Replace chartboost/ruff-action with astral-sh/ruff-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v4.1.0
+        with:
+          version: "<0.16"
 
 # vim:ts=2:sw=2:et

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v4.1.0
 
 # vim:ts=2:sw=2:et


### PR DESCRIPTION
https://github.com/chartboost/ruff-action, thanks for all the fish!

> chartboost/ruff-action is no longer actively maintained.
> It is strongly suggested that you use the officially-supported Ruff action from Astral.

Docs:
- https://github.com/marketplace/actions/ruff-action

Also, pin ruff to <0.16, because 0.16 introduces too many new checks that fail in this repo.