### PR TITLE
AGENTS.md: make splitting a fix from its test the default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ These instructions apply to the whole repository.
 - Prefer atomic commits: one intent, one self-contained change.
 - Keep commits small enough to review and revert independently.
 - Separate refactors, behavior changes, tests, and docs when practical.
+  A fix and the test covering it are practical to split in nearly every
+  case: commit the behavior change first, then the test. A single commit
+  touching both `plextraktsync/` and `tests/` is usually the signal to
+  split it.
 - Follow the principles from https://cbea.ms/git-commit/.
 - Use commit messages with:
   - a short imperative subject line


### PR DESCRIPTION
Refs #2559, requested by @glensc.

### Why the existing line did not catch me

```
- Separate refactors, behavior changes, tests, and docs when practical.
```

I read that line closely enough to copy the `Co-authored-by` convention four bullets below it, and still bundled the fix and its test in #2559. Two reasons, both fixable in the text:

1. **"when practical" is a judgement call with no stated default.** An agent that does not stop to evaluate it defaults to not splitting, because bundling is the path of least resistance.
2. **There is no way to notice the case.** The rule describes categories; it does not say what the common instance looks like or how to spot it in the diff you are about to commit.

### The change

```diff
 - Separate refactors, behavior changes, tests, and docs when practical.
+  A fix and the test covering it are practical to split in nearly every
+  case: commit the behavior change first, then the test. A single commit
+  touching both `plextraktsync/` and `tests/` is usually the signal to
+  split it.
```

Three things it adds:

- **A default.** "Nearly every case" removes the judgement call for the common instance.
- **An order**, taken from the existing list in that same line (behavior changes before tests) rather than invented. Flip it if that is not what you want.
- **A mechanical check.** Paths touched is something an agent can evaluate on `git status` with no reasoning. That is the part I think actually prevents recurrence; the prose alone did not.

I hedged with "usually" because a rename that moves a module and its test together is one commit legitimately.

I kept this to the one bullet rather than restructuring the section, per "Prefer small, focused changes".

### AI usage

Claude Code, disclosed per `AGENTS.md`, with the `Co-authored-by` trailer on the commit. The diagnosis of why the line failed is from my own case in #2559.
