### PR TITLE
Performance: defer logging init until first use

### DIFF
--- a/plextraktsync/factory/__init__.py
+++ b/plextraktsync/factory/__init__.py
@@ -1,7 +1,33 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from .Factory import Factory
 
+if TYPE_CHECKING:
+    import logging as logging_module
+
+    logger: logging_module.Logger
+    logging: Any
+
 factory = Factory()
-logger = factory.logger
-logging = factory.logging
+
+# Resolved on first access rather than at import time. Touching factory.logger
+# or factory.logging eagerly here loaded the config and initialized logging
+# (pulling in yaml, dotenv and rich.logging) for anything that imported this
+# module, including `plextraktsync.cli` for `--help`. Commands are lazily
+# loaded, so the modules that do `from plextraktsync.factory import logging`
+# only trigger this when they actually run.
+_LAZY = frozenset({"logger", "logging"})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY:
+        value = getattr(factory, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY})

--- a/tests/test_factory_lazy.py
+++ b/tests/test_factory_lazy.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+
+
+def test_importing_cli_does_not_initialize_logging():
+    """Importing the CLI must not load config or set up logging.
+
+    factory/__init__.py used to read factory.logger and factory.logging at
+    import time, so anything importing plextraktsync.cli (including `--help`)
+    loaded the config and initialized logging as a side effect, which also
+    emitted a log line.
+    """
+    result = _run("import plextraktsync.cli")
+
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_importing_cli_leaves_logging_deps_unimported():
+    """The deferred path is what keeps the import cheap."""
+    result = _run("import plextraktsync.cli, sys;print(sorted(m for m in ('yaml', 'dotenv', 'rich.logging') if m in sys.modules))")
+
+    assert result.stdout.strip() == "[]"
+
+
+def test_logging_and_logger_are_still_importable():
+    """`from plextraktsync.factory import logging` must keep working."""
+    result = _run("from plextraktsync.factory import logger, logging;print(logger.name, type(logging).__name__)")
+
+    assert "plextraktsync" in result.stdout
+
+
+def test_unknown_attribute_still_raises_attribute_error():
+    """The module __getattr__ must not swallow genuine typos."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import plextraktsync.factory as f; f.nope"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "has no attribute 'nope'" in result.stderr


### PR DESCRIPTION
Refs #2209.

`factory/__init__.py` read `factory.logger` and `factory.logging` at import time:

```python
factory = Factory()
logger = factory.logger
logging = factory.logging
```

Both are `cached_property`, and `Factory.logging` calls `logger.init.initialize(config)`. So importing that module loaded the config and set up logging as a side effect, and every importer of `plextraktsync.cli` paid for it, `--help` included.

It was visible, too. On `main`, a bare import prints:

```
$ python -c "import plextraktsync.cli"
INFO     Resolved logging config: log_file=.../plextraktsync.log append=True rotation=True
```

### Change

Resolve both through a module `__getattr__` (PEP 562), so `from plextraktsync.factory import logging` keeps working unchanged but only initializes when something reads it. The 35 modules doing that are commands, which `AGENTS.md` notes are lazily loaded, so they trigger it when they actually run.

```
import plextraktsync.cli
                 before      after
cumulative       93.9 ms     25.9 ms
sys.modules      246         116
on import        logs        silent
```

`yaml`, `dotenv` and `rich.logging` are no longer imported for `--help`. A test asserts that directly rather than trusting the timing, since timings are machine-dependent.

### Tests

Two commits, change then tests. Four tests, two of which fail on `main`:

```
FAILED tests/test_factory_lazy.py::test_importing_cli_does_not_initialize_logging
FAILED tests/test_factory_lazy.py::test_importing_cli_leaves_logging_deps_unimported
```

The other two are guards rather than regressions: `logger`/`logging` stay importable, and a genuine typo still raises `AttributeError` instead of being swallowed by the new `__getattr__`. That last one is the risk with module-level `__getattr__` and I wanted it pinned.

```
$ pytest -q
34 passed, 11 skipped        (main: 30 passed, 11 skipped)

$ ruff check    All checks passed!
$ ruff format --check    2 files already formatted
```

`python -m plextraktsync --help` and `info` both behave as before.

I did not touch the other half of #2209 (`@cached_property` for repeated calls). `Factory` already uses it throughout, so if you had specific call sites in mind, point me at them.

### AI usage

Claude Code, `Co-authored-by` trailer on both commits. I profiled with `-X importtime`, read `Factory.logging` and its `initialize` call, and ran every number above.
